### PR TITLE
Fix genesis tools build process

### DIFF
--- a/genesis-tools.Jenkinsfile
+++ b/genesis-tools.Jenkinsfile
@@ -20,9 +20,6 @@ pipeline {
             }
         }
         stage('build') {
-            environment {
-                DOCKER_BUILDKIT=1
-            }
             steps {
                 sh '''\
                     docker build \

--- a/genesis-tools.Jenkinsfile
+++ b/genesis-tools.Jenkinsfile
@@ -20,6 +20,9 @@ pipeline {
             }
         }
         stage('build') {
+            environment {
+                DOCKER_BUILDKIT=1
+            }
             steps {
                 sh '''\
                     docker build \

--- a/genesis-tools.Jenkinsfile
+++ b/genesis-tools.Jenkinsfile
@@ -2,7 +2,6 @@
 // 'https://gitlab.com/Concordium/infra/jenkins-jobs/-/blob/master/docker_image_genesis_tools.groovy':
 // - image_tag (default: "latest")
 // - base_image_tag
-// - base_ref
 
 pipeline {
     agent any
@@ -24,7 +23,6 @@ pipeline {
                 sh '''\
                     docker build \
                         --build-arg base_image_tag="$base_image_tag" \
-                        --build-arg base_ref="$base_ref" \
                         --label base_image_tag="$base_image_tag" \
                         --label base_ref="$base_ref" \
                         --label git_commit="$GIT_COMMIT" \

--- a/scripts/genesis-tools.Dockerfile
+++ b/scripts/genesis-tools.Dockerfile
@@ -47,10 +47,10 @@ RUN apt-get update && \
         libpq-dev
 
 # Copy shared libraries to a location in the library path.
-COPY --from=builder /concordium-base/libs/ /usr/local/lib/
+COPY --from=builder /build/libs/ /usr/local/lib/
 
 # And binaries into PATH.
-COPY --from=builder /concordium-base/bins/ /usr/local/bin/
+COPY --from=builder /build/bins/ /usr/local/bin/
 
 # Make a workspace for mapping and running commands.
 RUN mkdir /home/workspace

--- a/scripts/genesis-tools.Dockerfile
+++ b/scripts/genesis-tools.Dockerfile
@@ -11,10 +11,6 @@
 ARG base_image_tag
 FROM concordium/base:${base_image_tag} AS builder
 
-#RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-#RUN --mount=type=ssh git clone --depth 1 --branch ${base_ref} git@github.com:Concordium/concordium-base.git
-#WORKDIR /concordium-base
-
 COPY . /build
 WORKDIR /build
 

--- a/scripts/genesis-tools.Dockerfile
+++ b/scripts/genesis-tools.Dockerfile
@@ -1,5 +1,3 @@
-# syntax=docker/dockerfile:experimental
-
 # This Dockerfile builds a relatively small docker image that contains all the tools
 # needed to generate a genesis block. These tools are
 # - genesis_tool to create accounts
@@ -13,14 +11,12 @@
 ARG base_image_tag
 FROM concordium/base:${base_image_tag} AS builder
 
-# Which branch of concordium-base to build the tools from.
-ARG base_ref=main
+#RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+#RUN --mount=type=ssh git clone --depth 1 --branch ${base_ref} git@github.com:Concordium/concordium-base.git
+#WORKDIR /concordium-base
 
-RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
-
-RUN --mount=type=ssh git clone --depth 1 --branch ${base_ref} git@github.com:Concordium/concordium-base.git
-
-WORKDIR /concordium-base
+COPY . /build
+WORKDIR /build
 
 # Build haskell tools.
 RUN stack build concordium-base:exe:generate-update-keys concordium-base:exe:genesis


### PR DESCRIPTION
The current solution doesn't work because `docker build` wasn't called with `DOCKER_BUILDKIT` set.

But there isn't really any reason for needing it as we only use it for re-cloning out the repo that is already checked out in the pipeline.

If we need to build from a private fork, the jenkins job will just be redirected to build from that fork. 