### PR TITLE
Improve PS signature verification; add test to prevent regression.

### DIFF
--- a/rust-src/ps_sig/src/public.rs
+++ b/rust-src/ps_sig/src/public.rs
@@ -50,7 +50,7 @@ impl<C: Pairing> PublicKey<C> {
         let ys = &self.y_tildas;
         let x = self.x_tilda;
         let ms = &message.0;
-        if sig.0 == C::G1::zero_point() || ms.len() > ys.len() {
+        if sig.0.is_zero_point() || ms.len() > ys.len() {
             return false;
         }
         let h = ys

--- a/rust-src/ps_sig/src/public.rs
+++ b/rust-src/ps_sig/src/public.rs
@@ -198,7 +198,10 @@ mod tests {
                     let message = KnownMessage::<$pairing_type>::generate(i, &mut csprng);
                     let sig = sk.sign_known_message(&message, &mut csprng);
                     assert!(sig.is_ok());
-                    let dummy = Signature(<$pairing_type as Pairing>::G1::zero_point(), <$pairing_type as Pairing>::G1::zero_point());
+                    let dummy = Signature(
+                        <$pairing_type as Pairing>::G1::zero_point(),
+                        <$pairing_type as Pairing>::G1::zero_point(),
+                    );
                     assert!(!&pk.verify(&dummy, &message));
                 }
             }


### PR DESCRIPTION
## Purpose

Verification of PS signatures was improved to reject dummy signatures of form (point_at_infinity, point_at_infinity) which are valid for any combination of message and public_key.

## Changes

Signature verification now rejects signatures where the first group element is the point at infinity in G1, as per the original Pointcheval-Sanders paper. A test was also added to prevent future regressions.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

- [X] I accept the above linked CLA.
