### PR TITLE
Add threshold parameter to anonymity revocation tool.

### DIFF
--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -441,7 +441,7 @@ fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
                 AccountCredentialValues::Initial { .. } => {
                     return Err(
                         "Cannot use the initial account credential. Use --threshold to provide \
-                         revocation threshol."
+                         revocation threshold."
                             .to_owned(),
                     )
                 }

--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -422,6 +422,14 @@ fn handle_combine_id(cmb: Combine) -> Result<(), String> {
 }
 
 fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
+    // We check if a normal credential has been provided so that we can read the
+    // anonymity revocation threshold. Before we introduced the initial
+    // accounts, it made sense to make the --credential option mandatory.
+    // Since initial credentias do not contain the anonymity revocation threshold,
+    // we made the --credential option optional, and in case of revoking the
+    // anonymity of the identity behind an initial account, we will in this case
+    // assume that enough shares have been given and will therefore not compare the
+    // number of shares with any threshold.
     let revocation_threshold = match cmb.credential {
         Some(path) => {
             let credential: Versioned<AccountCredentialValues<ExampleCurve, ExampleAttribute>> = succeed_or_die!(read_json_from_file(path), e => "Could not read credential from provided file because {}");


### PR DESCRIPTION
## Purpose

To make the --credential option optional when using `combine-prf` command to compute the prf key given the shares. 
If not provided, or if the provided credential is initial, it will assume that the given shares are enough (i.e. there are at least threshold many). The reason for this is that the initial credential does not contain the anonymity revocation threshold, so it wasn't possible to check if enough shares were given in the case of revoking the identity behind an initial account.

## Changes

The --credential option is now optional, and if it is not provided, or the given credential is initial, the user is warned that it will assume that enough shares are given.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.


