### PR TITLE
Fix display for attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   When not used, the functionality is unaffected by this change.
 
 ## Other
+- the Display implementation of AttrubuteTag has been fixed. It was off by one.
 - the `create_credential` also outputs the randomness from the commitments used 
   in the proofs for credential deployment. The client tool will also output the randomness 
   using it to create credentials. 

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -437,10 +437,9 @@ impl<'a> std::convert::From<AttributeTag> for AttributeStringTag {
 
 impl fmt::Display for AttributeTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        assert!(self.0 > 0);
         let l: usize = (*self).into();
-        if l > 0 && l <= ATTRIBUTE_NAMES.len() {
-            write!(f, "{}", ATTRIBUTE_NAMES[l - 1])
+        if l < ATTRIBUTE_NAMES.len() {
+            write!(f, "{}", ATTRIBUTE_NAMES[l])
         } else {
             Err(fmt::Error)
         }


### PR DESCRIPTION
## Purpose

To fix the Display implementation for AttributeTag. It was off by one.

## Changes

The Display implementation has been fixed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

