### PR TITLE
Make serialization instances for transaction outcomes explicit.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -280,6 +280,7 @@ test-suite test
       Types.RewardTypes
       Types.TransactionGen
       Types.TransactionSerializationSpec
+      Types.TransactionSummarySpec
       Types.UpdatesSpec
       Paths_concordium_base
   hs-source-dirs:

--- a/haskell-src/Concordium/Crypto/EncryptedTransfers.hs
+++ b/haskell-src/Concordium/Crypto/EncryptedTransfers.hs
@@ -138,7 +138,7 @@ aggregateAmounts left right = unsafePerformIO $ do
 -------------------------- Encrypted aggregated index --------------------------
 --------------------------------------------------------------------------------
 
--- |An indexed used to determine which encryped amounts were used in a transaction.
+-- |An index used to determine which encrypted amounts were used in a transaction.
 newtype EncryptedAmountAggIndex = EncryptedAmountAggIndex {theAggIndex :: Word64}
     deriving newtype (Eq, Show, Ord, FromJSON, ToJSON, Num, Integral, Real, Enum, Storable, Serialize)
 

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -986,7 +986,7 @@ type TransactionSummary = TransactionSummary' ValidResult
 -- successful transaction with a list of events which occurred during execution.
 -- We also record the cost of the transaction.
 data ValidResult = TxSuccess { vrEvents :: ![Event] } | TxReject { vrRejectReason :: !RejectReason }
-  deriving(Show, Eq)
+  deriving(Show, Generic, Eq)
 
 instance S.Serialize ValidResult where
   put TxSuccess{..} = S.putWord8 0 <> putListOf S.put vrEvents
@@ -1087,7 +1087,7 @@ data RejectReason = ModuleNotWF -- ^Error raised when validating the Wasm module
                   | DuplicateCredIDs ![IDTypes.CredentialRegistrationID]
                   -- | A credential id that was to be removed is not part of the account.
                   | NonExistentCredIDs ![IDTypes.CredentialRegistrationID]
-                  -- | Attemp to remove the first credential
+                  -- | Attempt to remove the first credential
                   | RemoveFirstCredential
                   -- | The credential holder of the keys to be updated did not sign the transaction
                   | CredentialHolderDidNotSign

--- a/haskell-src/Concordium/Utils/Serialization.hs
+++ b/haskell-src/Concordium/Utils/Serialization.hs
@@ -69,6 +69,24 @@ getUtf8 = do
 
 -- * Containers
 
+-- |Put a list of elements by first putting the size using 'putLength', then
+-- putting the elements from head to tail.
+putListOf
+    :: Putter a
+    -- ^How to put a value
+    -> Putter [a]
+putListOf pVal xs = putLength (length xs) <> mapM_ pVal xs
+
+
+-- |Get a list of elements. Dual to 'putListOf'.
+getListOf
+    :: Get a
+    -- ^How to get a value.
+    -> Get [a]
+getListOf gVal = do
+        sz <- getLength
+        replicateM sz gVal
+
 -- |Put a 'Set.Set' by first putting the size, then putting the elements in ascending order.
 putSafeSetOf
     :: Putter a

--- a/haskell-tests/Spec.hs
+++ b/haskell-tests/Spec.hs
@@ -20,6 +20,7 @@ import qualified Types.AmountSpec
 import qualified Types.UpdatesSpec
 import qualified Types.AccountEncryptedAmountSpec
 import qualified Types.RewardTypes
+import qualified Types.TransactionSummarySpec
 
 main :: IO  ()
 main = hspec $ parallel $ do
@@ -36,7 +37,7 @@ main = hspec $ parallel $ do
     ConcordiumTests.Crypto.EncryptedTransfers.tests
     ConcordiumTests.Utils.Encryption.tests
     -- NB: The following tests are far from complete. They do not test what
-    -- happens when data is corrupt in various ways (number of commmited values
+    -- happens when data is corrupt in various ways (number of commmitted values
     -- is incorrect, or similar)
     Types.PayloadSerializationSpec.tests
     Types.TransactionSerializationSpec.tests
@@ -44,3 +45,4 @@ main = hspec $ parallel $ do
     Types.UpdatesSpec.tests
     Types.AccountEncryptedAmountSpec.tests
     Types.RewardTypes.tests
+    Types.TransactionSummarySpec.tests

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -36,7 +36,6 @@ import Concordium.Wasm
 
 import Concordium.Crypto.Proofs
 import Concordium.Crypto.DummyData
-import Concordium.Types.ProtocolVersion
 
 genAttributeValue :: Gen AttributeValue
 genAttributeValue = AttributeValue . BSS.pack <$> (vector =<< choose (0,31))

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -70,6 +70,22 @@ genCAddress = ContractAddress <$> (ContractIndex <$> arbitrary) <*> (ContractSub
 genModuleRef :: Gen ModuleRef
 genModuleRef = ModuleRef . SHA256.hash . BS.pack <$> vector 32
 
+-- These generators name contracts as numbers to make sure the names are valid.
+genInitName :: Gen InitName
+genInitName =
+  InitName . Text.pack . ("init_" ++) . show <$> (arbitrary :: Gen Word)
+
+genReceiveName :: Gen ReceiveName
+genReceiveName = do
+  contract <- show <$> (arbitrary :: Gen Word)
+  receive <- show <$> (arbitrary :: Gen Word)
+  return . ReceiveName . Text.pack $ receive ++ "." ++ contract
+
+genParameter :: Gen Parameter
+genParameter = do
+  n <- choose (0,1000)
+  Parameter . BSS.pack <$> vector n
+
 genPayload :: Gen Payload
 genPayload = oneof [genDeployModule,
                     genInit,
@@ -100,21 +116,6 @@ genPayload = oneof [genDeployModule,
         genByteString = do
           n <- choose (0,1000)
           BS.pack <$> vector n
-
-        -- These generators name contracts as numbers to make sure the names are valid.
-        genInitName :: Gen InitName
-        genInitName =
-          InitName . Text.pack . ("init_" ++) . show <$> (arbitrary :: Gen Word)
-
-        genReceiveName :: Gen ReceiveName
-        genReceiveName = do
-          contract <- show <$> (arbitrary :: Gen Word)
-          receive <- show <$> (arbitrary :: Gen Word)
-          return . ReceiveName . Text.pack $ receive ++ "." ++ contract
-
-        genParameter = do
-          n <- choose (0,1000)
-          Parameter . BSS.pack <$> vector n
 
         genDeployModule = DeployModule <$> (WasmModule 0 . ModuleSource <$> genByteString)
 

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -1,0 +1,263 @@
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Types.TransactionSummarySpec where
+
+import qualified Data.ByteString.Short as SBS
+import Data.Serialize
+import GHC.Generics
+import Test.Hspec
+import Test.QuickCheck
+
+import qualified Concordium.Crypto.BlockSignature as BlockSig
+import Concordium.Crypto.DummyData
+import Concordium.Crypto.EncryptedTransfers
+import Concordium.Crypto.SHA256 (Hash (Hash))
+import qualified Concordium.Crypto.VRF as VRF
+import Concordium.ID.Types (AccountThreshold (..), CredentialType (..))
+import Concordium.Types
+import Concordium.Types.Execution
+import qualified Concordium.Wasm as Wasm
+import qualified Data.FixedByteString as FBS
+
+import Types.AmountSpec (genAmount)
+import Types.PayloadSerializationSpec hiding (genAddress)
+import Types.TransactionGen (genAccountAddress)
+import Types.UpdatesSpec (genUpdatePayload)
+
+transactionTypes :: [TransactionType]
+transactionTypes =
+    [ TTDeployModule,
+      TTInitContract,
+      TTUpdate,
+      TTTransfer,
+      TTAddBaker,
+      TTRemoveBaker,
+      TTUpdateBakerStake,
+      TTUpdateBakerRestakeEarnings,
+      TTUpdateBakerKeys,
+      TTUpdateCredentialKeys,
+      TTEncryptedAmountTransfer,
+      TTTransferToEncrypted,
+      TTTransferToPublic,
+      TTTransferWithSchedule,
+      TTUpdateCredentials,
+      TTRegisterData,
+      TTTransferWithMemo,
+      TTEncryptedAmountTransferWithMemo,
+      TTTransferWithScheduleAndMemo
+    ]
+
+instance Arbitrary TransactionType where
+    arbitrary = elements transactionTypes
+
+testTransactionTypesSerialIdentity :: Expectation
+testTransactionTypesSerialIdentity = mapM_ testEncDec transactionTypes
+  where
+    testEncDec tt = decode (encode tt) `shouldBe` Right tt
+
+testTransactionTypesSerialGeneric :: Expectation
+testTransactionTypesSerialGeneric = mapM_ testEncGen transactionTypes
+  where
+    testEncGen tt = encode tt `shouldBe` runPut (gPut (from tt))
+
+genEncryptedAmount :: Gen EncryptedAmount
+genEncryptedAmount = EncryptedAmount <$> genElgamalCipher <*> genElgamalCipher
+
+genContractEvent :: Gen Wasm.ContractEvent
+genContractEvent = Wasm.ContractEvent . SBS.pack <$> arbitrary
+
+genAddress :: Gen Address
+genAddress = oneof [AddressAccount <$> genAccountAddress, AddressContract <$> genCAddress]
+
+genTransactionTime :: Gen TransactionTime
+genTransactionTime = TransactionTime <$> arbitrary
+
+genTimestamp :: Gen Timestamp
+genTimestamp = Timestamp <$> arbitrary
+
+genRegisteredData :: Gen RegisteredData
+genRegisteredData = do
+    len <- choose (0, maxRegisteredDataSize)
+    RegisteredData . SBS.pack <$> vector len
+
+genMemo :: Gen Memo
+genMemo = do
+    len <- choose (0, maxMemoSize)
+    Memo . SBS.pack <$> vector len
+
+genBakerId :: Gen BakerId
+genBakerId = BakerId . AccountIndex <$> arbitrary
+
+instance Arbitrary Event where
+    arbitrary =
+        oneof
+            [ ModuleDeployed <$> genModuleRef,
+              ContractInitialized <$> genModuleRef <*> genCAddress <*> genAmount <*> genInitName <*> listOf genContractEvent,
+              Updated <$> genCAddress <*> genAddress <*> genAmount <*> genParameter <*> genReceiveName <*> listOf genContractEvent,
+              Transferred <$> genAddress <*> genAmount <*> genAddress,
+              AccountCreated <$> genAccountAddress,
+              CredentialDeployed <$> genCredentialId <*> genAccountAddress,
+              genBakerAdded,
+              BakerRemoved <$> genBakerId <*> genAccountAddress,
+              BakerStakeIncreased <$> genBakerId <*> genAccountAddress <*> genAmount,
+              BakerStakeDecreased <$> genBakerId <*> genAccountAddress <*> genAmount,
+              BakerSetRestakeEarnings <$> genBakerId <*> genAccountAddress <*> arbitrary,
+              genBakerKeysUpdated,
+              CredentialKeysUpdated <$> genCredentialId,
+              NewEncryptedAmount <$> genAccountAddress <*> (EncryptedAmountIndex <$> arbitrary) <*> genEncryptedAmount,
+              EncryptedAmountsRemoved <$> genAccountAddress <*> genEncryptedAmount <*> genEncryptedAmount <*> (EncryptedAmountAggIndex <$> arbitrary),
+              AmountAddedByDecryption <$> genAccountAddress <*> genAmount,
+              EncryptedSelfAmountAdded <$> genAccountAddress <*> genEncryptedAmount <*> genAmount,
+              UpdateEnqueued <$> genTransactionTime <*> genUpdatePayload,
+              genTransferredWithSchedule,
+              genCredentialsUpdated,
+              DataRegistered <$> genRegisteredData,
+              TransferMemo <$> genMemo
+            ]
+      where
+        genBakerAdded = do
+            ebaBakerId <- genBakerId
+            ebaAccount <- genAccountAddress
+            ebaSignKey <- BlockSig.verifyKey <$> genBlockKeyPair
+            ebaElectionKey <- VRF.publicKey <$> arbitrary
+            (ebaAggregationKey, _) <- genAggregationVerifyKeyAndProof
+            ebaStake <- arbitrary
+            ebaRestakeEarnings <- arbitrary
+            return BakerAdded{..}
+        genBakerKeysUpdated = do
+            ebkuBakerId <- genBakerId
+            ebkuAccount <- genAccountAddress
+            ebkuSignKey <- BlockSig.verifyKey <$> genBlockKeyPair
+            ebkuElectionKey <- VRF.publicKey <$> arbitrary
+            (ebkuAggregationKey, _) <- genAggregationVerifyKeyAndProof
+            return BakerKeysUpdated{..}
+        genTransferredWithSchedule = do
+            etwsFrom <- genAccountAddress
+            etwsTo <- genAccountAddress
+            etwsAmount <- listOf ((,) <$> genTimestamp <*> genAmount)
+            return TransferredWithSchedule{..}
+        genCredentialsUpdated = do
+            cuAccount <- genAccountAddress
+            cuNewCredIds <- listOf genCredentialId
+            cuRemovedCredIds <- listOf genCredentialId
+            cuNewThreshold <- AccountThreshold <$> choose (1, maxBound)
+            return CredentialsUpdated{..}
+
+-- |Test that decoding is the inverse of encoding for 'Event's.
+testEventSerializationIdentity :: Event -> Property
+testEventSerializationIdentity e = decode (encode e) === Right e
+
+-- |Test that the serialization of 'Event's is equivalent to the 'Generic'-derived serialization
+-- instance.  This test may be superceded with future changes to the 'Event' type.
+testEventSerializationGeneric :: Event -> Property
+testEventSerializationGeneric e = encode e === runPut (gPut (from e))
+
+instance Arbitrary RejectReason where
+    arbitrary =
+        oneof
+            [ return ModuleNotWF,
+              ModuleHashAlreadyExists <$> genModuleRef,
+              InvalidAccountReference <$> genAccountAddress,
+              InvalidInitMethod <$> genModuleRef <*> genInitName,
+              InvalidReceiveMethod <$> genModuleRef <*> genReceiveName,
+              InvalidModuleReference <$> genModuleRef,
+              InvalidContractAddress <$> genCAddress,
+              return RuntimeFailure,
+              AmountTooLarge <$> genAddress <*> genAmount,
+              return SerializationFailure,
+              return OutOfEnergy,
+              RejectedInit <$> arbitrary,
+              RejectedReceive <$> arbitrary <*> genCAddress <*> genReceiveName <*> genParameter,
+              NonExistentRewardAccount <$> genAccountAddress,
+              return InvalidProof,
+              AlreadyABaker <$> genBakerId,
+              NotABaker <$> genAccountAddress,
+              return InsufficientBalanceForBakerStake,
+              return StakeUnderMinimumThresholdForBaking,
+              return BakerInCooldown,
+              DuplicateAggregationKey . fst <$> genAggregationVerifyKeyAndProof,
+              return NonExistentCredentialID,
+              return KeyIndexAlreadyInUse,
+              return InvalidAccountThreshold,
+              return InvalidCredentialKeySignThreshold,
+              return InvalidEncryptedAmountTransferProof,
+              return InvalidTransferToPublicProof,
+              EncryptedAmountSelfTransfer <$> genAccountAddress,
+              return InvalidIndexOnEncryptedTransfer,
+              return ZeroScheduledAmount,
+              return NonIncreasingSchedule,
+              return FirstScheduledReleaseExpired,
+              ScheduledSelfTransfer <$> genAccountAddress,
+              return InvalidCredentials,
+              DuplicateCredIDs <$> listOf genCredentialId,
+              NonExistentCredIDs <$> listOf genCredentialId,
+              return RemoveFirstCredential,
+              return CredentialHolderDidNotSign,
+              return NotAllowedMultipleCredentials,
+              return NotAllowedToReceiveEncrypted,
+              return NotAllowedToHandleEncrypted
+            ]
+
+-- |Test that decoding is the inverse of encoding for 'RejectReason's.
+testRejectReasonSerializationIdentity :: RejectReason -> Property
+testRejectReasonSerializationIdentity e = decode (encode e) === Right e
+
+-- |Test that the serialization of 'RejectReason's is equivalent to the 'Generic'-derived serialization
+-- instance.  This test may be superceded with future changes to the 'RejectReason' type.
+testRejectReasonSerializationGeneric :: RejectReason -> Property
+testRejectReasonSerializationGeneric e = encode e === runPut (gPut (from e))
+
+instance Arbitrary ValidResult where
+    arbitrary =
+        oneof
+            [ TxSuccess <$> arbitrary,
+              TxReject <$> arbitrary
+            ]
+
+-- |Test that decoding is the inverse of encoding for 'ValidResult's.
+testValidResultSerializationIdentity :: ValidResult -> Property
+testValidResultSerializationIdentity e = decode (encode e) === Right e
+
+-- |Test that the serialization of 'ValidResult's is equivalent to the 'Generic'-derived serialization
+-- instance.  This test may be superceded with future changes to the 'ValidResult' type.
+testValidResultSerializationGeneric :: ValidResult -> Property
+testValidResultSerializationGeneric e = encode e === runPut (gPut (from e))
+
+instance Arbitrary TransactionSummary where
+    arbitrary = do
+        tsSender <- oneof [return Nothing, Just <$> genAccountAddress]
+        tsHash <- TransactionHashV0 . Hash . FBS.pack <$> vector 32
+        tsCost <- genAmount
+        tsEnergyCost <- Energy <$> arbitrary
+        tsType <-
+            oneof
+                [ TSTAccountTransaction <$> arbitrary,
+                  TSTCredentialDeploymentTransaction <$> elements [Initial, Normal],
+                  TSTUpdateTransaction <$> arbitraryBoundedEnum
+                ]
+        tsResult <- arbitrary
+        tsIndex <- TransactionIndex <$> arbitrary
+        return TransactionSummary{..}
+
+-- |Test that decoding is the inverse of encoding for 'TransactionSummary's.
+testTransactionSummarySerializationIdentity :: TransactionSummary -> Property
+testTransactionSummarySerializationIdentity e = decode (encode e) === Right e
+
+-- |Test that the serialization of 'TransactionSummary's is equivalent to the 'Generic'-derived serialization
+-- instance.  This test may be superceded with future changes to the 'TransactionSummary' type.
+testTransactionSummarySerializationGeneric :: TransactionSummary -> Property
+testTransactionSummarySerializationGeneric e = encode e === runPut (gPut (from e))
+
+
+tests :: Spec
+tests = describe "Transaction summaries" $ do
+    specify "TransactionType: serialize then deserialize is identity" testTransactionTypesSerialIdentity
+    specify "TransactionType: serialize is equivalent to generic serialize" testTransactionTypesSerialGeneric
+    specify "Event: serialize then deserialize is identity" $ withMaxSuccess 10000 testEventSerializationIdentity
+    specify "Event: serialize is equivalent to generic serialize" $ withMaxSuccess 10000 testEventSerializationGeneric
+    specify "RejectReason: serialize then deserialize is identity" $ withMaxSuccess 10000 testRejectReasonSerializationIdentity
+    specify "RejectReason: serialize is equivalent to generic serialize" $ withMaxSuccess 10000 testRejectReasonSerializationGeneric
+    specify "ValidResult: serialize then deserialize is identity" $ withMaxSuccess 1000 testValidResultSerializationIdentity
+    specify "ValidResult: serialize is equivalent to generic serialize" $ withMaxSuccess 1000 testValidResultSerializationGeneric
+    specify "TransactionSummary: serialize then deserialize is identity" $ withMaxSuccess 1000 testTransactionSummarySerializationIdentity
+    specify "TransactionSummary: serialize is equivalent to generic serialize" $ withMaxSuccess 1000 testTransactionSummarySerializationGeneric

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -4,7 +4,6 @@ module Types.TransactionSummarySpec where
 
 import qualified Data.ByteString.Short as SBS
 import Data.Serialize
-import GHC.Generics
 import Test.Hspec
 import Test.QuickCheck
 
@@ -54,11 +53,6 @@ testTransactionTypesSerialIdentity :: Expectation
 testTransactionTypesSerialIdentity = mapM_ testEncDec transactionTypes
   where
     testEncDec tt = decode (encode tt) `shouldBe` Right tt
-
-testTransactionTypesSerialGeneric :: Expectation
-testTransactionTypesSerialGeneric = mapM_ testEncGen transactionTypes
-  where
-    testEncGen tt = encode tt `shouldBe` runPut (gPut (from tt))
 
 genEncryptedAmount :: Gen EncryptedAmount
 genEncryptedAmount = EncryptedAmount <$> genElgamalCipher <*> genElgamalCipher
@@ -147,11 +141,6 @@ instance Arbitrary Event where
 testEventSerializationIdentity :: Event -> Property
 testEventSerializationIdentity e = decode (encode e) === Right e
 
--- |Test that the serialization of 'Event's is equivalent to the 'Generic'-derived serialization
--- instance.  This test may be superceded with future changes to the 'Event' type.
-testEventSerializationGeneric :: Event -> Property
-testEventSerializationGeneric e = encode e === runPut (gPut (from e))
-
 instance Arbitrary RejectReason where
     arbitrary =
         oneof
@@ -202,11 +191,6 @@ instance Arbitrary RejectReason where
 testRejectReasonSerializationIdentity :: RejectReason -> Property
 testRejectReasonSerializationIdentity e = decode (encode e) === Right e
 
--- |Test that the serialization of 'RejectReason's is equivalent to the 'Generic'-derived serialization
--- instance.  This test may be superceded with future changes to the 'RejectReason' type.
-testRejectReasonSerializationGeneric :: RejectReason -> Property
-testRejectReasonSerializationGeneric e = encode e === runPut (gPut (from e))
-
 instance Arbitrary ValidResult where
     arbitrary =
         oneof
@@ -217,11 +201,6 @@ instance Arbitrary ValidResult where
 -- |Test that decoding is the inverse of encoding for 'ValidResult's.
 testValidResultSerializationIdentity :: ValidResult -> Property
 testValidResultSerializationIdentity e = decode (encode e) === Right e
-
--- |Test that the serialization of 'ValidResult's is equivalent to the 'Generic'-derived serialization
--- instance.  This test may be superceded with future changes to the 'ValidResult' type.
-testValidResultSerializationGeneric :: ValidResult -> Property
-testValidResultSerializationGeneric e = encode e === runPut (gPut (from e))
 
 instance Arbitrary TransactionSummary where
     arbitrary = do
@@ -243,21 +222,10 @@ instance Arbitrary TransactionSummary where
 testTransactionSummarySerializationIdentity :: TransactionSummary -> Property
 testTransactionSummarySerializationIdentity e = decode (encode e) === Right e
 
--- |Test that the serialization of 'TransactionSummary's is equivalent to the 'Generic'-derived serialization
--- instance.  This test may be superceded with future changes to the 'TransactionSummary' type.
-testTransactionSummarySerializationGeneric :: TransactionSummary -> Property
-testTransactionSummarySerializationGeneric e = encode e === runPut (gPut (from e))
-
-
 tests :: Spec
 tests = describe "Transaction summaries" $ do
     specify "TransactionType: serialize then deserialize is identity" testTransactionTypesSerialIdentity
-    specify "TransactionType: serialize is equivalent to generic serialize" testTransactionTypesSerialGeneric
     specify "Event: serialize then deserialize is identity" $ withMaxSuccess 10000 testEventSerializationIdentity
-    specify "Event: serialize is equivalent to generic serialize" $ withMaxSuccess 10000 testEventSerializationGeneric
     specify "RejectReason: serialize then deserialize is identity" $ withMaxSuccess 10000 testRejectReasonSerializationIdentity
-    specify "RejectReason: serialize is equivalent to generic serialize" $ withMaxSuccess 10000 testRejectReasonSerializationGeneric
     specify "ValidResult: serialize then deserialize is identity" $ withMaxSuccess 1000 testValidResultSerializationIdentity
-    specify "ValidResult: serialize is equivalent to generic serialize" $ withMaxSuccess 1000 testValidResultSerializationGeneric
     specify "TransactionSummary: serialize then deserialize is identity" $ withMaxSuccess 1000 testTransactionSummarySerializationIdentity
-    specify "TransactionSummary: serialize is equivalent to generic serialize" $ withMaxSuccess 1000 testTransactionSummarySerializationGeneric


### PR DESCRIPTION
## Purpose

Serialization defines the transaction outcome hash, which is part of blocks, and
therefore block hashes. Hence it is important that it is well-defined and not
accidentally changed. Making it explicit helps with that. Additionally it will more easily support changes to the relevant types while retaining backwards compatibility.

## Changes

Write serialization instances manually instead of using generic deriving.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.