### PR TITLE
Improve the JSON instances for attribute tags so they provide information in case of unrecognized tag.

### DIFF
--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -418,7 +418,11 @@ impl<'a> TryFrom<AttributeStringTag> for AttributeTag {
         if let Some(idx) = ATTRIBUTE_NAMES.iter().position(|&x| x == v.0) {
             Ok(AttributeTag(idx as u8))
         } else {
-            Err(anyhow!("{} tag unknown.", v.0))
+            match v.0.strip_prefix("UNNAMED#").and_then(|x| x.parse().ok()) {
+                Some(num) if num < 254 => Ok(AttributeTag(num)), // 254 is the capacity of the
+                // BLS curve field
+                _ => Err(anyhow!("Unrecognized attribute tag.")),
+            }
         }
     }
 }
@@ -429,7 +433,7 @@ impl<'a> std::convert::From<AttributeTag> for AttributeStringTag {
         if v_usize < ATTRIBUTE_NAMES.len() {
             AttributeStringTag(ATTRIBUTE_NAMES[v_usize].to_owned())
         } else {
-            AttributeStringTag("UNKNOWN".to_owned())
+            AttributeStringTag(format!("UNNAMED#{}", v))
         }
     }
 }


### PR DESCRIPTION
## Purpose

We might have additional attributes in the immediate future, this changes the JSON instance for attribute tags so that they provide the numeric value instead of mapping all of them to unnamed.

## Changes

Change the to/from json instances for AttributeTag to not lose information. This does not affect any current uses since all attribute tags are currently in the list of known attributes.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.