### PR TITLE
Fix keygen, increase version, add test vectors and changelog.

### DIFF
--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -1103,10 +1103,11 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keygen_bls"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "curve_arithmetic",
  "ff",
+ "hex",
  "hkdf",
  "pairing",
  "sha2 0.9.5",

--- a/rust-bins/Cargo.toml
+++ b/rust-bins/Cargo.toml
@@ -41,7 +41,7 @@ anyhow = "1.0"
 
 [dependencies.keygen_bls]
 path = "../rust-src/keygen_bls"
-version = "0"
+version = "2.0.0"
 
 [dependencies.crypto_common]
 path = "../rust-src/crypto_common"

--- a/rust-bins/docs/keygen.md
+++ b/rust-bins/docs/keygen.md
@@ -30,6 +30,7 @@ Generate keys for an anonymity revoker. The following options are supported
 - `--no-confirmation` if set, do not ask user to re-enter generated recovery phrase.
 - `--no-verification` if set, do not verify the validity of the input. Otherwise the input is verified to be a valid BIP39 sentence.
 - `--only-system-randomness` if set, do not ask the user for a list of words to add to randomness, instead only relying on system randomness.
+- `--v1` if set, use the deprecated version of the BLS keygen when generating `ar_secret_key`.
 
 No arguments are required. If the arguments `ar-identity`, `description`,
 `global`, `name`, `url`, `out`, or `out-pub` are not supplied they are queried
@@ -47,6 +48,7 @@ Generate keys for the identity provider. The following options are supported
 - `--out`, a filename where the private keys will be emitted
 - `--out-pub`, a filename where the public data will be emitted. This is the data that must go to the chain.
 - `--bound`, upper bound on the number of messages signed by the identity provider's key. See the Pointcheval-Sanders signatures scheme for details of what this means. This defaults to 30 which is sufficient for the current numbers.
+- `--v1` if set, use the deprecated version of the BLS keygen when generating `ip_secret_key`.
 
 ## gen-rand
 

--- a/rust-bins/docs/keygen.md
+++ b/rust-bins/docs/keygen.md
@@ -30,7 +30,7 @@ Generate keys for an anonymity revoker. The following options are supported
 - `--no-confirmation` if set, do not ask user to re-enter generated recovery phrase.
 - `--no-verification` if set, do not verify the validity of the input. Otherwise the input is verified to be a valid BIP39 sentence.
 - `--only-system-randomness` if set, do not ask the user for a list of words to add to randomness, instead only relying on system randomness.
-- `--v1` if set, use the deprecated version of the BLS keygen when generating `ar_secret_key`.
+- `--v1` if set, use the deprecated version of the BLS keygen when generating `ar_secret_key`. If keys were generated with version 1, this flag must be used during recovery.
 
 No arguments are required. If the arguments `ar-identity`, `description`,
 `global`, `name`, `url`, `out`, or `out-pub` are not supplied they are queried
@@ -48,7 +48,7 @@ Generate keys for the identity provider. The following options are supported
 - `--out`, a filename where the private keys will be emitted
 - `--out-pub`, a filename where the public data will be emitted. This is the data that must go to the chain.
 - `--bound`, upper bound on the number of messages signed by the identity provider's key. See the Pointcheval-Sanders signatures scheme for details of what this means. This defaults to 30 which is sufficient for the current numbers.
-- `--v1` if set, use the deprecated version of the BLS keygen when generating `ip_secret_key`.
+- `--v1` if set, use the deprecated version of the BLS keygen when generating `ip_secret_key`. If keys were generated with version 1, this flag must be used during recovery.
 
 ## gen-rand
 

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -60,7 +60,11 @@ struct KeygenIp {
     out:         PathBuf,
     #[structopt(long = "out-pub", help = "File to output the public keys to.")]
     out_pub:     PathBuf,
-    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, this flag must be used during recovery.")]
+    #[structopt(
+        long = "v1",
+        help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, \
+                this flag must be used during recovery."
+    )]
     v1:          bool,
 }
 
@@ -112,7 +116,11 @@ struct KeygenAr {
                 randomness."
     )]
     only_system_randomness: bool,
-    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, this flag must be used during recovery.")]
+    #[structopt(
+        long = "v1",
+        help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, \
+                this flag must be used during recovery."
+    )]
     v1:                     bool,
 }
 

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -12,7 +12,7 @@ use elgamal::{PublicKey, SecretKey};
 use hkdf::HkdfExtract;
 use hmac::{Hmac, Mac, NewMac};
 use id::types::*;
-use keygen_bls::keygen_bls;
+use keygen_bls::{keygen_bls, keygen_bls_deprecated};
 use pairing::bls12_381::{Bls12, Fr, G1, G2};
 use rand::Rng;
 use sha2::{Digest, Sha256, Sha512};
@@ -60,6 +60,8 @@ struct KeygenIp {
     out:         PathBuf,
     #[structopt(long = "out-pub", help = "File to output the public keys to.")]
     out_pub:     PathBuf,
+    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen.")]
+    v1:          bool,
 }
 
 #[derive(StructOpt)]
@@ -110,6 +112,8 @@ struct KeygenAr {
                 randomness."
     )]
     only_system_randomness: bool,
+    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen.")]
+    v1:                     bool,
 }
 
 #[derive(StructOpt)]
@@ -145,25 +149,25 @@ struct GenRand {
     about = "Tool for generating keys",
     name = "keygen",
     author = "Concordium",
-    version = "1.0"
+    version = "2.0"
 )]
 enum KeygenTool {
     #[structopt(
         name = "keygen-ip",
         about = "Generate identity provider keys.",
-        version = "1.0"
+        version = "2.0"
     )]
     KeygenIp(KeygenIp),
     #[structopt(
         name = "keygen-ar",
         about = "Generate anonymity revoker keys.",
-        version = "1.0"
+        version = "2.0"
     )]
     KeygenAr(KeygenAr),
     #[structopt(
         name = "gen-rand",
         about = "Generate randomness file.",
-        version = "1.0"
+        version = "2.0"
     )]
     GenRand(GenRand),
 }
@@ -329,7 +333,12 @@ fn handle_generate_ar_keys(kgar: KeygenAr) -> Result<(), String> {
     };
     let ar_base = global_ctx.on_chain_commitment_key.g;
     let key_info = b"elgamal_keys".as_ref();
-    let scalar = succeed_or_die!(keygen_bls(&random_bytes, &key_info), e => "Could not generate key because {}");
+    let scalar = if kgar.v1 {
+        println!("Using deprecated BLS keygen.");
+        succeed_or_die!(keygen_bls_deprecated(&random_bytes, &key_info), e => "Could not generate key because {}")
+    } else {
+        succeed_or_die!(keygen_bls(&random_bytes, &key_info), e => "Could not generate key because {}")
+    };
     let ar_secret_key = SecretKey {
         generator: ar_base,
         scalar,
@@ -418,7 +427,10 @@ fn handle_generate_ip_keys(kgip: KeygenIp) -> Result<(), String> {
         return Err("Provided randomness should be of size at least 64 bytes".to_string());
     }
     // let seed_32 = Sha256::digest(&bytes_from_file);
-    let ip_secret_key = succeed_or_die!(generate_ps_sk(kgip.bound, &bytes_from_file), e => "Could not generate signature key for the Pointcheval-Sanders Signature Scheme because {}");
+    let ip_secret_key = succeed_or_die!(generate_ps_sk(kgip.bound, &bytes_from_file, kgip.v1), e => "Could not generate signature key for the Pointcheval-Sanders Signature Scheme because {}");
+    if kgip.v1 {
+        println!("Using deprecated BLS keygen.");
+    }
     let ip_public_key = ps_sig::PublicKey::from(&ip_secret_key);
     let ed_sk = succeed_or_die!(generate_ed_sk(&bytes_from_file), e => "Could not generate signature key for EdDSA because {}");
     let ed_pk = ed25519_dalek::PublicKey::from(&ed_sk);
@@ -449,7 +461,7 @@ fn handle_generate_ip_keys(kgip: KeygenIp) -> Result<(), String> {
         Ok(_) => println!("Wrote private to {}.", kgip.out.display()),
         Err(e) => {
             return Err(format!(
-                "Could not JSON private keys write to file because {}",
+                "Could not JSON write private keys to file because {}",
                 e
             ));
         }
@@ -513,13 +525,25 @@ fn handle_generate_randomness(grand: GenRand) -> Result<(), String> {
 /// It generates multiple scalars by calling keygen_bls with different values
 /// `key_info`. The integer n determines the number of scalars generated and
 /// must be less than 256.
-pub fn generate_ps_sk(n: u32, ikm: &[u8]) -> Result<ps_sig::SecretKey<Bls12>, hkdf::InvalidLength> {
+pub fn generate_ps_sk(
+    n: u32,
+    ikm: &[u8],
+    legacy: bool,
+) -> Result<ps_sig::SecretKey<Bls12>, hkdf::InvalidLength> {
     let mut ys: Vec<Fr> = Vec::with_capacity(n as usize);
-    for i in 0..n {
-        let key = keygen_bls(&ikm, &i.to_be_bytes()[..])?;
-        ys.push(key);
-    }
-    let key = keygen_bls(&ikm, &[])?;
+    let key = if legacy {
+        for i in 0..n {
+            let key = keygen_bls_deprecated(&ikm, &i.to_be_bytes()[..])?;
+            ys.push(key);
+        }
+        keygen_bls_deprecated(&ikm, &[])?
+    } else {
+        for i in 0..n {
+            let key = keygen_bls(&ikm, &i.to_be_bytes()[..])?;
+            ys.push(key);
+        }
+        keygen_bls(&ikm, &[])?
+    };
     Ok(ps_sig::SecretKey {
         g: G1::one_point(),
         g_tilda: G2::one_point(),

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -60,7 +60,7 @@ struct KeygenIp {
     out:         PathBuf,
     #[structopt(long = "out-pub", help = "File to output the public keys to.")]
     out_pub:     PathBuf,
-    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen.")]
+    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, this flag must be used during recovery.")]
     v1:          bool,
 }
 
@@ -112,7 +112,7 @@ struct KeygenAr {
                 randomness."
     )]
     only_system_randomness: bool,
-    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen.")]
+    #[structopt(long = "v1", help = "Use deprecated version 1 of BLS keygen. If keys were generated with version 1, this flag must be used during recovery.")]
     v1:                     bool,
 }
 

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -901,10 +901,11 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
 name = "keygen_bls"
-version = "0.1.0"
+version = "2.0.0"
 dependencies = [
  "curve_arithmetic",
  "ff",
+ "hex",
  "hkdf",
  "pairing",
  "sha2 0.9.5",

--- a/rust-src/keygen_bls/CHANGELOG.md
+++ b/rust-src/keygen_bls/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+## 2.0.0
+  - Fix bug in keygen, where wrong endianness was used according to the standard (cf. https://datatracker.ietf.org/doc/html/draft-irtf-cfrg-bls-signature-04#section-2.3). 
+  - Keep old keygen for backwards compatibility.
+  - Add test vectors

--- a/rust-src/keygen_bls/Cargo.toml
+++ b/rust-src/keygen_bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "keygen_bls"
-version = "0.1.0"
+version = "2.0.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE"
@@ -10,6 +10,7 @@ pairing = "0.15"
 sha2 = "0.9"
 hkdf = "0.11.0"
 ff = "0.5"
+hex = "0.4"
 
 [dependencies.curve_arithmetic]
 path = "../curve_arithmetic"

--- a/rust-src/keygen_bls/src/lib.rs
+++ b/rust-src/keygen_bls/src/lib.rs
@@ -10,8 +10,58 @@ use sha2::{Digest, Sha256};
 /// It computes a random scalar in Fr given a seed (the argument `ikm`).
 ///
 /// This is a building block for deterministic key generation for identity
-/// provider and anonymity revoker keys.
+/// provider, anonymity revoker keys and PRF keys.
 pub fn keygen_bls(ikm: &[u8], key_info: &[u8]) -> Result<Fr, hkdf::InvalidLength> {
+    let mut ikm = ikm.to_vec();
+    ikm.push(0);
+    let l = 48; // = 48 for G1; r is
+                // 52435875175126190479447740508185965837690552500527637822603658699938581184513
+    let mut l_bytes = key_info.to_vec();
+    l_bytes.push(0);
+    l_bytes.push(l);
+    let salt = b"BLS-SIG-KEYGEN-SALT-";
+    let mut sk = Fr::zero();
+    // shift with
+    // 452312848583266388373324160190187140051835877600158453279131187530910662656 =
+    // 2^248 = 2^(31*8)
+    let shift = Fr::from_repr(FrRepr([0, 0, 0, 72057594037927936])).unwrap();
+    let mut salt = Sha256::digest(&salt[..]);
+    while sk.is_zero() {
+        let (_, h) = Hkdf::<Sha256>::extract(Some(&salt), &ikm);
+        let mut okm = vec![0u8; l as usize];
+        h.expand(&l_bytes, &mut okm)?;
+        // Reverse the vector since `scalar_from_bytes` expects the bytes in
+        // little-endian
+        okm.reverse();
+        // Following the standard, we have to
+        // interpret the 48 bytes in `okm` as an integer and then reduce modulo r.
+        // Since 2^(31*8) < r < 2^(32*8), we use `scalar_from_bytes` twice by
+        // calculating (in Fr) y1 + shift*y2, where
+        // y1 = scalar_from_bytes(first 31 bytes of okm), and
+        // y2 = scalar_from_bytes(last 17 bytes of okm)
+        let mut y1_vec = [0; 32];
+        let mut y2_vec = [0; 32];
+        let slice_y1 = &mut y1_vec[0..31];
+        slice_y1.clone_from_slice(&okm[0..31]);
+        let slice_y2 = &mut y2_vec[0..okm.len() - slice_y1.len()];
+        slice_y2.clone_from_slice(&okm[31..]);
+        let y1 = G1::scalar_from_bytes(&y1_vec);
+        let mut y2 = G1::scalar_from_bytes(&y2_vec);
+        y2.mul_assign(&shift);
+        sk = y1;
+        sk.add_assign(&y2);
+        salt = Sha256::digest(&salt);
+    }
+    Ok(sk)
+}
+
+/// This function is a deprecated version of the above `keygen_bls`.
+/// The difference is that it uses little-endian instead of big-endian, both as
+/// input to the `expand` function and when interpreting the bytes in `okm` as
+/// an integer modulo r. It therefore does not follow the standard (cf. <https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.3>),
+/// but is still secure.
+/// This function is needed for backwards compatibility.
+pub fn keygen_bls_deprecated(ikm: &[u8], key_info: &[u8]) -> Result<Fr, hkdf::InvalidLength> {
     let mut ikm = ikm.to_vec();
     ikm.push(0);
     let l = 48; // = 48 for G1; r is
@@ -44,4 +94,102 @@ pub fn keygen_bls(ikm: &[u8], key_info: &[u8]) -> Result<Fr, hkdf::InvalidLength
         salt = Sha256::digest(&salt);
     }
     Ok(sk)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_keygen() {
+        let inputs: [&str; 10] = [
+            "09e74ad3ead373439388bf7cfb52b151c450632e67f3c84e6ed762bc0928d5eb",
+            "9dcce7d6b6a70ddb382d2c212273ad9b99d8ea206353313beabc14b7e5833a0f",
+            "8a430bd1343b5cb1686961d7959095214952767f80bb681e465aebf467ca05c0",
+            "c940716ce93f72b2d4f9ff792193ee541e3748ff5b13f1bb01d5d091af4e2635",
+            "bc14d035741cd9225795ad1e7070a1b488deb0cc19daedcb47f12408cbfe71cc",
+            "00bbfd863df0068b841c12f6e6a8d6c571c80eaf37fae324c669d214f90a762c",
+            "30c0a09b5175febb462b64efe28475fa434b0ccfb05bc77d16fd2f1ba13bc05c",
+            "34a3f5d8b0cfaa9d235c8c1ecfbf10223259d45be5f4d30b33c697e19ac9e525",
+            "d57e90d96aab5616c266568ad4659dfe985f8baf24042e5e28e901801944f49d",
+            "725150bb38d49fc2a7ad8a8cba1f0dc32c3a468739e88b9aa62c450ce3ce1f32",
+        ];
+
+        // The expected outputs have been derived using https://github.com/paulmillr/bls12-381-keygen
+        // and double checked with https://github.com/ChainSafe/bls-hd-key
+        let expected_outputs: [[u64; 4]; 10] = [
+            [
+                17351079049985859042,
+                9243168354177730561,
+                1354598858808160974,
+                6326193586470323551,
+            ], // 0x57cb278c9deb055f12cc807c3068f2ce804654a54de54801f0cb6a774c211de2
+            [
+                5120851860807520862,
+                7537404979026392860,
+                17958325247724939891,
+                2827706577331116975,
+            ], // 0x273e082676db5baff938c9aa5f92ea73689a3de4bf20f71c4710eba2ced4925e
+            [
+                15727871129641048774,
+                11988799985501999947,
+                1388620089874179915,
+                8145693946474164108,
+            ], // 0x710b517c90a46f8c13455e9d50ebe74ba660c611430e134bda449f766b605ac6
+            [
+                3932271522535121134,
+                8872934998377405368,
+                7259163645480412069,
+                3750812284986048912,
+            ], // 0x340d8fe689c3c19064bdbadff74a23a57b22ff5ec56a9bb836923c1d9d1720ee
+            [
+                16107158621426899190,
+                10500072591120856542,
+                15181573451644741747,
+                3125850084510497659,
+            ], // 0x2b614017245f7b7bd2afc89e6cc9287391b7c063cd92f5dedf881f6d430558f6
+            [
+                13771624569621348445,
+                3146403120475439736,
+                18069601902237922649,
+                6758674237477415953,
+            ], // 0x5dcba268f56cec11fac41f31779d35592baa44f7bc1e8278bf1ea394b452805d
+            [
+                4833464224170637233,
+                15025051245287273709,
+                1074686477808441037,
+                3419044651413101239,
+            ], // 0x2f72e2fedead5ab70eea0da85ab016cdd083b4805f6374ed4313ea1a643ff7b1
+            [
+                3385693996904717713,
+                6453425908238454111,
+                11250048985110811077,
+                3660893330520285257,
+            ], // 0x32ce1b167e4220499c2033f2574611c5598f2cabfcdb0d5f2efc66c083ad9d91
+            [
+                13103272484668436394,
+                12668243431219103286,
+                12426998760715496251,
+                6676359852315787176,
+            ], // 0x5ca731e9adf63fa8ac75918824aaab3bafcea4480dfd8636b5d82ce693cfefaa
+            [
+                12161214505729619043,
+                2991033334211776658,
+                18345117405735658320,
+                4138888141383584617,
+            ], // 0x397048d5f83ecb69fe96f3157bb5a350298248f8650b9092a8c55028fb577463
+        ];
+
+        for i in 0..10 {
+            if let Ok(seed) = hex::decode(inputs[i]) {
+                if let Ok(sk) = keygen_bls(&seed, b"") {
+                    assert_eq!(sk.into_repr(), FrRepr(expected_outputs[i]))
+                } else {
+                    assert!(false);
+                }
+            } else {
+                assert!(false);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Purpose

To fix the BLS keygen. Closes https://github.com/Concordium/concordium-base/issues/90. 

## Changes

* The function `keygen_bls` has been corrected according to the standard (cf. https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.3) so that it now uses the correct endianness. 
* Test vectors have been added.
* A changelog has been added.
* Version increased to 2.0.0. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

