### PR TITLE
Optional arThreshold field added in create_id_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@
   There is a new field `credentialPublicKeys` and the old field `account` is removed.
 - there is a new field inside the `credential` object in the response from `create_credential`.
   The field is `messageExpiry`, it is mandatory and has type `u64`.
+- the input object of `create_id_request_and_private_data` has an additional optional field `arThreshold`.
+  When used it must be at least 1 and no more than the number of anonymity revokers.
+  When not used, the functionality is unaffected by this change.
 
 ## Other
 

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -283,15 +283,22 @@ fn create_id_request_and_private_data_aux(input: &str) -> anyhow::Result<String>
     let num_of_ars = ars_infos.len();
     let threshold = match v.get("arThreshold") {
         Some(v) => {
-            let threshold : u8 = from_value(v.clone())?;
+            let threshold: u8 = from_value(v.clone())?;
             ensure!(threshold > 0, "arThreshold must be at least 1.");
-            ensure!(num_of_ars >= usize::from(threshold), "Number of anonymity revokers in arsInfos should be at least arThreshold.");
+            ensure!(
+                num_of_ars >= usize::from(threshold),
+                "Number of anonymity revokers in arsInfos should be at least arThreshold."
+            );
             Threshold(threshold)
         }
         None => {
-            // arThreshold not specified, use `number of anonymity revokers` - 1 or 1 in the case of only a single anonymity revoker.
-            ensure!(num_of_ars > 0, "arsInfos should have at least 1 anonymity revoker.");
-            Threshold(max((num_of_ars - 1).try_into().unwrap_or(255), 1)) 
+            // arThreshold not specified, use `number of anonymity revokers` - 1 or 1 in the
+            // case of only a single anonymity revoker.
+            ensure!(
+                num_of_ars > 0,
+                "arsInfos should have at least 1 anonymity revoker."
+            );
+            Threshold(max((num_of_ars - 1).try_into().unwrap_or(255), 1))
         }
     };
 

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -280,11 +280,19 @@ fn create_id_request_and_private_data_aux(input: &str) -> anyhow::Result<String>
 
     let ars_infos: BTreeMap<ArIdentity, ArInfo<ExampleCurve>> = try_get(&v, "arsInfos")?;
 
-    // FIXME: IP defined threshold
-    let threshold = {
-        let l = ars_infos.len();
-        ensure!(l > 0, "ArInfos should have at least 1 anonymity revoker.");
-        Threshold(max((l - 1).try_into().unwrap_or(255), 1))
+    let num_of_ars = ars_infos.len();
+    let threshold = match v.get("arThreshold") {
+        Some(v) => {
+            let threshold : u8 = from_value(v.clone())?;
+            ensure!(threshold > 0, "arThreshold must be at least 1.");
+            ensure!(num_of_ars >= usize::from(threshold), "Number of anonymity revokers in arsInfos should be at least arThreshold.");
+            Threshold(threshold)
+        }
+        None => {
+            // arThreshold not specified, use `number of anonymity revokers` - 1 or 1 in the case of only a single anonymity revoker.
+            ensure!(num_of_ars > 0, "arsInfos should have at least 1 anonymity revoker.");
+            Threshold(max((num_of_ars - 1).try_into().unwrap_or(255), 1)) 
+        }
     };
 
     // Should be safe on iOS and Android, by calling SecRandomCopyBytes/getrandom,

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -50,6 +50,7 @@ must be a valid JSON object with fields
 - `"global"` ... is a JSON object that can describes global cryptographic parameters.
    This data is obtained from the server by making a GET request to /global.
 
+In addition the field `"arThreshold"` can be added to specify an anonymity revocation threshold different from the default value, as a JSON encoded byte value.
 
 The output of this function is a JSON object with two keys
 - "idObjectRequest" - this is the identity object request that should be sent to


### PR DESCRIPTION
## Purpose

Closes #30  

## Changes

The input object of create_id_request_and_private_data can optionally contain a field specifying an anonymity revocation threshold. If it does we check that it is at least 1 and not more than the number of anonymity revokers. If not the functionality is the same as before.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] I have updated the CHANGELOG.


