### PR TITLE
Print the entire genesis in the genesis tool.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.24
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 7eaa7403793b3e5ab92a451a158a922442f53c3399265692e643144111450e6c
+-- hash: bee12c1a1aa1edcfaed5a30df0cb5d539332b071c1d34ad598ee6edfcc35b64b
 
 name:           concordium-base
 version:        0.1.0.0
@@ -193,6 +193,7 @@ executable genesis
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , aeson-pretty >=0.8
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0

--- a/haskell-bins/genesis/Genesis.hs
+++ b/haskell-bins/genesis/Genesis.hs
@@ -206,8 +206,8 @@ main = cmdArgsRun mode >>=
               putStrLn $ "Terminal block of previous chain: " ++ show genesisTerminalBlock
               putStrLn $ "State hash: " ++ show genesisStateHash
 
-            Right (GDP1 P1.GDP1Initial{genesisCore = P1.CoreGenesisParameters{..}, genesisInitialState = P1.GenesisState{..}}) -> do
-              putStrLn "Genesis data."
+            Right gd@(GDP1 P1.GDP1Initial{genesisCore = P1.CoreGenesisParameters{..}, genesisInitialState = P1.GenesisState{..}}) -> do
+              putStrLn $ "Genesis data for genesis block with hash " ++ show (genesisBlockHash gd)
               putStrLn $ "Genesis time is set to: " ++ showTime genesisTime
               putStrLn $ "Slot duration: " ++ show (durationToNominalDiffTime genesisSlotDuration)
               putStrLn $ "Leadership election nonce: " ++ show genesisLeadershipElectionNonce

--- a/haskell-bins/genesis/Genesis.hs
+++ b/haskell-bins/genesis/Genesis.hs
@@ -304,6 +304,9 @@ main = cmdArgsRun mode >>=
               printAccessStructure "mint distribution" asParamMintDistribution
               printAccessStructure "transaction fee distribution" asParamTransactionFeeDistribution
               printAccessStructure "gas reward parameters" asParamGASRewards
+              printAccessStructure "baker stake threshold" asBakerStakeThreshold
+              printAccessStructure "add anonymity revokers" asAddAnonymityRevoker
+              printAccessStructure "add identity providers" asAddIdentityProvider
 
   where showTime t = formatTime defaultTimeLocale rfc822DateFormat (timestampToUTCTime t)
         showBalance totalGTU balance =

--- a/haskell-bins/genesis/Genesis.hs
+++ b/haskell-bins/genesis/Genesis.hs
@@ -239,6 +239,7 @@ main = cmdArgsRun mode >>=
               putStrLn $ "  - microGTU per Euro rate: " ++ showExchangeRate _cpMicroGTUPerEuro
               putStrLn $ "  - baker extra cooldown epochs: " ++ show _cpBakerExtraCooldownEpochs
               putStrLn $ "  - maximum credential deployments per block: " ++ show _cpAccountCreationLimit
+              putStrLn $ "  - minimum stake to become a baker: " ++ showBalance totalGTU _cpBakerStakeThreshold
               putStrLn "  - reward parameters:"
               putStrLn "    + mint distribution:"
               putStrLn $ "      * mint rate per slot: " ++ show (_cpRewardParameters ^. mdMintPerSlot)

--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeFamilies #-}
@@ -501,10 +502,10 @@ type AccountVerificationKey = VerifyKey
 -- |The number of keys required to sign the message.
 -- The value is at least 1 and at most 255.
 newtype SignatureThreshold = SignatureThreshold Word8
-    deriving(Eq, Ord, Show, Enum, Num, Real, Integral)
+    deriving newtype (Eq, Ord, Show, Enum, Num, Real, Integral)
 
 newtype AccountThreshold = AccountThreshold Word8
-    deriving(Eq, Ord, Show, Enum, Num, Real, Integral)
+    deriving newtype (Eq, Ord, Show, Enum, Num, Real, Integral)
 
 instance Serialize SignatureThreshold where
   get = do

--- a/haskell-src/Concordium/Types/Updates.hs
+++ b/haskell-src/Concordium/Types/Updates.hs
@@ -236,7 +236,7 @@ type UpdateKeyIndex = Word16
 -- |A wrapper over Word16 to ensure on Serialize.get and Aeson.parseJSON that it
 -- is not zero and it doesn't exceed the max value.
 newtype UpdateKeysThreshold = UpdateKeysThreshold { uktTheThreshold :: Word16 }
- deriving (Show, Eq, Enum, Num, Real, Ord, Integral, AE.ToJSON, AE.FromJSON)
+ deriving newtype (Show, Eq, Enum, Num, Real, Ord, Integral, AE.ToJSON, AE.FromJSON)
 
 instance Serialize UpdateKeysThreshold where
   put = putWord16be . uktTheThreshold

--- a/package.yaml
+++ b/package.yaml
@@ -136,7 +136,7 @@ executables:
     - concordium-base
     - cmdargs >= 0.10
     - filepath >= 1.4
-
+    - aeson-pretty >= 0.8
 
 tests:
   test:


### PR DESCRIPTION
## Purpose

Make the genesis tool output the entire genesis.

Example output: [genesis-block.txt](https://github.com/Concordium/concordium-base/files/6397777/genesis-block.txt)


## Changes

- Output the parts of genesis that was not yet printed.
- Try to pretty print as much as possible.
- Modify Show instances of UpdateKeysThreshold and AccountThreshold to simply print the number.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
