### PR TITLE
Re-exports.

### DIFF
--- a/rust-src/id/src/lib.rs
+++ b/rust-src/id/src/lib.rs
@@ -15,6 +15,18 @@ pub mod sigma_protocols;
 pub mod types;
 pub mod utils;
 
+/// Re-export of Pedersen commitments functionality.
+pub use pedersen_scheme as pedersen_commitment;
+
+/// Re-export of curve arithmetic.
+pub use curve_arithmetic;
+
+/// Re-export of Elgamal encryption.
+pub use elgamal;
+
+/// Re-export of bulletproofs.
+pub use bulletproofs::range_proof;
+
 #[macro_use]
 extern crate crypto_common_derive;
 


### PR DESCRIPTION
## Purpose

To re-export crates.

## Changes

* The ID crate now re-exports the crates pedersen_scheme, curve_arithmetic, elgamal and the range_proof module from the bulletproofs crate.

