### PR TITLE
Support parsing of key indices from strings in JSON.

### DIFF
--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -1094,7 +1094,7 @@ fn handle_start_ip(sip: StartIp) {
     } else if let Ok(threshold) = Select::new()
         .with_prompt("Revocation threshold")
         .items(&(1..=num_ars).collect::<Vec<usize>>())
-        .default(1)
+        .default(0)
         .interact()
     {
         Threshold((threshold + 1) as u8) // +1 because the indexing of the

--- a/rust-src/crypto_common/src/serde_impls.rs
+++ b/rust-src/crypto_common/src/serde_impls.rs
@@ -1,4 +1,6 @@
 use crate::*;
+use serde::{de, de::Visitor, Deserializer};
+use std::convert::TryInto;
 
 // A workaround since dalek does not implement proper serde instances.
 #[derive(SerdeSerialize, SerdeDeserialize)]
@@ -37,6 +39,38 @@ impl From<KeyPairDef> for ed25519_dalek::Keypair {
         ed25519_dalek::Keypair {
             secret: kp.secret,
             public: kp.public,
+        }
+    }
+}
+
+/// A manual implementation of the Serde deserializer to support
+/// reading both from strings and from integers.
+impl<'de> SerdeDeserialize<'de> for types::KeyIndex {
+    fn deserialize<D: Deserializer<'de>>(des: D) -> Result<Self, D::Error> {
+        // expect a u8, but also handle string
+        des.deserialize_any(KeyIndexVisitor)
+    }
+}
+
+struct KeyIndexVisitor;
+
+impl<'de> Visitor<'de> for KeyIndexVisitor {
+    type Value = types::KeyIndex;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(formatter, "Either a string or a u8.")
+    }
+
+    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        let x = v.parse().map_err(de::Error::custom)?;
+        Ok(types::KeyIndex(x))
+    }
+
+    fn visit_u64<E: de::Error>(self, x: u64) -> Result<Self::Value, E> {
+        if let Ok(x) = x.try_into() {
+            Ok(types::KeyIndex(x))
+        } else {
+            Err(de::Error::custom("Key index value out of range."))
         }
     }
 }

--- a/rust-src/crypto_common/src/types.rs
+++ b/rust-src/crypto_common/src/types.rs
@@ -15,7 +15,7 @@ use std::{collections::BTreeMap, num::ParseIntError, ops::Add, str::FromStr};
 /// Index of an account key that is to be used.
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash, Serialize)]
 #[repr(transparent)]
-#[derive(SerdeSerialize, SerdeDeserialize)]
+#[derive(SerdeSerialize)]
 #[serde(transparent)]
 pub struct KeyIndex(pub u8);
 


### PR DESCRIPTION
## Purpose

Support using key indices as map keys in JSON.

## Changes

Support parsing key indices from JSON strings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
