### PR TITLE
Verify that keys which are part of the keypair are mutually consistent.

### DIFF
--- a/haskell-src/Concordium/Crypto/BlockSignature.hs
+++ b/haskell-src/Concordium/Crypto/BlockSignature.hs
@@ -8,6 +8,7 @@ import qualified Concordium.Crypto.Ed25519Signature as Ed25519
 import           Data.ByteString
 import qualified Data.ByteString.Short as BSS
 import Concordium.Crypto.ByteStringHelpers
+import Control.Monad
 import Data.Serialize
 import Data.Aeson
 
@@ -23,12 +24,14 @@ instance Serialize KeyPair where
   get = do
     signKey <- get
     verifyKey <- get
+    when (verifyKey /= Ed25519.deriveVerifyKey signKey) $ fail "Signing key does not correspond to the verification key."
     return KeyPair{..}
 
 instance FromJSON KeyPair where
     parseJSON = withObject "Baker block signature key" $ \obj -> do
       signKey <- obj .: "signatureSignKey"
       verifyKey <- obj .: "signatureVerifyKey"
+      when (verifyKey /= Ed25519.deriveVerifyKey signKey) $ fail "Signing key does not correspond to the verification key."
       return KeyPair{..}
 
 newtype Signature = Signature BSS.ShortByteString


### PR DESCRIPTION
## Purpose

Extra caution against corrupted key files.

## Changes

Ensure that keypair consistency is checked whenever we read them.

Serialization performance for keypair serialization is worse now, but practically that should not matter since we don't constantly deserialize keypairs.

An alternative design that would remove this downside would be to add a "verifyKeyPair" function to ensure consistency.
But I think adding a check during serialization is more in-line with the current design (we also check that the public key is a valid curve point for example).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
