### PR TITLE
Add revocation threshold to the anonymity revocation record.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -932,7 +932,7 @@ dependencies = [
 
 [[package]]
 name = "identity-provider-service"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/identity-provider-service/Cargo.toml
+++ b/identity-provider-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-provider-service"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/identity-provider-service/src/bin/main.rs
+++ b/identity-provider-service/src/bin/main.rs
@@ -1133,6 +1133,7 @@ fn save_revocation_record<A: Attribute<id::constants::BaseField>>(
         id_cred_pub:  pre_identity_object.pub_info_for_ip.id_cred_pub,
         ar_data:      pre_identity_object.ip_ar_data.clone(),
         max_accounts: alist.max_accounts,
+        threshold:    pre_identity_object.choice_ar_parameters.threshold,
     };
     let base16_id_cred_pub = base16_encode_string(&ar_record.id_cred_pub);
     db.write_revocation_record(&base16_id_cred_pub, ar_record)

--- a/idiss/Cargo.lock
+++ b/idiss/Cargo.lock
@@ -659,7 +659,7 @@ dependencies = [
 
 [[package]]
 name = "idiss"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "byteorder",
  "chrono",

--- a/idiss/Cargo.toml
+++ b/idiss/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "idiss"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/idiss/src/lib.rs
+++ b/idiss/src/lib.rs
@@ -154,6 +154,7 @@ pub fn create_identity_object(
         id_cred_pub:  request.value.pub_info_for_ip.id_cred_pub,
         ar_data:      request.value.ip_ar_data.clone(),
         max_accounts: alist.max_accounts,
+        threshold:    request.value.choice_ar_parameters.threshold,
     });
 
     let icdi = create_initial_cdi(

--- a/rust-bins/src/bin/anonymity_revocation.rs
+++ b/rust-bins/src/bin/anonymity_revocation.rs
@@ -16,7 +16,7 @@ use structopt::StructOpt;
 struct DecryptPrf {
     #[structopt(
         long = "ar-record",
-        help = "File with the JSON encoded (pre) identity object."
+        help = "File with the JSON encoded anonymity revocation record."
     )]
     ar_record: PathBuf,
     #[structopt(
@@ -49,10 +49,10 @@ struct Decrypt {
 #[derive(StructOpt)]
 struct CombinePrf {
     #[structopt(
-        long = "credential",
-        help = "File with the JSON encoded credential or credential values."
+        long = "ar-record",
+        help = "File with the JSON encoded anonymity revocation record."
     )]
-    credential: Option<PathBuf>,
+    ar_record: PathBuf,
     #[structopt(
         long = "shares",
         help = "Files with the JSON encoded decrypted shares."
@@ -99,7 +99,7 @@ struct ComputeRegIds {
 #[structopt(
     about = "Prototype tool showcasing anonymity revoker (inter)actions.",
     author = "Concordium",
-    version = "0.36787944117"
+    version = "0.5"
 )]
 enum AnonymityRevocation {
     #[structopt(
@@ -244,7 +244,7 @@ fn handle_compute_regids(rid: ComputeRegIds) -> Result<(), String> {
     }
 
     match write_json_to_file(&rid.out, &regids) {
-        Ok(_) => eprintln!("Wrote regIds to {}.", rid.out.to_string_lossy()),
+        Ok(_) => eprintln!("Wrote regIds to {}.", rid.out.display()),
         Err(e) => {
             eprintln!("Could not JSON write to file due to {}", e);
         }
@@ -300,7 +300,7 @@ fn handle_decrypt_id(dcr: Decrypt) -> Result<(), String> {
         id_cred_pub_share: m,
     };
     match write_json_to_file(&dcr.out, &share) {
-        Ok(_) => println!("Wrote decryption to {}", dcr.out.to_string_lossy()),
+        Ok(_) => println!("Wrote decryption to {}", dcr.out.display()),
         Err(e) => {
             eprintln!("Could not write JSON to file due to {}", e);
         }
@@ -342,7 +342,7 @@ fn handle_decrypt_prf(dcr: DecryptPrf) -> Result<(), String> {
         prf_key_share: m,
     };
     match write_json_to_file(&dcr.out, &share) {
-        Ok(_) => println!("Wrote decryption to {}.", dcr.out.to_string_lossy()),
+        Ok(_) => println!("Wrote decryption to {}.", dcr.out.display()),
         Err(e) => {
             eprintln!("Could not write JSON to file because {}", e);
         }
@@ -385,7 +385,7 @@ fn handle_combine_id(cmb: Combine) -> Result<(), String> {
         let decrypted = read_json_from_file(&share_value).map_err(|e| {
             format!(
                 "Could not read from ar file {}, error: {}",
-                share_value.to_string_lossy(),
+                share_value.display(),
                 e
             )
         })?;
@@ -413,7 +413,7 @@ fn handle_combine_id(cmb: Combine) -> Result<(), String> {
 
     let json = json!({ "idCredPub": id_cred_pub_string });
     match write_json_to_file(&cmb.out, &json) {
-        Ok(_) => println!("Wrote idCredPub to {}.", cmb.out.to_string_lossy()),
+        Ok(_) => println!("Wrote idCredPub to {}.", cmb.out.display()),
         Err(e) => {
             eprintln!("Could not write to file because {}", e);
         }
@@ -422,52 +422,24 @@ fn handle_combine_id(cmb: Combine) -> Result<(), String> {
 }
 
 fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
-    // We check if a normal credential has been provided so that we can read the
-    // anonymity revocation threshold. Before we introduced the initial
-    // accounts, it made sense to make the --credential option mandatory.
-    // Since initial credentias do not contain the anonymity revocation threshold,
-    // we made the --credential option optional, and in case of revoking the
-    // anonymity of the identity behind an initial account, we will in this case
-    // assume that enough shares have been given and will therefore not compare the
-    // number of shares with any threshold.
-    let revocation_threshold = match cmb.credential {
-        Some(path) => {
-            let credential: Versioned<AccountCredentialValues<ExampleCurve, ExampleAttribute>> = succeed_or_die!(read_json_from_file(path), e => "Could not read credential from provided file because {}");
-            if credential.version != VERSION_0 {
-                return Err("The version of the credential should be 0".to_owned());
-            }
-            match credential.value {
-                AccountCredentialValues::Initial { .. } => {
-                    println!(
-                        "Initial credentials do not contain the anonymity revocation threshold. \
-                         Assuming threshold is less than or equal to the number of given shares."
-                    );
-                    None
-                }
-                AccountCredentialValues::Normal { cdi } => Some(cdi.threshold),
-            }
-        }
-        _ => {
-            println!(
-                "No credential provided. Assuming threshold is less than or equal to the number \
-                 of given shares."
-            );
-            None
-        }
-    };
+    let ar_record: Versioned<AnonymityRevocationRecord<ExampleCurve>> = succeed_or_die!(read_json_from_file(cmb.ar_record), e => "Could not read ArRecord due to {}");
+
+    if ar_record.version != VERSION_0 {
+        return Err("The version of the ArRecord should be 0.".to_owned());
+    }
+
+    let revocation_threshold = ar_record.value.threshold;
 
     let shares_values: Vec<_> = cmb.shares;
 
     let number_of_ars = shares_values.len();
     let number_of_ars =
         u8::try_from(number_of_ars).expect("Number of anonymity revokers should not exceed 2^8-1");
-    if let Some(t) = revocation_threshold {
-        if number_of_ars < t.into() {
-            return Err(format!(
-                "Insufficient number of anonymity revokers ({}). Threshold is {}.",
-                number_of_ars, t
-            ));
-        }
+    if number_of_ars < revocation_threshold.into() {
+        return Err(format!(
+            "Insufficient number of anonymity revokers ({}). Threshold is {}.",
+            number_of_ars, revocation_threshold
+        ));
     }
 
     let mut ar_decrypted_data_vec: Vec<IpArDecryptedData<ExampleCurve>> =
@@ -480,7 +452,7 @@ fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
             Err(y) => {
                 return Err(format!(
                     "Could not read from ar file {}, error: {}",
-                    share_value.to_string_lossy(),
+                    share_value.display(),
                     y
                 ));
             }
@@ -508,7 +480,7 @@ fn handle_combine_prf(cmb: CombinePrf) -> Result<(), String> {
     let prf_key_string = base16_encode_string(&prf_key);
     let json = json!({ "prfKey": prf_key_string });
     match write_json_to_file(&cmb.out, &json) {
-        Ok(_) => println!("Wrote PRF key to {}.", cmb.out.to_string_lossy()),
+        Ok(_) => println!("Wrote PRF key to {}.", cmb.out.display()),
         Err(e) => {
             println!("Could not write to file because {}", e);
         }

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -1960,6 +1960,8 @@ pub struct AnonymityRevocationRecord<C: Curve> {
     pub ar_data: BTreeMap<ArIdentity, IpArData<C>>,
     #[serde(rename = "maxAccounts")]
     pub max_accounts: u8,
+    #[serde(rename = "revocationThreshold")]
+    pub threshold: Threshold,
 }
 
 /// A type encapsulating both types of credentials.


### PR DESCRIPTION
## Purpose

Simplify the anonymity revocation process, and make the information in the AR record self-contained.

## Changes

- Add a field to the anonymity revocation record.
- Update the AR tool to use the new field, and remove the old `credential` argument.
- Update the idiss library to return the new field.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.