### PR TITLE
Identity provider service: Fix Docker build

### DIFF
--- a/identity-provider-service.Jenkinsfile
+++ b/identity-provider-service.Jenkinsfile
@@ -22,8 +22,8 @@ pipeline {
                 sh '''\
                     docker build \
                       -t "${image_name}" \
-                      --build-arg development_image_tag="${development_image_tag}" \
-                      --label development_image_tag="${development_image_tag}" \
+                      --build-arg base_image_tag="${base_image_tag}" \
+                      --label base_image_tag="${base_image_tag}" \
                       -f scripts/identity-provider-service.Dockerfile \
                       .
                     docker push "${image_name}"

--- a/scripts/identity-provider-service.Dockerfile
+++ b/scripts/identity-provider-service.Dockerfile
@@ -1,5 +1,5 @@
 # Build binaries in builder image.
-ARG development_image_tag
+ARG base_image_tag
 FROM concordium/base:${base_image_tag} as builder
 COPY . /build
 WORKDIR /build/identity-provider-service


### PR DESCRIPTION
The service currently doesn't build because a previous PR changed the base image but only partially updated a build arg.

This change updates the remaining occurrences.