### PR TITLE
Fix how IPS are queried to not rely on them being in order starting at 0

### DIFF
--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -1175,8 +1175,10 @@ fn handle_start_ip(sip: StartIp) {
             .interact()
         {
             ips.identity_providers
-                .get(&IpIdentity(ip_info_idx as u32))
+                .iter()
+                .nth(ip_info_idx)
                 .unwrap()
+                .1
                 .clone()
         } else {
             eprintln!("You have to choose an identity provider. Terminating.");


### PR DESCRIPTION
## Purpose

Fix bug in testing tool that made it rely on specific ordering.

## Changes

Use the index in the map when linearized rather than as the key in the map.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.