### PR TITLE
Add a few trait implementations and a bit of type safety.

### DIFF
--- a/rust-src/aggregate_sig/Cargo.toml
+++ b/rust-src/aggregate_sig/Cargo.toml
@@ -13,6 +13,7 @@ generic-array = "0.14"
 pairing = "0.15"
 ff = "0.5"
 group = "0.2"
+serde = "1.0"
 
 [dependencies.curve_arithmetic]
 path = "../curve_arithmetic"

--- a/rust-src/aggregate_sig/src/aggregate_sig.rs
+++ b/rust-src/aggregate_sig/src/aggregate_sig.rs
@@ -1,3 +1,5 @@
+use crypto_common::*;
+use crypto_common_derive::*;
 use curve_arithmetic::{Curve, Pairing, Value};
 use ff::Field;
 use generic_array::GenericArray;
@@ -6,8 +8,6 @@ use rand::Rng;
 use random_oracle::RandomOracle;
 use rayon::iter::*;
 use sha2::{Digest, Sha512};
-
-use crypto_common::*;
 
 pub const PUBLIC_KEY_SIZE: usize = 96;
 pub const SECRET_KEY_SIZE: usize = 32;
@@ -56,7 +56,7 @@ impl<P: Pairing> PartialEq for SecretKey<P> {
 }
 
 // A Public Key is a point on the second curve of the pairing
-#[derive(Debug, Eq, Serialize)]
+#[derive(Debug, Eq, Serialize, SerdeBase16Serialize)]
 pub struct PublicKey<P: Pairing>(P::G2);
 
 impl<P: Pairing> PublicKey<P> {

--- a/rust-src/aggregate_sig/src/lib.rs
+++ b/rust-src/aggregate_sig/src/lib.rs
@@ -2,6 +2,3 @@ pub mod aggregate_sig;
 pub mod ffi;
 
 pub use crate::aggregate_sig::*;
-
-#[macro_use]
-extern crate crypto_common_derive;

--- a/rust-src/crypto_common/src/lib.rs
+++ b/rust-src/crypto_common/src/lib.rs
@@ -27,3 +27,6 @@ pub use std::os::raw::c_char;
 /// Module that provides a simple API for symmetric encryption in the output
 /// formats compatible used by Concordium.
 pub mod encryption;
+
+/// Reexport for ease of use.
+pub use crypto_common_derive as derive;

--- a/rust-src/crypto_common/src/types.rs
+++ b/rust-src/crypto_common/src/types.rs
@@ -257,6 +257,29 @@ impl FromStr for TransactionTime {
     }
 }
 
+/// Datatype used to indicate a timestamp in milliseconds.
+#[derive(
+    SerdeDeserialize, SerdeSerialize, PartialEq, Eq, Debug, Serialize, Clone, Copy, PartialOrd, Ord,
+)]
+#[serde(transparent)]
+pub struct Timestamp {
+    /// Milliseconds since the unix epoch.
+    pub millis: u64,
+}
+
+impl From<u64> for Timestamp {
+    fn from(millis: u64) -> Self { Self { millis } }
+}
+
+impl FromStr for Timestamp {
+    type Err = ParseIntError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let millis = u64::from_str(s)?;
+        Ok(Self { millis })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust-src/crypto_common_derive/src/lib.rs
+++ b/rust-src/crypto_common_derive/src/lib.rs
@@ -26,13 +26,13 @@ pub fn serde_base16_serialize_derive(input: TokenStream) -> TokenStream {
     let gen = quote! {
         impl #impl_generics SerdeSerialize for #name #ty_generics #where_clauses {
             fn serialize<#ident: serde::Serializer>(&self, #ident_serializer: #ident) -> Result<#ident::Ok, #ident::Error> {
-                base16_encode(self, #ident_serializer)
+                crypto_common::base16_encode(self, #ident_serializer)
             }
         }
 
         impl #impl_generics SerdeDeserialize<#lifetime> for #name #ty_generics #where_clauses {
             fn deserialize<#ident: serde::Deserializer<#lifetime>>(#ident_deserializer: #ident) -> Result<Self, #ident::Error> {
-                base16_decode::<#lifetime, #ident, #name #ty_generics>(#ident_deserializer)
+                crypto_common::base16_decode::<#lifetime, #ident, #name #ty_generics>(#ident_deserializer)
             }
         }
     };

--- a/rust-src/encrypted_transfers/benches/enc_trans_benchmarks.rs
+++ b/rust-src/encrypted_transfers/benches/enc_trans_benchmarks.rs
@@ -47,7 +47,7 @@ pub fn enc_trans_bench(c: &mut Criterion) {
     let challenge_prefix = generate_challenge_prefix(&mut csprng);
     let ro = RandomOracle::domain(&challenge_prefix);
 
-    let index = csprng.gen();
+    let index = csprng.gen::<u64>().into();
 
     let context_clone = context.clone();
     let sk_clone = sk_sender.clone();
@@ -73,7 +73,7 @@ pub fn enc_trans_bench(c: &mut Criterion) {
     let ro = RandomOracle::domain(&challenge_prefix);
     let mut ro_copy = ro.split();
 
-    let index = csprng.gen();
+    let index = csprng.gen::<u64>().into();
     let transaction = gen_enc_trans(
         &context,
         &mut ro_copy,
@@ -127,7 +127,7 @@ pub fn sec_to_pub_bench(c: &mut Criterion) {
     let challenge_prefix = generate_challenge_prefix(&mut csprng);
     let ro = RandomOracle::domain(&challenge_prefix);
 
-    let index = csprng.gen();
+    let index = csprng.gen::<u64>().into();
 
     let context_clone = context.clone();
     let sk_clone = sk.clone();
@@ -152,7 +152,7 @@ pub fn sec_to_pub_bench(c: &mut Criterion) {
     let ro = RandomOracle::domain(&challenge_prefix);
     let mut ro_copy = ro.split();
 
-    let index = csprng.gen();
+    let index = csprng.gen::<u64>().into();
     let transaction = gen_sec_to_pub_trans(
         &context,
         &mut ro_copy,

--- a/rust-src/encrypted_transfers/src/ffi.rs
+++ b/rust-src/encrypted_transfers/src/ffi.rs
@@ -133,7 +133,7 @@ unsafe extern "C" fn make_encrypted_transfer_data(
     *low_remaining = Box::into_raw(Box::new(data.remaining_amount.encryptions[0]));
     *high_transfer = Box::into_raw(Box::new(data.transfer_amount.encryptions[1]));
     *low_transfer = Box::into_raw(Box::new(data.transfer_amount.encryptions[0]));
-    *out_index = data.index;
+    *out_index = data.index.index;
 
     let mut bytes = to_bytes(&data.proof);
     *proof_len = bytes.len() as u64;
@@ -198,7 +198,7 @@ unsafe extern "C" fn verify_encrypted_transfer(
     let transfer_data = EncryptedAmountTransferData {
         remaining_amount,
         transfer_amount,
-        index: encrypted_agg_index,
+        index: encrypted_agg_index.into(),
         proof,
     };
 
@@ -244,7 +244,7 @@ unsafe extern "C" fn make_sec_to_pub_data(
 
     *high_remaining = Box::into_raw(Box::new(data.remaining_amount.encryptions[1]));
     *low_remaining = Box::into_raw(Box::new(data.remaining_amount.encryptions[0]));
-    *out_index = data.index;
+    *out_index = data.index.index;
 
     let mut bytes = to_bytes(&data.proof);
     *proof_len = bytes.len() as u64;
@@ -301,7 +301,7 @@ unsafe extern "C" fn verify_sec_to_pub_transfer(
     let transfer_data = SecToPubAmountTransferData {
         remaining_amount,
         transfer_amount,
-        index: encrypted_agg_index,
+        index: encrypted_agg_index.into(),
         proof,
     };
 
@@ -330,7 +330,7 @@ unsafe extern "C" fn make_aggregated_decrypted_amount(
     Box::into_raw(Box::new(AggregatedDecryptedAmount {
         agg_encrypted_amount,
         agg_amount: Amount { microgtu },
-        agg_index,
+        agg_index: agg_index.into(),
     }))
 }
 

--- a/rust-src/encrypted_transfers/src/lib.rs
+++ b/rust-src/encrypted_transfers/src/lib.rs
@@ -371,7 +371,7 @@ mod tests {
         let context = GlobalContext::<G1>::generate_size(String::from("genesis_string"), nm);
         let S_in_chunks = encrypt_amount(&context, &pk_sender, Amount::from(s), &mut csprng);
 
-        let index = csprng.gen(); // index is only important for on-chain stuff, not for proofs.
+        let index = csprng.gen::<u64>().into(); // index is only important for on-chain stuff, not for proofs.
         let input_amount = AggregatedDecryptedAmount {
             agg_amount:           Amount::from(s),
             agg_encrypted_amount: S_in_chunks.0.clone(),
@@ -416,7 +416,7 @@ mod tests {
         let context = GlobalContext::<G1>::generate_size(String::from("genesis_string"), nm);
         let S_in_chunks = encrypt_amount(&context, &pk_sender, Amount::from(s), &mut csprng);
 
-        let index = csprng.gen(); // index is only important for on-chain stuff, not for proofs.
+        let index = csprng.gen::<u64>().into(); // index is only important for on-chain stuff, not for proofs.
         let input_amount = AggregatedDecryptedAmount {
             agg_amount:           Amount::from(s),
             agg_encrypted_amount: S_in_chunks.0.clone(),

--- a/rust-src/encrypted_transfers/src/proofs/generate_proofs.rs
+++ b/rust-src/encrypted_transfers/src/proofs/generate_proofs.rs
@@ -182,7 +182,7 @@ pub fn gen_enc_trans<C: Curve, R: Rng>(
     pk_sender: &PublicKey<C>,
     sk_sender: &SecretKey<C>,
     pk_receiver: &PublicKey<C>,
-    index: u64,
+    index: EncryptedAmountAggIndex,
     S: &Cipher<C>,
     s: Amount,
     a: Amount,
@@ -363,10 +363,11 @@ pub fn gen_sec_to_pub_trans<C: Curve, R: Rng>(
     ro: &mut RandomOracle,
     pk: &PublicKey<C>, // sender and receiver are the same person
     sk: &SecretKey<C>,
-    index: u64,    // indicates which amounts were used
-    S: &Cipher<C>, // encryption of the input amount up to the index, combined into one encryption
-    s: Amount,     // input amount
-    a: Amount,     // amount to send
+    index: EncryptedAmountAggIndex, // indicates which amounts were used
+    S: &Cipher<C>,                  /* encryption of the input amount up to the index, combined
+                                     * into one encryption */
+    s: Amount, // input amount
+    a: Amount, // amount to send
     csprng: &mut R,
 ) -> Option<SecToPubAmountTransferData<C>> {
     if s < a {
@@ -685,7 +686,7 @@ mod test {
         let challenge_prefix = generate_challenge_prefix(&mut csprng);
         let mut ro = RandomOracle::domain(&challenge_prefix);
 
-        let index = csprng.gen(); // index is only important for on-chain stuff, not for proofs.
+        let index = csprng.gen::<u64>().into(); // index is only important for on-chain stuff, not for proofs.
         let transaction = gen_enc_trans(
             &context,
             &mut ro.split(),
@@ -735,7 +736,7 @@ mod test {
         let challenge_prefix = generate_challenge_prefix(&mut csprng);
 
         let mut ro = RandomOracle::domain(&challenge_prefix);
-        let index = csprng.gen(); // index is only important for on-chain stuff, not for proofs.
+        let index = csprng.gen::<u64>().into(); // index is only important for on-chain stuff, not for proofs.
         let transaction = gen_sec_to_pub_trans(
             &context,
             &mut ro.split(),

--- a/rust-src/encrypted_transfers/src/types.rs
+++ b/rust-src/encrypted_transfers/src/types.rs
@@ -1,11 +1,35 @@
 //! This module provides common types and constants for encrypted transfers.
 
+use std::u64;
+
 use crate::proofs::*;
 use bulletproofs::range_proof::*;
 use crypto_common::{types::Amount, *};
 use curve_arithmetic::*;
 use elgamal::*;
 use id::sigma_protocols::common::*;
+
+#[derive(Clone, Copy, Serialize, SerdeSerialize, SerdeDeserialize, Debug, Default)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct EncryptedAmountIndex {
+    pub index: u64,
+}
+
+#[derive(Clone, Copy, Serialize, SerdeSerialize, SerdeDeserialize, Debug, Default)]
+#[serde(transparent)]
+#[repr(transparent)]
+pub struct EncryptedAmountAggIndex {
+    pub index: u64,
+}
+
+impl From<u64> for EncryptedAmountAggIndex {
+    fn from(index: u64) -> Self { EncryptedAmountAggIndex { index } }
+}
+
+impl From<u64> for EncryptedAmountIndex {
+    fn from(index: u64) -> Self { EncryptedAmountIndex { index } }
+}
 
 #[derive(Clone, Serialize, SerdeBase16Serialize, Debug)]
 /// An encrypted amount, in two chunks. The JSON serialization of this is just
@@ -41,7 +65,7 @@ pub struct IndexedEncryptedAmount<C: Curve> {
     /// The actual encrypted amount.
     pub encrypted_chunks: EncryptedAmount<C>,
     /// Index of the amount on the account.
-    pub index:            u64,
+    pub index:            EncryptedAmountIndex,
 }
 
 /// Size of the chunk for encrypted amounts.
@@ -60,7 +84,7 @@ pub struct EncryptedAmountTransferData<C: Curve> {
     /// the aggregate of all encrypted amounts with indices < `index` existing
     /// on the account at the time. New encrypted amounts can only add new
     /// indices.
-    pub index:            u64,
+    pub index:            EncryptedAmountAggIndex,
     /// A collection of all the proofs.
     pub proof:            EncryptedAmountTransferProof<C>,
 }
@@ -78,7 +102,7 @@ pub struct SecToPubAmountTransferData<C: Curve> {
     /// the aggregate of all encrypted amounts with indices < `index` existing
     /// on the account at the time. New encrypted amounts can only add new
     /// indices.
-    pub index:            u64,
+    pub index:            EncryptedAmountAggIndex,
     /// A collection of all the proofs.
     pub proof:            SecToPubAmountTransferProof<C>,
 }
@@ -97,7 +121,7 @@ pub struct AggregatedDecryptedAmount<C: Curve> {
     /// Index such that the `agg_amount` is the sum of all encrypted amounts
     /// on an account with indices strictly below `agg_index`.
     #[serde(default)]
-    pub agg_index:            u64,
+    pub agg_index:            EncryptedAmountAggIndex,
 }
 
 /// # Proof datatypes

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -54,7 +54,7 @@ pub const NUM_BULLETPROOF_GENERATORS: usize = 32 * 8;
 /// Chunk size for encryption of prf key
 pub const CHUNK_SIZE: ChunkSize = ChunkSize::ThirtyTwo;
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, PartialOrd, Ord)]
 pub struct AccountAddress(pub(crate) [u8; ACCOUNT_ADDRESS_SIZE]);
 
 impl std::fmt::Display for AccountAddress {
@@ -1450,7 +1450,7 @@ pub struct CredentialDeploymentInfo<
 /// Account credential with values and commitments, but without proofs.
 /// Serialization must match the serializaiton of `AccountCredential` in
 /// Haskell.
-#[derive(SerdeSerialize, SerdeDeserialize)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug)]
 #[serde(tag = "type", content = "contents")]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",


### PR DESCRIPTION
This mimics what is already done on the Haskell side.

## Purpose

Type safety changes just add a bit of safety, mimicking the types that already exist on the Haskell side.

The additional instances make it easier to use the types in external libraries.

## Changes

- add a Timestamp type, mimicking the one in Concordium/Types.hs
- add EncryptedAmountIndex/AggIndex, replacing the previous use of u64 for both
- make the derive macros a bit more hygienic, avoiding some hard to understand errors.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
