### PR TITLE
Fail quickly when the initial account transaction goes missing.

### DIFF
--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -43,7 +43,9 @@ world scenario the attributes will be derived from the identity verification pro
 <body>
   <div>
     <h1>Concordium Identity Verification</h1>
-    <form action="/api/submit" method="post">
+    <form action="/api/submit"
+          onsubmit="var button = document.getElementById('submitButton');
+          button.disabled=true; button.value='Processing ...'" method="post">
 
         <input type="hidden" id="idcredpub" name="id_cred_pub" value="$id_cred_pub$">
         <input type="hidden" id="idcredpubsignature" name="id_cred_pub_signature" value="$id_cred_pub_signature$">
@@ -87,7 +89,7 @@ world scenario the attributes will be derived from the identity verification pro
         <label for="taxIdNo">Tax id no</label>
         <input type="text" id="taxIdNo" name="taxIdNo" value="T-1234">
 
-        <input type="submit" value="Submit">
+        <input id="submitButton" type="submit" value="Submit">
     </form>
   </div>
 </body>


### PR DESCRIPTION
## Purpose

Make the identity provider service fail early when the account creation transaction becomes absent. There are some legitimate cases where the transaction could become absent due to configuration errors, e.g., the node the wallet proxy talks to being temporarily out of date. In the past that was really the predominant reason for the transaction being absent, but with the desktop wallet's deterministic key generation it is now quite possible for somebody to get into this state by mistake.

In such a case it is better for a test service like this to fail quickly.

## Changes

Fail early in case initial account creation transaction goes absent.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

