### PR TITLE
Add reference to credential data in prover function.

### DIFF
--- a/rust-src/id/src/id_prover.rs
+++ b/rust-src/id/src/id_prover.rs
@@ -25,7 +25,7 @@ use sha2::{Digest, Sha256};
 /// coincide with the hash of a transaction (assuming that SHA256 is
 /// collision-resistant).
 pub fn prove_ownership_of_account(
-    data: CredentialData,
+    data: &CredentialData,
     account: AccountAddress,
     challenge: &[u8],
 ) -> AccountOwnershipProof {

--- a/rust-src/id/src/id_verifier.rs
+++ b/rust-src/id/src/id_verifier.rs
@@ -126,7 +126,7 @@ mod tests {
         let account_address = AccountAddress::new(&reg_id);
         let challenge = b"13549686546546546854651357687354";
 
-        let proof = prove_ownership_of_account(cred_data, account_address, challenge);
+        let proof = prove_ownership_of_account(&cred_data, account_address, challenge);
 
         assert!(verify_account_ownership(
             &pub_data,


### PR DESCRIPTION
## Purpose

To take a reference to the credential data when proving ownership of account instead of consuming it.

## Changes

Added above reference.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

