### PR TITLE
Make the AR keygen tool interactive.

### DIFF
--- a/rust-bins/docs/keygen.md
+++ b/rust-bins/docs/keygen.md
@@ -30,6 +30,10 @@ Generate keys for an anonymity revoker. The following options are supported
 - `--no-confirmation` if set, do not ask user to re-enter generated recovery phrase.
 - `--no-verification` if set, do not verify the validity of the input. Otherwise the input is verified to be a valid BIP39 sentence.
 
+No arguments are required. If the arguments `ar-identity`, `description`,
+`global`, `name`, `url`, `out`, or `out-pub` are not supplied they are queried
+by the tool.
+
 ## keygen-ip
 
 Generate keys for the identity provider. The following options are supported

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -137,15 +137,28 @@ struct GenRand {
 #[derive(StructOpt)]
 #[structopt(
     about = "Tool for generating keys",
+    name = "keygen",
     author = "Concordium",
-    version = "1"
+    version = "1.0"
 )]
 enum KeygenTool {
-    #[structopt(name = "keygen-ip", about = "Generate identity provider keys")]
+    #[structopt(
+        name = "keygen-ip",
+        about = "Generate identity provider keys.",
+        version = "1.0"
+    )]
     KeygenIp(KeygenIp),
-    #[structopt(name = "keygen-ar", about = "Generate anonymity revoker keys")]
+    #[structopt(
+        name = "keygen-ar",
+        about = "Generate anonymity revoker keys.",
+        version = "1.0"
+    )]
     KeygenAr(KeygenAr),
-    #[structopt(name = "gen-rand", about = "Generate randomness file")]
+    #[structopt(
+        name = "gen-rand",
+        about = "Generate randomness file.",
+        version = "1.0"
+    )]
     GenRand(GenRand),
 }
 
@@ -304,13 +317,12 @@ fn handle_generate_ar_keys(kgar: KeygenAr) -> Result<(), String> {
         scalar,
     };
     let ar_public_key = PublicKey::from(&ar_secret_key);
-    let ar_identity = match kgar.ar_identity {
-        Some(x) => x,
-        None => Input::new()
+    let ar_identity = kgar.ar_identity.unwrap_or_else(|| {
+        Input::new()
             .with_prompt("Enter AR identity")
             .interact()
-            .expect("AR identity not provided"),
-    };
+            .expect("AR identity not provided")
+    });
     let name = kgar.name.unwrap_or_else(|| {
         Input::new()
             .with_prompt("Enter the name of the AR")


### PR DESCRIPTION
The same interface that used to exist is still supported, however all arguments
to the tool are now optional. If they are not supplied the relevant values are
queried interactively.

## Purpose

Make the AR keygen tool easier to use.

## Changes

Query for input interactively if it is not supplied on the command-line.

```
Enter the path to the cryptographic parameters file: foo/global.json
Enter AR identity: 1
Enter the name of the AR: Foobar
Enter URL of the AR: foobar@baz
Enter description of the AR: blah
Output file name: ar-data-1.json
Output file for public data: ar-info-1.pub.json
Enter password to encrypt credentials (leave empty for no encryption): 
No password supplied, so output will not be encrypted.
Wrote private keys to ar-data-1.json.
Wrote public keys to ar-info-1.pub.json.
```

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.