### PR TITLE
Bump version of mobile libraries.

### DIFF
--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.1.0"
+version = "0.7.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"


### PR DESCRIPTION
## Purpose

Bump version. The previous one is no longer compatible since genesis generators are embedded.