### PR TITLE
Fix identity provider docker image build to use the public base image.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+*.swo
+*.swp
+**/target
+*.orig
+*.bk
+_rust_rocksdb*
+*rlib
+tags
+path
+.vscode
+concordium.test.key
+win_build
+scripts/local
+.git
+concordium-node/deps/*
+**/.stack-work/*

--- a/scripts/identity-provider-service.Dockerfile
+++ b/scripts/identity-provider-service.Dockerfile
@@ -1,6 +1,6 @@
 # Build binaries in builder image.
 ARG development_image_tag
-FROM 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/development:${development_image_tag} as builder
+FROM concordium/base:${development_image_tag} as builder
 COPY . /build
 WORKDIR /build/identity-provider-service
 RUN cargo build --release


### PR DESCRIPTION
Additionally add a dockerignore file to not copy useless files into the builder context.

## Purpose

- Make the identity provider images buildable from public images.
- Speed up the builds.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
