### PR TITLE
Retry word entry on failure and make it possible to run just with system randomness.

### DIFF
--- a/rust-bins/docs/keygen.md
+++ b/rust-bins/docs/keygen.md
@@ -29,6 +29,7 @@ Generate keys for an anonymity revoker. The following options are supported
 - `--recover-from-phrase` if set, recover keys from backup phrase. Otherwise, fresh keys are generated.
 - `--no-confirmation` if set, do not ask user to re-enter generated recovery phrase.
 - `--no-verification` if set, do not verify the validity of the input. Otherwise the input is verified to be a valid BIP39 sentence.
+- `--only-system-randomness` if set, do not ask the user for a list of words to add to randomness, instead only relying on system randomness.
 
 No arguments are required. If the arguments `ar-identity`, `description`,
 `global`, `name`, `url`, `out`, or `out-pub` are not supplied they are queried

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -104,6 +104,12 @@ struct KeygenAr {
         help = "Do not ask user to re-enter generated recovery phrase."
     )]
     no_confirmation: bool,
+    #[structopt(
+        long = "only-system-randomness",
+        help = "Do not ask for a list of words from the user. Generate keys only using the system \
+                randomness."
+    )]
+    only_system_randomness: bool,
 }
 
 #[derive(StructOpt)]
@@ -232,11 +238,15 @@ fn handle_generate_ar_keys(kgar: KeygenAr) -> Result<(), String> {
 
         input_words.join(" ")
     } else {
-        println!(
-            "Please generate a seed phrase, e.g., using a hardware wallet, and input the words \
-             below."
-        );
-        let input_words = read_words_from_terminal(kgar.in_len, !kgar.no_verification, &bip39_map)?;
+        let input_words = if kgar.only_system_randomness {
+            Vec::new()
+        } else {
+            println!(
+                "Please generate a seed phrase, e.g., using a hardware wallet, and input the \
+                 words below."
+            );
+            read_words_from_terminal(kgar.in_len, !kgar.no_verification, &bip39_map)?
+        };
 
         // rerandomize input words using system randomness
         let randomized_words = rerandomize_bip39(&input_words, &bip39_vec)?;

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -259,15 +259,23 @@ fn handle_generate_ar_keys(kgar: KeygenAr) -> Result<(), String> {
         }
 
         if !kgar.no_confirmation {
-            // clear screen
-            execute!(std::io::stdout(), Clear(ClearType::All))
-                .map_err(|_| "Could not clear screen.".to_owned())?;
-            println!("Please enter recovery phrase again to confirm.");
+            let mut first = true;
+            loop {
+                // clear screen
+                execute!(std::io::stdout(), Clear(ClearType::All))
+                    .map_err(|_| "Could not clear screen.".to_owned())?;
+                if first {
+                    println!("Please enter recovery phrase again to confirm.");
+                } else {
+                    println!("Recovery phrases do not match. Try again.")
+                }
 
-            let confirmation_words = read_words_from_terminal(kgar.in_len, true, &bip39_map)?;
+                let confirmation_words = read_words_from_terminal(kgar.in_len, true, &bip39_map)?;
 
-            if confirmation_words != randomized_words {
-                return Err("Recovery phrases do not match.".to_string());
+                if confirmation_words == randomized_words {
+                    break;
+                }
+                first = false;
             }
         }
 


### PR DESCRIPTION
## Purpose

Retry word entry on failure to make it easier to use the tool.

## Changes

- Retry word entry on failure.
- Add an option to just use the system randomness. It really is good enough for all practical purposes so there is no harm in supporting this.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
