### PR TITLE
Ask for password confirmation and minor cleanup

### DIFF
--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -488,7 +488,7 @@ fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
     match write_json_to_file(&cmb.out, &json) {
         Ok(_) => println!("Wrote PRF key to {}.", cmb.out.to_string_lossy()),
         Err(e) => {
-            println!("Could not JSON write to file because {}", e);
+            println!("Could not write to file because {}", e);
         }
     }
     Ok(())

--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -416,7 +416,7 @@ fn handle_combine_id(cmb: Combine) -> Result<(), String> {
     match write_json_to_file(&cmb.out, &json) {
         Ok(_) => println!("Wrote idCredPub to {}.", cmb.out.to_string_lossy()),
         Err(e) => {
-            eprintln!("Could not JSON write to file because {}", e);
+            eprintln!("Could not write to file because {}", e);
         }
     }
     Ok(())

--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -246,8 +246,7 @@ fn handle_compute_regids(rid: ComputeRegIds) -> Result<(), String> {
     match write_json_to_file(&rid.out, &regids) {
         Ok(_) => eprintln!("Wrote regIds to {}.", rid.out.to_string_lossy()),
         Err(e) => {
-            eprintln!("Could not JSON write to file because {}", e);
-            eprintln!("Here are the potential accounts.");
+            eprintln!("Could not JSON write to file due to {}", e);
         }
     }
     Ok(())

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -122,17 +122,28 @@ fn output_possibly_encrypted<X: SerdeSerialize>(
     fname: &PathBuf,
     data: &X,
 ) -> Result<(), std::io::Error> {
-    let pass = rpassword::read_password_from_tty(Some(
-        "Enter password to encrypt credentials (leave empty for no encryption): ",
-    ))?;
-    if pass.is_empty() {
-        println!("No password supplied, so output will not be encrypted.");
-        write_json_to_file(fname, data)
-    } else {
-        let plaintext = serde_json::to_vec(data).expect("JSON serialization does not fail.");
-        let encrypted =
-            crypto_common::encryption::encrypt(&pass.into(), &plaintext, &mut rand::thread_rng());
-        write_json_to_file(fname, &encrypted)
+    loop {
+        let pass = rpassword::read_password_from_tty(Some(
+            "Enter password to encrypt credentials (leave empty for no encryption): ",
+        ))?;
+        if pass.is_empty() {
+            println!("No password supplied, so output will not be encrypted.");
+            return write_json_to_file(fname, data);
+        } else {
+            let pass2 = rpassword::read_password_from_tty(Some("Re-enter password: "))?;
+            if pass != pass2 {
+                println!("Passwords were not equal. Try again.");
+            } else {
+                let plaintext =
+                    serde_json::to_vec(data).expect("JSON serialization does not fail.");
+                let encrypted = crypto_common::encryption::encrypt(
+                    &pass.into(),
+                    &plaintext,
+                    &mut rand::thread_rng(),
+                );
+                return write_json_to_file(fname, &encrypted);
+            }
+        }
     }
 }
 

--- a/rust-bins/src/bin/utils.rs
+++ b/rust-bins/src/bin/utils.rs
@@ -54,12 +54,19 @@ fn main() -> failure::Fallible<()> {
 
 fn handle_encrypt(cfg: ConfigEncrypt) -> failure::Fallible<()> {
     let data = std::fs::read(&cfg.input).context("Cannot read input file.")?;
-    let pass = rpassword::read_password_from_tty(Some("Enter password to encrypt with: "))?;
-    let encrypted =
-        crypto_common::encryption::encrypt(&pass.into(), &data, &mut rand::thread_rng());
-    eprintln!("Writing output to {}", cfg.output.to_string_lossy());
-    write_json_to_file(&cfg.output, &encrypted)?;
-    Ok(())
+    loop {
+        let pass = rpassword::read_password_from_tty(Some("Enter password to encrypt with: "))?;
+        let pass2 = rpassword::read_password_from_tty(Some("Re-enter password: "))?;
+        if pass != pass2 {
+            println!("The passwords were not equal. Try again.");
+        } else {
+            let encrypted =
+                crypto_common::encryption::encrypt(&pass.into(), &data, &mut rand::thread_rng());
+            eprintln!("Writing output to {}", cfg.output.to_string_lossy());
+            write_json_to_file(&cfg.output, &encrypted)?;
+            return Ok(());
+        }
+    }
 }
 
 fn handle_decrypt(cfg: ConfigDecrypt) -> failure::Fallible<()> {

--- a/rust-bins/src/bin/utils.rs
+++ b/rust-bins/src/bin/utils.rs
@@ -54,19 +54,12 @@ fn main() -> failure::Fallible<()> {
 
 fn handle_encrypt(cfg: ConfigEncrypt) -> failure::Fallible<()> {
     let data = std::fs::read(&cfg.input).context("Cannot read input file.")?;
-    loop {
-        let pass = rpassword::read_password_from_tty(Some("Enter password to encrypt with: "))?;
-        let pass2 = rpassword::read_password_from_tty(Some("Re-enter password: "))?;
-        if pass != pass2 {
-            println!("The passwords were not equal. Try again.");
-        } else {
-            let encrypted =
-                crypto_common::encryption::encrypt(&pass.into(), &data, &mut rand::thread_rng());
-            eprintln!("Writing output to {}", cfg.output.to_string_lossy());
-            write_json_to_file(&cfg.output, &encrypted)?;
-            return Ok(());
-        }
-    }
+    let pass = ask_for_password_confirm("Enter password to encrypt with: ", false)?;
+    let encrypted =
+        crypto_common::encryption::encrypt(&pass.into(), &data, &mut rand::thread_rng());
+    eprintln!("Writing output to {}", cfg.output.to_string_lossy());
+    write_json_to_file(&cfg.output, &encrypted)?;
+    Ok(())
 }
 
 fn handle_decrypt(cfg: ConfigDecrypt) -> failure::Fallible<()> {

--- a/rust-bins/src/lib.rs
+++ b/rust-bins/src/lib.rs
@@ -167,3 +167,23 @@ where
     let u = serde_json::from_reader(reader)?;
     Ok(u)
 }
+
+/// Ask for a password and a confirmation
+/// It doesn't ask for a confirmation if `skip_if_empty` is `true` and the
+/// password is empty
+pub fn ask_for_password_confirm(
+    prompt: &str,
+    skip_if_empty: bool,
+) -> Result<String, std::io::Error> {
+    loop {
+        let pass = rpassword::read_password_from_tty(Some(prompt))?;
+        if !(skip_if_empty && pass.is_empty()) {
+            let pass2 = rpassword::read_password_from_tty(Some("Re-enter password: "))?;
+            if pass != pass2 {
+                println!("Passwords were not equal. Try again.");
+                continue;
+            }
+        }
+        return Ok(pass);
+    }
+}


### PR DESCRIPTION
## Purpose

Address https://github.com/Concordium/concordium-base/issues/19. 

## Changes

The keygen tool now asks for a password twice to encrypt the generated keys under. If passwords are different, it will ask again.
The same has been done in the "utils" tool which can also encrypt data.
In the anonymity revocation tool the prints of decrypted data have been removed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
