### PR TITLE
Add checks for RO challenge prefix collision in soundness tests

### DIFF
--- a/rust-src/encrypted_transfers/src/proofs/enc_trans.rs
+++ b/rust-src/encrypted_transfers/src/proofs/enc_trans.rs
@@ -498,7 +498,9 @@ mod tests {
                     prove(&mut ro_split, &enc_trans, secret, rng).expect("Proving should succeed.");
 
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(rng));
-                assert!(!verify(&mut wrong_ro, &enc_trans, &proof));
+                if verify(&mut wrong_ro, &enc_trans, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
 
                 // check that changing any information in the protocol makes the proof not
                 // verify

--- a/rust-src/id/src/sigma_protocols/aggregate_dlog.rs
+++ b/rust-src/id/src/sigma_protocols/aggregate_dlog.rs
@@ -162,7 +162,9 @@ mod tests {
 
                 // Verify failure for invalid parameters
                 // Incorrect context string
-                assert!(!verify(&mut wrong_ro, &agg, &proof));
+                if verify(&mut wrong_ro, &agg, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let wrong_agg = AggregateDlog {
                     public: wrong_public,
                     ..agg

--- a/rust-src/id/src/sigma_protocols/com_enc_eq.rs
+++ b/rust-src/id/src/sigma_protocols/com_enc_eq.rs
@@ -227,7 +227,9 @@ mod tests {
                 // Construct invalid parameters
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
                 // Verify failure for invalid parameters
-                assert!(!verify(&mut wrong_ro, &com_enc_eq, &proof));
+                if verify(&mut wrong_ro, &com_enc_eq, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let mut wrong_com_enc_eq = com_enc_eq;
                 {
                     let tmp = wrong_com_enc_eq.cipher;

--- a/rust-src/id/src/sigma_protocols/com_eq.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq.rs
@@ -177,7 +177,9 @@ mod test {
                     .expect("Proving should succeed.");
 
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
-                assert!(!verify(&mut wrong_ro, &com_eq, &proof));
+                if verify(&mut wrong_ro, &com_eq, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let mut wrong_com_eq = com_eq;
                 {
                     let tmp = wrong_com_eq.commitment;

--- a/rust-src/id/src/sigma_protocols/com_eq_different_groups.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq_different_groups.rs
@@ -191,7 +191,9 @@ mod tests {
 
                 // Construct invalid parameters
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
-                assert!(!verify(&mut wrong_ro, &cdg, &proof));
+                if verify(&mut wrong_ro, &cdg, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let mut wrong_cdg = cdg;
                 {
                     let tmp = wrong_cdg.cmm_key_1;

--- a/rust-src/id/src/sigma_protocols/com_eq_sig.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq_sig.rs
@@ -322,7 +322,9 @@ mod tests {
 
                 // Construct invalid parameters
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
-                assert!(!verify(&mut wrong_ro, &ces, &proof));
+                if verify(&mut wrong_ro, &ces, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
 
                 let mut wrong_ces = ces;
                 {

--- a/rust-src/id/src/sigma_protocols/com_lin.rs
+++ b/rust-src/id/src/sigma_protocols/com_lin.rs
@@ -255,7 +255,9 @@ mod tests {
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
 
                 // Verify failure for invalid parameters
-                assert!(!verify(&mut wrong_ro, &com_lin, &proof));
+                if verify(&mut wrong_ro, &com_lin, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let mut wrong_cmm = com_lin;
                 for i in 0..n {
                     let tmp = wrong_cmm.cmms[i];

--- a/rust-src/id/src/sigma_protocols/com_mult.rs
+++ b/rust-src/id/src/sigma_protocols/com_mult.rs
@@ -203,8 +203,11 @@ mod tests {
                 // Construct invalid parameters
                 let mut wrong_ro = RandomOracle::domain(generate_challenge_prefix(csprng));
 
-                // Verify failure for invalid parameters
-                assert!(!verify(&mut wrong_ro, &com_mult, &proof));
+                // Verify failure for invalid parameters, or that the same RO state has been
+                // sampled
+                if verify(&mut wrong_ro, &com_mult, &proof) {
+                    assert_eq!(ro, wrong_ro)
+                }
                 let mut wrong_cmm = com_mult;
                 for i in 0..3 {
                     let tmp = wrong_cmm.cmms[i];

--- a/rust-src/id/src/sigma_protocols/dlog.rs
+++ b/rust-src/id/src/sigma_protocols/dlog.rs
@@ -145,7 +145,9 @@ mod tests {
                 };
 
                 // Verify failure for invalid parameters
-                assert!(!verify(&mut wrong_ro, &dlog, &proof));
+                if verify(&mut wrong_ro, &dlog, &proof) {
+                    assert_eq!(wrong_ro, ro);
+                }
                 let dlog_wrong_base = Dlog {
                     coeff: wrong_base,
                     ..dlog

--- a/rust-src/random_oracle/src/lib.rs
+++ b/rust-src/random_oracle/src/lib.rs
@@ -57,10 +57,10 @@ impl Buffer for RandomOracle {
     fn result(self) -> Self::Result { self.0.finalize() }
 }
 
+impl Eq for RandomOracle {}
+
 impl PartialEq for RandomOracle {
-    fn eq(&self, other: &Self) -> bool {
-        self.split().get_challenge() == other.split().get_challenge()
-    }
+    fn eq(&self, other: &Self) -> bool { self.0.clone().finalize() == other.0.clone().finalize() }
 }
 
 impl RandomOracle {

--- a/rust-src/random_oracle/src/lib.rs
+++ b/rust-src/random_oracle/src/lib.rs
@@ -9,6 +9,7 @@ use std::io::Write;
 
 /// State of the random oracle, used to incrementally build up the output.
 #[repr(transparent)]
+#[derive(Debug)]
 pub struct RandomOracle(Sha3_256);
 
 /// Type of challenges computed from the random oracle.
@@ -54,6 +55,12 @@ impl Buffer for RandomOracle {
 
     // Compute the result in the given state, consuming the state.
     fn result(self) -> Self::Result { self.0.finalize() }
+}
+
+impl PartialEq for RandomOracle {
+    fn eq(&self, other: &Self) -> bool {
+        self.split().get_challenge() == other.split().get_challenge()
+    }
 }
 
 impl RandomOracle {


### PR DESCRIPTION
## Purpose

Some tests of soundness of various protocols did not test for collision of RO challenge prefixes. These would happen with probability > 1/10^6, and thus make the tests fail in some rare cases.

## Changes

Add tests checking if two randomly selected ROs are identical in case of unexpected verifications, when one is used for generating a proof and the other for verification.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
