### PR TITLE
Run workflows when switching status from draft to ready for review.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -16,6 +16,7 @@ name: Build and test
 on:
   pull_request:
     branches: main
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
     - '.github/workflows/build-test.yaml'
     - '**.hs'

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -16,6 +16,7 @@ on:
     - '**.rs'
   pull_request:
     branches: main
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
     - '.github/workflows/rustfmt.yaml'
     - '**.rs'


### PR DESCRIPTION
Run workflows when marking a pull request as ready for review.

The default types are only `opened, synchronize, reopened`.