### PR TITLE
Add small utility to combine credentials from the destkop wallet into a genesis account structure.

### DIFF
--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -210,7 +210,7 @@ macro_rules! succeed_or_die {
 }
 
 fn output_possibly_encrypted<X: SerdeSerialize>(
-    fname: &PathBuf,
+    fname: &std::path::Path,
     data: &X,
 ) -> Result<(), std::io::Error> {
     let pass = ask_for_password_confirm(


### PR DESCRIPTION
## Purpose

Make it easier to construct the genesis block.

## Changes

Add a subcommand to the ID client that can combine credentials into an account.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
