### PR TITLE
Make separate binaries for user and identity provider.

### DIFF
--- a/rust-bins/docs/identity-provider-cli.md
+++ b/rust-bins/docs/identity-provider-cli.md
@@ -4,10 +4,8 @@ This page describes how to use the `identity_provider_cli` tool to sign identity
 The identity provider uses the binary `identity_provider_cli` to do the following steps:
 1. Await request from user
 2. When getting a request, say, `public.json` from the user, do
-
-```bash
-./identity_provider_cli ip-sign-pio --expiry 500 --pio public.json --ip-data identity_provider.json --out identity_object.json --initial-cdi-out initial_credential_creation.json --ar-record ar_record.json
-```
-
-This will read the identity private keys from `identity_provider.json` and use them to produce the identity object together with the initial account message. They will be written to `identity_object.json` and `initial_credential_creation.json`, respectively. An anonymity revocation record will be written to `ar_record.json`.
+    ```bash
+    ./identity_provider_cli ip-sign-pio --expiry 500 --pio public.json --ip-data identity_provider.json --out identity_object.json --initial-cdi-out initial_credential_creation.json --ar-record ar_record.json
+    ```
+    This will read the identity private keys from `identity_provider.json` and use them to produce the identity object together with the initial account message. They will be written to `identity_object.json` and `initial_credential_creation.json`, respectively. An anonymity revocation record will be written to `ar_record.json`.
 3. Give back `identity_object.json` to the user, send `initial_credential_creation.json` to chain to create the initial account and store `ar_record.json`.

--- a/rust-bins/docs/identity-provider-cli.md
+++ b/rust-bins/docs/identity-provider-cli.md
@@ -1,11 +1,58 @@
-This page describes how to use the `identity_provider_cli` tool to sign identity objects, create initial account messages and anonymity revocation records.
+This page describes how to use the `identity_provider_cli` tool that can be used by the identity provider to manually sign identity objects and create initial accounts.
 
-# Steps to sign pre-identity object and produce identity object, initial account creation message and anonymity revocation record
-The identity provider uses the binary `identity_provider_cli` to do the following steps:
-1. Await request from user
-2. When getting a request, say, `public.json` from the user, do
-    ```bash
-    ./identity_provider_cli ip-sign-pio --expiry 500 --pio public.json --ip-data identity_provider.json --out identity_object.json --initial-cdi-out initial_credential_creation.json --ar-record ar_record.json
-    ```
-    This will read the identity private keys from `identity_provider.json` and use them to produce the identity object together with the initial account message. They will be written to `identity_object.json` and `initial_credential_creation.json`, respectively. An anonymity revocation record will be written to `ar_record.json`.
-3. Give back `identity_object.json` to the user, send `initial_credential_creation.json` to chain to create the initial account and store `ar_record.json`.
+The tool is partially interactive.
+
+# Prerequisites
+
+- The `identity_provider_cli` tool.
+- A file with cryptographic parameters for the chain. We'll refer to this file as `cryptographic-parameters.json` below.
+- A file with the list of anonymity revokers supported by the identity provider. We refer to this file as `ars.json` below.
+- A file with identity provider private keys. We refer to this file as `ip-data.json` below.
+- An identity object request sent by the user. We refer to this file as `request.json` below.
+
+# Output files
+
+Upon success the tool will generate three files.
+
+- The identity object which must be sent back to the user. We refer to this as `id-object.json` below.
+- The initial account creation transaction. We refer to this as `initial-account.json` below. This must be submitted to the chain, for example via the wallet proxy.
+- The anonymity revocation record. We refer to this as `ar-record.json` below. This must be stored by the identity provider.
+
+# Tool invocation
+
+```console
+identity_provider_cli --cryptographic-parameters cryptographic-parameters.json \
+                      --ars ars.json \
+                      --ip-data ip-data.json \
+                      --request request.json \
+                      --id-out id-object.json  \
+                      --initial-account-out initial-account.json\
+                      --ar-record-out ar-record.json
+```
+
+The tool will first verify the cryptographic validity of the request and then ask for the following data
+- expiry year and month of the identity object.
+- an LEI of the entity for which this identity object is being created. This is optional, and if left empty will not be used.
+
+Upon success the tool will display output similar to the following.
+```
+Successfully checked pre-identity data.
+Wrote signed identity object to file id-object.json. Return it to the user.
+Wrote initial account transaction to file initial-account.json. Submit it before 2021-11-21 21:56:59 +01:00.
+Wrote anonymity revocation record to file ar-record.json. Store it.
+```
+
+The initial account transaction must be submitted to the chain before the identity object is returned to the user.
+To submit it to the wallet proxy curl may be used via the following invocation on the **testnet**. On **mainnet** replace
+`https://wallet-proxy.testnet.concordium.com/v0/submitCredential` with `https://wallet-proxy.mainnet.concordium.software/v0/submitCredential`.
+
+```console
+curl -X PUT https://wallet-proxy.testnet.concordium.com/v0/submitCredential -d @initial-account.json -H 'Content-Type: application/json'
+```
+If successful this will print the submission id of the account creation transaction.
+This can be queried either via curl as
+```console
+curl https://wallet-proxy.testnet.concordium.com/v0/submissionStatus/$submissionId
+```
+or on the network dashboard
+`https://dashboard.testnet.concordium.com/lookup/$submissionId`

--- a/rust-bins/docs/identity-provider-cli.md
+++ b/rust-bins/docs/identity-provider-cli.md
@@ -1,0 +1,13 @@
+This page describes how to use the `identity_provider_cli` tool to sign identity objects, create initial account messages and anonymity revocation records.
+
+# Steps to sign pre-identity object and produce identity object, initial account creation message and anonymity revocation record
+The identity provider uses the binary `identity_provider_cli` to do the following steps:
+1. Await request from user
+2. When getting a request, say, `public.json` from the user, do
+
+```bash
+./identity_provider_cli ip-sign-pio --expiry 500 --pio public.json --ip-data identity_provider.json --out identity_object.json --initial-cdi-out initial_credential_creation.json --ar-record ar_record.json
+```
+
+This will read the identity private keys from `identity_provider.json` and use them to produce the identity object together with the initial account message. They will be written to `identity_object.json` and `initial_credential_creation.json`, respectively. An anonymity revocation record will be written to `ar_record.json`.
+3. Give back `identity_object.json` to the user, send `initial_credential_creation.json` to chain to create the initial account and store `ar_record.json`.

--- a/rust-bins/docs/user-cli.md
+++ b/rust-bins/docs/user-cli.md
@@ -3,17 +3,13 @@ This page describes how to use the `user_cli` tool to create an identity and an 
 # Steps to obtain an enterprise identity and account
 The entity uses the binary `user_cli` to do the following steps:
 1. Create secret account holder information and generate the data to be sent to the identity provider using the command
-
-```bash
-./user_cli start-ip --private private.json --public public.json --ip-info identity_provider.json --ars anonymity_revokers.json --initial-keys initial_account_keys.json
-```
-
-This will ask the entity for a password to encrypt the account holder information that will be written to `private.json`. In case no password is provided, the data will not be encrypted. Public information needed by the identity provider will be written to `public.json`. The private keys of the initial account will be written to `initial_account_keys.json`.
+    ```bash
+    ./user_cli start-ip --private private.json --public public.json --ip-info identity_provider.json --ars anonymity_revokers.json --initial-keys initial_account_keys.json
+    ```
+    This will ask the entity for a password to encrypt the account holder information that will be written to `private.json`. In case no password is provided, the data will not be encrypted. Public information needed by the identity provider will be written to `public.json`. The private keys of the initial account will be written to `initial_account_keys.json`.
 2. Prove real-life identity to the identity provider and give them public.json. Await identity object from the identity provider.
 3. Create a credential
-
-```bash
-./user_cli create-credential --expiry 500 --id-object id_object.json --ip-info identity_provider.json --out create_credential.json --private private.json --keys-out account_keys.json
-```
-
-This will decrypt the `private.json` if it was encrypted in step 1 and encrypt the account keys that will be written to `account_keys.json`. The transaction payload for deploying the new account will be written to `create_credential.json`. The expiry is given in seconds from the current time.
+    ```bash
+    ./user_cli create-credential --expiry 500 --id-object id_object.json --ip-info identity_provider.json --out create_credential.json --private private.json --keys-out account_keys.json
+    ```
+    This will decrypt the `private.json` if it was encrypted in step 1 and encrypt the account keys that will be written to `account_keys.json`. The transaction payload for deploying the new account will be written to `create_credential.json`. The expiry is given in seconds from the current time.

--- a/rust-bins/docs/user-cli.md
+++ b/rust-bins/docs/user-cli.md
@@ -1,0 +1,19 @@
+This page describes how to use the `user_cli` tool to create an identity and an account interacticting with an identity provider using the tool `identity_provider_cli`.
+
+# Steps to obtain an enterprise identity and account
+The entity uses the binary `user_cli` to do the following steps:
+1. Create secret account holder information and generate the data to be sent to the identity provider using the command
+
+```bash
+./user_cli start-ip --private private.json --public public.json --ip-info identity_provider.json --ars anonymity_revokers.json --initial-keys initial_account_keys.json
+```
+
+This will ask the entity for a password to encrypt the account holder information that will be written to `private.json`. In case no password is provided, the data will not be encrypted. Public information needed by the identity provider will be written to `public.json`. The private keys of the initial account will be written to `initial_account_keys.json`.
+2. Prove real-life identity to the identity provider and give them public.json. Await identity object from the identity provider.
+3. Create a credential
+
+```bash
+./user_cli create-credential --expiry 500 --id-object id_object.json --ip-info identity_provider.json --out create_credential.json --private private.json --keys-out account_keys.json
+```
+
+This will decrypt the `private.json` if it was encrypted in step 1 and encrypt the account keys that will be written to `account_keys.json`. The transaction payload for deploying the new account will be written to `create_credential.json`. The expiry is given in seconds from the current time.

--- a/rust-bins/docs/user-cli.md
+++ b/rust-bins/docs/user-cli.md
@@ -29,7 +29,7 @@ This will ask for some additional input and output the following files
 
 Assuming everything is in order the identity provider should eventually return the identity object. We refer to it as `id-object.json` in the command below.
 
-# Create accounts from an identity object.
+# Create accounts from an identity object
 
 After obtaining the identity object from the identity object from the identity provider you can create additional accounts on the chain.
 Note that at this point the initial account already exists on the chain. Accounts are created by deploying credentials.
@@ -43,7 +43,7 @@ user_cli create-credential --id-use-data id-use-data.json \
                            --credential-out credential.json
 ```
 this will output two files
-- `account-keys.json` which contains account keys of the account that will be created by the credential. DO NOT LOSE THIS FILE. It canno be recovered.
+- `account-keys.json` which contains account keys of the account that will be created by the credential. DO NOT LOSE THIS FILE. It cannot be recovered.
 - `credential.json` which contains the payload of the account creation transaction. **This must be sent to the chain, otherwise the account will not be created.**
 By default this must be sent to the chain within 15min. A larger or shorter message expiry may be set with `--message-expiry` flag to the command.
 Do note that an expiry longer than 2 hours is not acceptable.

--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -777,10 +777,10 @@ fn handle_create_credential(cc: CreateCredential) {
     // which we need to generate CDI.
     // This file should also contain the public keys of the identity provider who
     // signed the object.
-    let id_use_data: IdObjectUseData<Bls12, ExampleCurve> = match read_id_use_data(&cc.private) {
+    let id_use_data: IdObjectUseData<Bls12, ExampleCurve> = match read_id_use_data(cc.private) {
         Ok(v) => v,
         Err(x) => {
-            eprintln!("Could not read CHI object because {}", x);
+            eprintln!("Could not read CHI object because: {}", x);
             return;
         }
     };
@@ -876,14 +876,17 @@ fn handle_create_credential(cc: CreateCredential) {
     };
 
     if let Some(addr) = cc.account {
-        println!("Generated additional keys for the account.");
+        println!(
+            "Generated additional keys for the account to be encrypted and written to file {}.",
+            cc.keys_out.to_string_lossy()
+        );
         let js = json!({
             "address": addr,
             "accountKeys": AccountKeys::from((CredentialIndex{index: cc.key_index.unwrap()}, acc_data)),
             "credentials": versioned_credentials,
             "commitmentsRandomness": randomness_map,
         });
-        write_json_to_file(&cc.keys_out, &js).ok();
+        output_possibly_encrypted(&cc.keys_out, &js).ok();
     } else {
         let account_data_json = json!({
             "address": address,
@@ -895,10 +898,11 @@ fn handle_create_credential(cc: CreateCredential) {
             "aci": id_use_data.aci,
         });
         println!(
-            "Generated fresh verification and signature key of the account to file {}.",
+            "Generated fresh verification and signature key of the account to be encrypted and \
+             written to file {}.",
             cc.keys_out.to_string_lossy()
         );
-        write_json_to_file(&cc.keys_out, &account_data_json).ok();
+        output_possibly_encrypted(&cc.keys_out, &account_data_json).ok();
     }
 
     // Double check that the generated CDI is going to be successfully validated.
@@ -942,7 +946,7 @@ fn handle_create_chi(cc: CreateChi) {
         id_cred: IdCredentials::generate(&mut csprng),
     };
     if let Some(filepath) = cc.out {
-        match write_json_to_file(filepath, &ah_info) {
+        match output_possibly_encrypted(&filepath, &ah_info) {
             Ok(()) => println!("Wrote CHI to file."),
             Err(_) => {
                 eprintln!("Could not write to file. The generated information is");
@@ -968,14 +972,14 @@ fn handle_act_as_ip(aai: IpSignPio) {
         }
     };
     let (ip_info, ip_sec_key, ip_cdi_secret_key) =
-        match read_json_from_file::<_, IpData<Bls12>>(&aai.ip_data) {
+        match decrypt_input::<_, IpData<Bls12>>(&aai.ip_data) {
             Ok(ip_data) => (
                 ip_data.public_ip_info,
                 ip_data.ip_secret_key,
                 ip_data.ip_cdi_secret_key,
             ),
             Err(x) => {
-                eprintln!("Could not read identity issuer information because {}", x);
+                eprintln!("Could not read identity issuer information because: {}", x);
                 return;
             }
         };
@@ -985,7 +989,7 @@ fn handle_act_as_ip(aai: IpSignPio) {
         None => match read_validto() {
             Ok(ym) => ym,
             Err(e) => {
-                eprintln!("Could not read credential expiry because {}", e);
+                eprintln!("Could not read credential expiry because: {}", e);
                 return;
             }
         },
@@ -1126,11 +1130,12 @@ fn handle_act_as_ip(aai: IpSignPio) {
 
 fn handle_start_ip(sip: StartIp) {
     let chi = {
-        if let Ok(chi) = read_json_from_file(&sip.chi) {
-            chi
-        } else {
-            eprintln!("Could not read credential holder information.");
-            return;
+        match decrypt_input(sip.chi) {
+            Ok(chi) => chi,
+            Err(e) => {
+                eprintln!("Could not read credential holder information: {}", e);
+                return;
+            }
         }
     };
     let mut csprng = thread_rng();
@@ -1294,7 +1299,7 @@ fn handle_start_ip(sip: StartIp) {
     let id_use_data = IdObjectUseData { aci, randomness };
     let ver_id_use_data = Versioned::new(VERSION_0, id_use_data);
     if let Some(aci_out_path) = sip.private {
-        if write_json_to_file(aci_out_path, &ver_id_use_data).is_ok() {
+        if output_possibly_encrypted(&aci_out_path, &ver_id_use_data).is_ok() {
             println!("Wrote ACI and randomness to file.");
         } else {
             println!("Could not write ACI data to file. Outputting to standard output.");

--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -947,7 +947,7 @@ fn handle_create_chi(cc: CreateChi) {
     };
     if let Some(filepath) = cc.out {
         match output_possibly_encrypted(&filepath, &ah_info) {
-            Ok(()) => println!("Wrote CHI to file."),
+            Ok(_) => println!("Wrote CHI to file."),
             Err(_) => {
                 eprintln!("Could not write to file. The generated information is");
                 output_json(&ah_info);

--- a/rust-bins/src/bin/identity_provider_cli.rs
+++ b/rust-bins/src/bin/identity_provider_cli.rs
@@ -95,6 +95,27 @@ fn main() -> anyhow::Result<()> {
         app.anonymity_revokers.display()
     ))?;
 
+    let confirm_ar = dialoguer::Confirm::new()
+        .default(false)
+        .show_default(true)
+        .wait_for_newline(true)
+        .with_prompt(format!(
+            "The user chose anonymity revocation threshold {} and anonymity revokers [{}]. Accept?",
+            pio.choice_ar_parameters.threshold,
+            pio.choice_ar_parameters
+                .ar_identities
+                .iter()
+                .map(|ar| ar.to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))
+        .interact()
+        .context("Did not get acceptable response.")?;
+    anyhow::ensure!(
+        confirm_ar,
+        "Anonymity revocation parameters are not acceptable."
+    );
+
     let created_at = YearMonth::now();
     let valid_to = match app.id_expiry {
         Some(exp) => exp,

--- a/rust-bins/src/bin/identity_provider_cli.rs
+++ b/rust-bins/src/bin/identity_provider_cli.rs
@@ -1,21 +1,28 @@
+use anyhow::Context;
+use chrono::TimeZone;
 use clap::AppSettings;
 use client_server_helpers::*;
 use crypto_common::{types::TransactionTime, *};
 use dialoguer::Input;
 use id::{
-    constants::{ArCurve, IpPairing},
+    constants::{ArCurve, AttributeKind, IpPairing},
     identity_provider::*,
     types::*,
 };
 use pairing::bls12_381::Bls12;
-use std::{collections::btree_map::BTreeMap, io, path::PathBuf};
+use std::{collections::btree_map::BTreeMap, path::PathBuf};
 use structopt::StructOpt;
 
 #[derive(StructOpt)]
-struct IpSignPio {
+#[structopt(
+    about = "Identity provider command line client",
+    author = "Concordium",
+    version = "1"
+)]
+struct IpClient {
     #[structopt(
-        long = "pio",
-        help = "File with input pre-identity object information."
+        long = "request",
+        help = "File with the identity object request received from the user."
     )]
     pio:                PathBuf,
     #[structopt(
@@ -24,145 +31,97 @@ struct IpSignPio {
                 and private)."
     )]
     ip_data:            PathBuf,
-    #[structopt(long = "out", help = "File to write the signed identity object to.")]
+    #[structopt(long = "id-out", help = "File to write the signed identity object to.")]
     out_file:           PathBuf,
     #[structopt(
-        long = "initial-cdi-out",
-        help = "File to output the JSON transaction payload to (regarding the initial account)."
+        long = "ar-record-out",
+        help = "File to write anonymity revocation record to."
+    )]
+    ar_record:          PathBuf,
+    #[structopt(
+        long = "initial-account-out",
+        help = "File to output the payload of the initial account creation transaction."
     )]
     out_icdi:           PathBuf,
     #[structopt(
-        long = "global",
-        help = "File with global parameters.",
-        default_value = "database/global.json"
+        long = "cryptographic-parameters",
+        help = "File with cryptographic parameters."
     )]
     global:             PathBuf,
-    #[structopt(
-        long = "ars",
-        help = "File with a list of anonymity revokers.",
-        default_value = "database/anonymity_revokers.json"
-    )]
+    #[structopt(long = "ars", help = "File with a list of anonymity revokers.")]
     anonymity_revokers: PathBuf,
     #[structopt(
-        long = "expiry",
-        help = "Expiry time of the initial credential message. In seconds from __now__.",
-        required = true
+        long = "message-expiry",
+        help = "Expiry time of the initial credential transaction. In seconds from __now__.",
+        default_value = "900"
     )]
     expiry:             u64,
     #[structopt(
         long = "id-object-expiry",
-        help = "Expiry time of the identity object message. As YYYYMM."
+        help = "Expiry time of the identity object. As YYYYMM."
     )]
     id_expiry:          Option<YearMonth>,
     #[structopt(
-        long = "ar-record",
-        help = "File to write anonymity revocation record to."
+        long = "max-accounts",
+        help = "Maximum number of accounts that can be created from the identity object.",
+        default_value = "25"
     )]
-    ar_record:          PathBuf,
+    max_accounts:       u8,
 }
 
-#[derive(StructOpt)]
-#[structopt(
-    about = "Identity provider client",
-    author = "Concordium",
-    version = "1"
-)]
-enum IpClient {
-    #[structopt(
-        name = "ip-sign-pio",
-        about = "Act as the identity provider, checking and signing a pre-identity object."
-    )]
-    IpSignPio(IpSignPio),
-}
-
-fn read_validto() -> io::Result<YearMonth> {
-    let input: String = Input::new()
-        .with_prompt("Enter valid to (YYYYMM)")
-        .interact()?;
-    match parse_yearmonth(&input) {
-        Some(ym) => Ok(ym),
-        None => panic!("Unable to parse YYYYMM"),
-    }
-}
-
-fn main() {
+fn main() -> anyhow::Result<()> {
     let app = IpClient::clap()
         .setting(AppSettings::ArgRequiredElseHelp)
         .global_setting(AppSettings::ColoredHelp);
     let matches = app.get_matches();
-    let client = IpClient::from_clap(&matches);
-    use IpClient::*;
-    match client {
-        IpSignPio(isp) => handle_act_as_ip(isp),
-    }
-}
+    let app = IpClient::from_clap(&matches);
 
-fn handle_act_as_ip(aai: IpSignPio) {
-    let pio = match read_pre_identity_object(&aai.pio) {
-        Ok(pio) => pio,
-        Err(e) => {
-            eprintln!("Could not read file because {}", e);
-            return;
-        }
-    };
-    let (ip_info, ip_sec_key, ip_cdi_secret_key) =
-        match decrypt_input::<_, IpData<Bls12>>(&aai.ip_data) {
-            Ok(ip_data) => (
-                ip_data.public_ip_info,
-                ip_data.ip_secret_key,
-                ip_data.ip_cdi_secret_key,
-            ),
-            Err(x) => {
-                eprintln!("Could not read identity issuer information because: {}", x);
-                return;
-            }
-        };
+    let pio = read_pre_identity_object(&app.pio).context(format!(
+        "Could not read the identity object request from file {}.",
+        app.pio.display()
+    ))?;
 
-    let valid_to = match aai.id_expiry {
-        Some(exp) => exp,
-        None => match read_validto() {
-            Ok(ym) => ym,
-            Err(e) => {
-                eprintln!("Could not read credential expiry because: {}", e);
-                return;
-            }
-        },
-    };
+    let ip_data = decrypt_input::<_, IpData<Bls12>>(&app.ip_data)
+        .context("Could not read identity provider keys.")?;
 
-    let global_ctx = {
-        if let Some(gc) = read_global_context(aai.global) {
-            gc
-        } else {
-            eprintln!("Cannot read global context information database. Terminating.");
-            return;
-        }
-    };
+    let global_ctx = read_global_context(&app.global).context(format!(
+        "Could not read cryptographic parameters file '{}'.",
+        app.global.display()
+    ))?;
 
     // all known anonymity revokers.
-    let ars = {
-        if let Ok(ars) = read_anonymity_revokers(aai.anonymity_revokers) {
-            ars.anonymity_revokers
-        } else {
-            eprintln!("Cannot read anonymity revokers from the database. Terminating.");
-            return;
-        }
-    };
+    let ars = read_anonymity_revokers(&app.anonymity_revokers).context(format!(
+        "Could not read anonymity revokers from the file {}.",
+        app.anonymity_revokers.display()
+    ))?;
 
     let created_at = YearMonth::now();
+    let valid_to = match app.id_expiry {
+        Some(exp) => exp,
+        None => {
+            let default_value = YearMonth {
+                year:  created_at.year + 5,
+                month: created_at.month,
+            };
+            let input: String = Input::new()
+                .with_prompt("Enter identity object expiry (YYYYMM)")
+                .default(default_value.to_string())
+                .interact()?;
+            input
+                .parse()
+                .context("Could not parse the valid to date.")?
+        }
+    };
 
     let alist = {
         let mut alist: BTreeMap<AttributeTag, ExampleAttribute> = BTreeMap::new();
-        match Input::new()
-            .with_prompt("Please provide LEI (Legal Entity Identifier)")
+        let s: String = Input::new()
+            .with_prompt("Please provide LEI (Legal Entity Identifier) (Leave empty for no LEI)")
+            .allow_empty(true)
             .interact()
-        {
-            Err(e) => {
-                eprintln!("Could not read input because: {}", e);
-                return;
-            }
-            Ok(s) => {
-                let _ = alist.insert(AttributeTag(13u8), s);
-            }
+            .context("Could not read attribute LEI")?;
+        if !s.is_empty() {
+            alist.insert(AttributeTag(13u8), AttributeKind(s));
         }
         alist
     };
@@ -170,21 +129,25 @@ fn handle_act_as_ip(aai: IpSignPio) {
     let attributes = AttributeList {
         valid_to,
         created_at,
-        max_accounts: 238,
+        max_accounts: app.max_accounts,
         alist,
         _phantom: Default::default(),
     };
-    let context = IpContext::new(&ip_info, &ars, &global_ctx);
+    let context = IpContext::new(
+        &ip_data.public_ip_info,
+        &ars.anonymity_revokers,
+        &global_ctx,
+    );
     let message_expiry = TransactionTime {
-        seconds: chrono::Utc::now().timestamp() as u64 + aai.expiry,
+        seconds: chrono::Utc::now().timestamp() as u64 + app.expiry,
     };
     let vf = verify_credentials(
         &pio,
         context,
         &attributes,
         message_expiry,
-        &ip_sec_key,
-        &ip_cdi_secret_key,
+        &ip_data.ip_secret_key,
+        &ip_data.ip_cdi_secret_key,
     );
     let ar_record = Versioned::new(VERSION_0, AnonymityRevocationRecord {
         id_cred_pub:  pio.pub_info_for_ip.id_cred_pub,
@@ -193,58 +156,55 @@ fn handle_act_as_ip(aai: IpSignPio) {
         threshold:    pio.choice_ar_parameters.threshold,
     });
 
-    match vf {
-        Ok((signature, icdi)) => {
-            let account_address = AccountAddress::new(&pio.pub_info_for_ip.reg_id);
-            let id_object = IdentityObject {
-                pre_identity_object: pio,
-                alist: attributes,
-                signature,
-            };
-            let ver_id_object = Versioned::new(VERSION_0, id_object);
-            println!("Successfully checked pre-identity data.");
-            match write_json_to_file(&aai.out_file, &ver_id_object) {
-                Ok(_) => println!(
-                    "Wrote signed identity object to file {:?}",
-                    &aai.out_file.to_string_lossy()
-                ),
-                Err(e) => eprintln!("Could not write Identity object to file because: {:?}", e),
-            }
+    let (signature, icdi) = vf.map_err(|e| {
+        anyhow::anyhow!(
+            "Could not verify the identity object request. The reason is {}.",
+            e
+        )
+    })?;
+    let account_address = AccountAddress::new(&pio.pub_info_for_ip.reg_id);
+    let id_object = IdentityObject {
+        pre_identity_object: pio,
+        alist: attributes,
+        signature,
+    };
+    let ver_id_object = Versioned::new(VERSION_0, id_object);
+    println!("Successfully checked pre-identity data.");
+    write_json_to_file(&app.out_file, &ver_id_object).context(format!(
+        "Could not write the identity object to file {}.",
+        app.out_file.display()
+    ))?;
+    println!(
+        "Wrote signed identity object to file {}. Return it to the user.",
+        &app.out_file.display()
+    );
 
-            let icdi_message = AccountCredentialMessage::<IpPairing, ArCurve, _> {
-                message_expiry,
-                credential: AccountCredential::Initial { icdi },
-            };
-            let versioned_icdi = Versioned::new(VERSION_0, icdi_message);
-            match write_json_to_file(&aai.out_icdi, &versioned_icdi) {
-                Ok(_) => println!(
-                    "Wrote transaction payload to JSON file {}.",
-                    &aai.out_icdi.to_string_lossy()
-                ),
-                Err(e) => {
-                    eprintln!(
-                        "Could not JSON write transaction payload to file because: {}",
-                        e
-                    );
-                }
-            }
-            let to_store = serde_json::json!({
-                "arRecord": ar_record,
-                "accountAddress": account_address
-            });
-            match write_json_to_file(&aai.ar_record, &to_store) {
-                Ok(_) => println!(
-                    "Wrote anonymity revocation record to JSON file {}.",
-                    &aai.ar_record.to_string_lossy()
-                ),
-                Err(e) => {
-                    eprintln!(
-                        "Could not JSON write anonymity revocation record to file because: {}",
-                        e
-                    );
-                }
-            }
-        }
-        Err(r) => eprintln!("Could not verify pre-identity object because {}", r),
-    }
+    let icdi_message = AccountCredentialMessage::<IpPairing, ArCurve, _> {
+        message_expiry,
+        credential: AccountCredential::Initial { icdi },
+    };
+    let versioned_icdi = Versioned::new(VERSION_0, icdi_message);
+    write_json_to_file(&app.out_icdi, &versioned_icdi).context(format!(
+        "Could not write the initial account transaction to file {}. Try again.",
+        app.out_icdi.display()
+    ))?;
+    println!(
+        "Wrote initial account transaction to file {}. Submit it before {}.",
+        &app.out_icdi.to_string_lossy(),
+        chrono::Local.timestamp(message_expiry.seconds as i64, 0),
+    );
+
+    let to_store = serde_json::json!({
+        "arRecord": ar_record,
+        "accountAddress": account_address
+    });
+    write_json_to_file(&app.ar_record, &to_store).context(format!(
+        "Could not write the anonymity revocation record to file {}.",
+        app.ar_record.display()
+    ))?;
+    println!(
+        "Wrote anonymity revocation record to file {}. Store it.",
+        &app.ar_record.display()
+    );
+    Ok(())
 }

--- a/rust-bins/src/bin/identity_provider_cli.rs
+++ b/rust-bins/src/bin/identity_provider_cli.rs
@@ -1,0 +1,219 @@
+use clap::AppSettings;
+use client_server_helpers::*;
+use crypto_common::{types::TransactionTime, *};
+use dialoguer::Input;
+use id::{
+    constants::{ArCurve, IpPairing},
+    identity_provider::*,
+    types::*,
+};
+use pairing::bls12_381::Bls12;
+use std::{collections::btree_map::BTreeMap, io, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct IpSignPio {
+    #[structopt(
+        long = "pio",
+        help = "File with input pre-identity object information."
+    )]
+    pio:                PathBuf,
+    #[structopt(
+        long = "ip-data",
+        help = "Possibly encrypted file with all information about the identity provider (public \
+                and private)."
+    )]
+    ip_data:            PathBuf,
+    #[structopt(long = "out", help = "File to write the signed identity object to.")]
+    out_file:           PathBuf,
+    #[structopt(
+        long = "initial-cdi-out",
+        help = "File to output the JSON transaction payload to (regarding the initial account)."
+    )]
+    out_icdi:           PathBuf,
+    #[structopt(
+        long = "global",
+        help = "File with global parameters.",
+        default_value = "database/global.json"
+    )]
+    global:             PathBuf,
+    #[structopt(
+        long = "ars",
+        help = "File with a list of anonymity revokers.",
+        default_value = "database/anonymity_revokers.json"
+    )]
+    anonymity_revokers: PathBuf,
+    #[structopt(
+        long = "expiry",
+        help = "Expiry time of the initial credential message. In seconds from __now__.",
+        required = true
+    )]
+    expiry:             u64,
+    #[structopt(
+        long = "id-object-expiry",
+        help = "Expiry time of the identity object message. As YYYYMM."
+    )]
+    id_expiry:          Option<YearMonth>,
+}
+
+#[derive(StructOpt)]
+#[structopt(
+    about = "Identity provider client",
+    author = "Concordium",
+    version = "1"
+)]
+enum IpClient {
+    #[structopt(
+        name = "ip-sign-pio",
+        about = "Act as the identity provider, checking and signing a pre-identity object."
+    )]
+    IpSignPio(IpSignPio),
+}
+
+fn read_validto() -> io::Result<YearMonth> {
+    let input: String = Input::new()
+        .with_prompt("Enter valid to (YYYYMM)")
+        .interact()?;
+    match parse_yearmonth(&input) {
+        Some(ym) => Ok(ym),
+        None => panic!("Unable to parse YYYYMM"),
+    }
+}
+
+fn main() {
+    let app = IpClient::clap()
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .global_setting(AppSettings::ColoredHelp);
+    let matches = app.get_matches();
+    let client = IpClient::from_clap(&matches);
+    use IpClient::*;
+    match client {
+        IpSignPio(isp) => handle_act_as_ip(isp),
+    }
+}
+
+fn handle_act_as_ip(aai: IpSignPio) {
+    let pio = match read_pre_identity_object(&aai.pio) {
+        Ok(pio) => pio,
+        Err(e) => {
+            eprintln!("Could not read file because {}", e);
+            return;
+        }
+    };
+    let (ip_info, ip_sec_key, ip_cdi_secret_key) =
+        match decrypt_input::<_, IpData<Bls12>>(&aai.ip_data) {
+            Ok(ip_data) => (
+                ip_data.public_ip_info,
+                ip_data.ip_secret_key,
+                ip_data.ip_cdi_secret_key,
+            ),
+            Err(x) => {
+                eprintln!("Could not read identity issuer information because: {}", x);
+                return;
+            }
+        };
+
+    let valid_to = match aai.id_expiry {
+        Some(exp) => exp,
+        None => match read_validto() {
+            Ok(ym) => ym,
+            Err(e) => {
+                eprintln!("Could not read credential expiry because: {}", e);
+                return;
+            }
+        },
+    };
+
+    let global_ctx = {
+        if let Some(gc) = read_global_context(aai.global) {
+            gc
+        } else {
+            eprintln!("Cannot read global context information database. Terminating.");
+            return;
+        }
+    };
+
+    // all known anonymity revokers.
+    let ars = {
+        if let Ok(ars) = read_anonymity_revokers(aai.anonymity_revokers) {
+            ars.anonymity_revokers
+        } else {
+            eprintln!("Cannot read anonymity revokers from the database. Terminating.");
+            return;
+        }
+    };
+
+    let created_at = YearMonth::now();
+
+    let alist = {
+        let mut alist: BTreeMap<AttributeTag, ExampleAttribute> = BTreeMap::new();
+        match Input::new()
+            .with_prompt("Please provide LEI (Legal Entity Identifier)")
+            .interact()
+        {
+            Err(e) => {
+                eprintln!("Could not read input because: {}", e);
+                return;
+            }
+            Ok(s) => {
+                let _ = alist.insert(AttributeTag(13u8), s);
+            }
+        }
+        alist
+    };
+
+    let attributes = AttributeList {
+        valid_to,
+        created_at,
+        max_accounts: 238,
+        alist,
+        _phantom: Default::default(),
+    };
+    let context = IpContext::new(&ip_info, &ars, &global_ctx);
+    let message_expiry = TransactionTime {
+        seconds: chrono::Utc::now().timestamp() as u64 + aai.expiry,
+    };
+    let vf = verify_credentials(
+        &pio,
+        context,
+        &attributes,
+        message_expiry,
+        &ip_sec_key,
+        &ip_cdi_secret_key,
+    );
+
+    match vf {
+        Ok((signature, icdi)) => {
+            let id_object = IdentityObject {
+                pre_identity_object: pio,
+                alist: attributes,
+                signature,
+            };
+            let ver_id_object = Versioned::new(VERSION_0, id_object);
+            println!("Successfully checked pre-identity data.");
+            match write_json_to_file(&aai.out_file, &ver_id_object) {
+                Ok(_) => println!(
+                    "Wrote signed identity object to file {:?}",
+                    &aai.out_file.to_string_lossy()
+                ),
+                Err(e) => eprintln!("Could not write Identity object to file because: {:?}", e),
+            }
+
+            let icdi_message = AccountCredentialMessage::<IpPairing, ArCurve, _> {
+                message_expiry,
+                credential: AccountCredential::Initial { icdi },
+            };
+            let versioned_icdi = Versioned::new(VERSION_0, icdi_message);
+            match write_json_to_file(&aai.out_icdi, &versioned_icdi) {
+                Ok(_) => println!(
+                    "Wrote transaction payload to JSON file {}.",
+                    &aai.out_icdi.to_string_lossy()
+                ),
+                Err(e) => {
+                    eprintln!("Could not JSON write to file because: {}", e);
+                }
+            }
+        }
+        Err(r) => eprintln!("Could not verify pre-identity object because {}", r),
+    }
+}

--- a/rust-bins/src/bin/identity_provider_cli.rs
+++ b/rust-bins/src/bin/identity_provider_cli.rs
@@ -142,7 +142,7 @@ fn main() -> anyhow::Result<()> {
             .interact()
             .context("Could not read attribute LEI")?;
         if !s.is_empty() {
-            alist.insert(AttributeTag(13u8), AttributeKind(s));
+            alist.insert(ATTRIBUTE_TAG_LEI, AttributeKind(s));
         }
         alist
     };

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -20,7 +20,7 @@ use std::{
     collections::HashMap,
     fs::{self, File},
     io::Write,
-    path::{Path, PathBuf},
+    path::PathBuf,
 };
 use structopt::StructOpt;
 
@@ -219,25 +219,6 @@ macro_rules! succeed_or_die {
             None => return Err($s.to_owned()),
         }
     };
-}
-
-fn output_possibly_encrypted<X: SerdeSerialize>(
-    fname: &Path,
-    data: &X,
-) -> Result<(), std::io::Error> {
-    let pass = ask_for_password_confirm(
-        "Enter password to encrypt credentials (leave empty for no encryption): ",
-        true,
-    )?;
-    if pass.is_empty() {
-        println!("No password supplied, so output will not be encrypted.");
-        write_json_to_file(fname, data)
-    } else {
-        let plaintext = serde_json::to_vec(data).expect("JSON serialization does not fail.");
-        let encrypted =
-            crypto_common::encryption::encrypt(&pass.into(), &plaintext, &mut rand::thread_rng());
-        write_json_to_file(fname, &encrypted)
-    }
 }
 
 fn handle_generate_ar_keys(kgar: KeygenAr) -> Result<(), String> {

--- a/rust-bins/src/bin/user_cli.rs
+++ b/rust-bins/src/bin/user_cli.rs
@@ -22,6 +22,11 @@ struct StartIp {
     )]
     ip_info:            PathBuf,
     #[structopt(
+        long = "initial-keys",
+        help = "File to write the JSON encoded private keys of the user's initial account."
+    )]
+    initial_keys:       PathBuf,
+    #[structopt(
         long = "ars",
         help = "File with a list of anonymity revokers.",
         default_value = "database/anonymity_revokers.json"
@@ -266,6 +271,18 @@ fn handle_start_ip(sip: StartIp) {
         },
         threshold: SignatureThreshold(2),
     };
+    println!("Generated private keys for initial account.");
+    if let Err(e) = output_possibly_encrypted(&sip.initial_keys, &initial_acc_data) {
+        eprintln!(
+            "Could not write (encrypted) private keys of initial account to file because: {}",
+            e
+        );
+        return;
+    }
+    println!(
+        "Wrote (encrypted) private keys of initial account to file {}.",
+        &sip.private.to_string_lossy()
+    );
     let (pio, randomness) = generate_pio(&context, threshold, &aci, &initial_acc_data)
         .expect("Generating the pre-identity object should succeed.");
 

--- a/rust-bins/src/bin/user_cli.rs
+++ b/rust-bins/src/bin/user_cli.rs
@@ -1,0 +1,528 @@
+use clap::AppSettings;
+use client_server_helpers::*;
+use crypto_common::{
+    types::{CredentialIndex, KeyIndex, KeyPair, TransactionTime},
+    *,
+};
+use dialoguer::{Input, MultiSelect, Select};
+use dodis_yampolskiy_prf as prf;
+use either::Either::{Left, Right};
+use id::{account_holder::*, secret_sharing::*, types::*};
+use pairing::bls12_381::Bls12;
+use rand::*;
+use serde_json::{json, to_value};
+use std::{cmp::max, collections::btree_map::BTreeMap, convert::TryFrom, path::PathBuf};
+use structopt::StructOpt;
+
+#[derive(StructOpt)]
+struct StartIp {
+    #[structopt(
+        long = "ip-info",
+        help = "File with the JSON encoded information about the identity provider."
+    )]
+    ip_info:            PathBuf,
+    #[structopt(
+        long = "ars",
+        help = "File with a list of anonymity revokers.",
+        default_value = "database/anonymity_revokers.json"
+    )]
+    anonymity_revokers: PathBuf,
+    #[structopt(long = "private", help = "File to write the private ACI data to.")]
+    private:            PathBuf,
+    #[structopt(
+        long = "public",
+        help = "File to write the public data to be sent to the identity provider."
+    )]
+    public:             PathBuf,
+    #[structopt(
+        long = "global",
+        help = "File with global parameters.",
+        default_value = "database/global.json"
+    )]
+    global:             PathBuf,
+    #[structopt(
+        name = "ar-threshold",
+        long = "ar-threshold",
+        help = "Anonymity revocation threshold.",
+        requires = "selected-ars"
+    )]
+    threshold:          Option<u8>,
+    #[structopt(
+        long = "selected-ars",
+        help = "Indices of selected ars. If none are provided an interactive choice will be given.",
+        requires = "ar-threshold"
+    )]
+    selected_ars:       Vec<u32>,
+}
+
+#[derive(StructOpt)]
+struct CreateCredential {
+    #[structopt(
+        long = "id-object",
+        help = "File with the JSON encoded identity object."
+    )]
+    id_object:          PathBuf,
+    #[structopt(
+        long = "global",
+        help = "File with global parameters.",
+        default_value = "database/global.json"
+    )]
+    global:             PathBuf,
+    #[structopt(
+        long = "ip-info",
+        help = "File with the JSON encoded information about the identity provider."
+    )]
+    ip_info:            PathBuf,
+    #[structopt(
+        long = "private",
+        help = "File with private credential holder information used to generate the identity \
+                object."
+    )]
+    private:            PathBuf,
+    #[structopt(
+        long = "account",
+        help = "Account address onto which the credential should be deployed.",
+        requires = "key-index"
+    )]
+    account:            Option<AccountAddress>,
+    #[structopt(
+        long = "expiry",
+        help = "Expiry time of the credential message. In seconds from __now__.",
+        required_unless = "account",
+        conflicts_with = "account"
+    )]
+    expiry:             Option<u64>,
+    #[structopt(
+        name = "key-index",
+        long = "key-index",
+        help = "Credential index of the new credential.",
+        requires = "account",
+        conflicts_with = "expiry"
+    )]
+    key_index:          Option<u8>,
+    #[structopt(long = "out", help = "File to output the JSON transaction payload to.")]
+    out:                PathBuf,
+    #[structopt(
+        long = "keys-out",
+        help = "File to output account keys.",
+        default_value = "account_keys.json"
+    )]
+    keys_out:           PathBuf,
+    #[structopt(
+        long = "ars",
+        help = "File with a list of anonymity revokers.",
+        default_value = "database/anonymity_revokers.json"
+    )]
+    anonymity_revokers: PathBuf,
+    #[structopt(long = "index", help = "Index of the account to be created.")]
+    index:              Option<u8>,
+}
+
+#[derive(StructOpt)]
+#[structopt(about = "User client", author = "Concordium", version = "1")]
+enum UserClient {
+    #[structopt(
+        name = "start-ip",
+        about = "Generate data to send to the identity provider to sign and verify."
+    )]
+    StartIp(StartIp),
+    #[structopt(
+        name = "create-credential",
+        about = "Take the identity object, select attributes to reveal and create a credential \
+                 object to deploy on chain."
+    )]
+    CreateCredential(CreateCredential),
+}
+
+fn main() {
+    let app = UserClient::clap()
+        .setting(AppSettings::ArgRequiredElseHelp)
+        .global_setting(AppSettings::ColoredHelp);
+    let matches = app.get_matches();
+    let client = UserClient::from_clap(&matches);
+    use UserClient::*;
+    match client {
+        StartIp(ip) => handle_start_ip(ip),
+        CreateCredential(cc) => handle_create_credential(cc),
+    }
+}
+
+fn handle_start_ip(sip: StartIp) {
+    let mut csprng = thread_rng();
+    let chi = CredentialHolderInfo::<ExampleCurve> {
+        id_cred: IdCredentials::generate(&mut csprng),
+    };
+    let mut csprng = thread_rng();
+    let prf_key = prf::SecretKey::generate(&mut csprng);
+
+    // the chosen account credential information
+    let aci = AccCredentialInfo {
+        cred_holder_info: chi,
+        prf_key,
+    };
+
+    let ip_info = match read_ip_info(sip.ip_info) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("Could not read identity provider info because {}", err);
+            return;
+        }
+    };
+
+    let ars = {
+        if let Ok(ars) = read_anonymity_revokers(sip.anonymity_revokers) {
+            ars
+        } else {
+            eprintln!("Cannot read anonymity revokers from the database. Terminating.");
+            return;
+        }
+    };
+
+    let ar_ids = if sip.selected_ars.is_empty() {
+        let mrs: Vec<&str> = ars
+            .anonymity_revokers
+            .values()
+            .map(|x| x.ar_description.name.as_str())
+            .collect();
+        let keys = ars.anonymity_revokers.keys().collect::<Vec<_>>();
+        let ar_ids = MultiSelect::new()
+            .with_prompt("Choose anonymity revokers")
+            .items(&mrs)
+            .interact()
+            .unwrap()
+            .iter()
+            .map(|&x| *keys[x])
+            .collect::<Vec<_>>();
+        if ar_ids.is_empty() {
+            eprintln!("You need to select an AR.");
+            return;
+        }
+        ar_ids
+    } else {
+        let res = sip
+            .selected_ars
+            .iter()
+            .map(|&x| ArIdentity::try_from(x))
+            .collect();
+        match res {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Incorrect AR identities: {}", e);
+                return;
+            }
+        }
+    };
+    let num_ars = ar_ids.len();
+    let mut choice_ars = BTreeMap::new();
+    for ar_id in ar_ids.iter() {
+        choice_ars.insert(
+            *ar_id,
+            ars.anonymity_revokers
+                .get(ar_id)
+                .expect("Chosen AR does not exist.")
+                .clone(),
+        );
+    }
+
+    let threshold = if let Some(thr) = sip.threshold {
+        Threshold(thr)
+    } else if let Ok(threshold) = Select::new()
+        .with_prompt("Revocation threshold")
+        .items(&(1..=num_ars).collect::<Vec<usize>>())
+        .default(0)
+        .interact()
+    {
+        Threshold((threshold + 1) as u8) // +1 because the indexing of the
+                                         // selection starts at 1
+    } else {
+        let d = max(1, num_ars - 1);
+        println!(
+            "Selecting default value (= {}) for revocation threshold.",
+            d
+        );
+        Threshold(d as u8)
+    };
+
+    let global_ctx = {
+        if let Some(gc) = read_global_context(sip.global) {
+            gc
+        } else {
+            eprintln!("Cannot read global context information database. Terminating.");
+            return;
+        }
+    };
+
+    let context = IpContext::new(&ip_info, &choice_ars, &global_ctx);
+    // and finally generate the pre-identity object
+    // we also retrieve the randomness which we must keep private.
+    // This randomness must be used
+    let initial_acc_data = InitialAccountData {
+        keys:      {
+            let mut keys = BTreeMap::new();
+            keys.insert(KeyIndex(0), KeyPair::generate(&mut csprng));
+            keys.insert(KeyIndex(1), KeyPair::generate(&mut csprng));
+            keys.insert(KeyIndex(2), KeyPair::generate(&mut csprng));
+            keys
+        },
+        threshold: SignatureThreshold(2),
+    };
+    let (pio, randomness) = generate_pio(&context, threshold, &aci, &initial_acc_data)
+        .expect("Generating the pre-identity object should succeed.");
+
+    // the only thing left is to output all the information
+
+    let id_use_data = IdObjectUseData { aci, randomness };
+    let ver_id_use_data = Versioned::new(VERSION_0, id_use_data);
+    println!("Generated ACI and randomness.");
+    if let Err(e) = output_possibly_encrypted(&sip.private, &ver_id_use_data) {
+        eprintln!(
+            "Could not write (encrypted) ACI data to file because: {}",
+            e
+        );
+        return;
+    }
+    println!(
+        "Wrote (encrypted) ACI and randomness to file {}.",
+        &sip.private.to_string_lossy()
+    );
+
+    let ver_pio = Versioned::new(VERSION_0, pio);
+    if let Err(e) = write_json_to_file(&sip.public, &ver_pio) {
+        println!("Could not write PIO data to file because: {}", e);
+        return;
+    }
+    println!("Wrote PIO data to file {}.", &sip.public.to_string_lossy());
+}
+
+fn handle_create_credential(cc: CreateCredential) {
+    let id_object = {
+        match read_id_object(cc.id_object) {
+            Ok(v) => v,
+            Err(x) => {
+                eprintln!("Could not read identity object because {}", x);
+                return;
+            }
+        }
+    };
+
+    let ip_info = match read_ip_info(cc.ip_info) {
+        Ok(v) => v,
+        Err(err) => {
+            eprintln!("Could not read identity provider info because {}", err);
+            return;
+        }
+    };
+
+    // we also read the global context from another json file (called
+    // global.context). We need commitment keys and other data in there.
+    let global_ctx = {
+        if let Some(gc) = read_global_context(cc.global) {
+            gc
+        } else {
+            eprintln!("Cannot read global context information database. Terminating.");
+            return;
+        }
+    };
+
+    // now we have all the data ready.
+    // we first ask the user to select which attributes they wish to reveal
+    let alist = &id_object.alist.alist;
+
+    let alist_items = alist
+        .keys()
+        .map(|&x| AttributeStringTag::from(x))
+        .collect::<Vec<_>>();
+    let atts = if alist_items.is_empty() {
+        eprintln!("No attributes on the identity object, so none will be on the credential.");
+        Vec::new()
+    } else {
+        match MultiSelect::new()
+            .with_prompt("Select which attributes you wish to reveal")
+            .items(&alist_items)
+            .interact()
+        {
+            Ok(idxs) => idxs,
+            Err(x) => {
+                eprintln!("You need to select which attributes you want. {}", x);
+                return;
+            }
+        }
+    };
+
+    // from the above and the pre-identity object we make a policy
+    let mut revealed_attributes: BTreeMap<AttributeTag, ExampleAttribute> = BTreeMap::new();
+    for idx in atts {
+        let tag = alist.keys().collect::<Vec<_>>()[idx];
+        match alist.get(tag) {
+            Some(elem) => {
+                if revealed_attributes.insert(*tag, elem.clone()).is_some() {
+                    eprintln!("Duplicate attribute idx.");
+                    return;
+                }
+            }
+            None => {
+                eprintln!("Selected an attribute which does not exist. Aborting.");
+                return;
+            }
+        }
+    }
+    let policy = Policy {
+        valid_to:   id_object.alist.valid_to,
+        created_at: id_object.alist.created_at,
+        policy_vec: revealed_attributes,
+        _phantom:   Default::default(),
+    };
+
+    // finally we also read the credential holder information with secret keys
+    // which we need to generate CDI.
+    // This file should also contain the public keys of the identity provider who
+    // signed the object.
+    let id_use_data: IdObjectUseData<Bls12, ExampleCurve> = match read_id_use_data(cc.private) {
+        Ok(v) => v,
+        Err(x) => {
+            eprintln!("Could not read CHI object because: {}", x);
+            return;
+        }
+    };
+
+    // We ask what regid index they would like to use.
+    let x = match cc.index {
+        Some(x) => x,
+        None => Input::new().with_prompt("Index").interact().unwrap_or(0), // 0 is the default index
+    };
+
+    // Now we have have everything we need to generate the proofs
+    // we have
+    // - chi
+    // - pio
+    // - ip_info
+    // - signature of the identity provider
+    // - acc_data of the account onto which we are deploying this credential
+    //   (private and public)
+
+    // all known anonymity revokers.
+    let ars = {
+        if let Ok(ars) = read_anonymity_revokers(cc.anonymity_revokers) {
+            ars.anonymity_revokers
+        } else {
+            eprintln!("Cannot read anonymity revokers from the database. Terminating.");
+            return;
+        }
+    };
+
+    let context = IpContext::new(&ip_info, &ars, &global_ctx);
+
+    // We now generate or read account verification/signature key pair.
+    let acc_data = {
+        let mut csprng = thread_rng();
+        let mut keys = BTreeMap::new();
+        keys.insert(KeyIndex(0), KeyPair::generate(&mut csprng));
+        keys.insert(KeyIndex(1), KeyPair::generate(&mut csprng));
+        keys.insert(KeyIndex(2), KeyPair::generate(&mut csprng));
+
+        CredentialData {
+            keys,
+            threshold: SignatureThreshold(2),
+        }
+    };
+
+    let new_or_existing = match (cc.expiry, cc.account) {
+        (None, None) => panic!("One of (expiry, address) is required."),
+        (None, Some(addr)) => Right(addr),
+        (Some(seconds), None) => Left(TransactionTime {
+            seconds: chrono::Utc::now().timestamp() as u64 + seconds,
+        }),
+        (Some(_), Some(_)) => panic!("Exactly one of (expiry, address) is required."),
+    };
+
+    let cdi = create_credential(
+        context,
+        &id_object,
+        &id_use_data,
+        x,
+        policy,
+        &acc_data,
+        &new_or_existing,
+    );
+
+    let (cdi, commitments_randomness) = match cdi {
+        Ok(cdi) => cdi,
+        Err(x) => {
+            eprintln!("Could not generate the credential because {}", x);
+            return;
+        }
+    };
+
+    let address = AccountAddress::new(&cdi.values.cred_id);
+
+    let cdi = AccountCredential::Normal { cdi };
+
+    let (versioned_credentials, randomness_map) = {
+        let ki = cc.key_index.map_or(KeyIndex(0), KeyIndex);
+        let mut credentials = BTreeMap::new();
+        let mut randomness = BTreeMap::new();
+        // NB: We insert the reference to the credential here so as to avoid cloning
+        // (which is not implemented for the type)
+        credentials.insert(ki, &cdi);
+        randomness.insert(ki, &commitments_randomness);
+        (Versioned::new(VERSION_0, credentials), randomness)
+    };
+
+    let enc_key = id_use_data.aci.prf_key.prf_exponent(x).unwrap();
+
+    let secret_key = elgamal::SecretKey {
+        generator: *global_ctx.elgamal_generator(),
+        scalar:    enc_key,
+    };
+
+    if let Some(addr) = cc.account {
+        println!(
+            "Generated additional keys for the account to be encrypted and written to file {}.",
+            cc.keys_out.to_string_lossy()
+        );
+        let js = json!({
+            "address": addr,
+            "accountKeys": AccountKeys::from((CredentialIndex{index: cc.key_index.unwrap()}, acc_data)),
+            "credentials": versioned_credentials,
+            "commitmentsRandomness": randomness_map,
+        });
+        if let Err(e) = output_possibly_encrypted(&cc.keys_out, &js) {
+            eprintln!("Could not output (encrypted) account keys because: {}", e);
+            return;
+        }
+    } else {
+        let account_data_json = json!({
+            "address": address,
+            "encryptionSecretKey": secret_key,
+            "encryptionPublicKey": elgamal::PublicKey::from(&secret_key),
+            "accountKeys": AccountKeys::from(acc_data),
+            "credentials": versioned_credentials,
+            "commitmentsRandomness": randomness_map,
+            "aci": id_use_data.aci,
+        });
+        println!(
+            "Generated fresh verification and signature key of the account to be encrypted and \
+             written to file {}.",
+            cc.keys_out.to_string_lossy()
+        );
+        if let Err(e) = output_possibly_encrypted(&cc.keys_out, &account_data_json) {
+            eprintln!("Could not output (encrypted) account keys because: {}", e);
+            return;
+        }
+    }
+
+    let cdi_json_value = match new_or_existing {
+        Left(tt) => to_value(&Versioned::new(VERSION_0, AccountCredentialMessage {
+            message_expiry: tt,
+            credential:     cdi,
+        }))
+        .expect("Cannot fail."),
+        Right(_) => to_value(&Versioned::new(VERSION_0, cdi)).expect("Cannot fail"),
+    };
+    match write_json_to_file(&cc.out, &cdi_json_value) {
+        Ok(_) => println!("Wrote transaction payload to JSON file."),
+        Err(e) => {
+            eprintln!("Could not JSON write to file because {}", e);
+        }
+    }
+}

--- a/rust-bins/src/lib.rs
+++ b/rust-bins/src/lib.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use crypto_common::*;
 use curve_arithmetic::*;
 use id::{constants::*, types::*};
@@ -59,11 +60,55 @@ pub fn read_id_object<P: AsRef<Path> + Debug>(
     }
 }
 
+/// Encrypt data (if password is provided), and write the (encrypted) data to
+/// file
+pub fn output_possibly_encrypted<X: SerdeSerialize>(
+    fname: &Path,
+    data: &X,
+) -> Result<(), std::io::Error> {
+    let pass = ask_for_password_confirm(
+        "Enter password to encrypt (leave empty for no encryption): ",
+        true,
+    )?;
+    if pass.is_empty() {
+        println!("No password supplied, so output will not be encrypted.");
+        write_json_to_file(fname, data)
+    } else {
+        let plaintext = serde_json::to_vec(data).expect("JSON serialization does not fail.");
+        let encrypted =
+            crypto_common::encryption::encrypt(&pass.into(), &plaintext, &mut rand::thread_rng());
+        write_json_to_file(fname, &encrypted)
+    }
+}
+
+/// Decrypt data if encrypted.
+pub fn decrypt_input<P: AsRef<Path> + Debug, X: DeserializeOwned>(input: P) -> anyhow::Result<X> {
+    let data = std::fs::read(&input).context("Cannot read input file.")?;
+    match serde_json::from_slice(&data) {
+        Ok(data) => Ok(data),
+        Err(_) => {
+            let parsed_data = serde_json::from_slice(&data)?;
+            let pass = rpassword::read_password_from_tty(Some(&format!(
+                "Enter password to decrypt file {} with: ",
+                input.as_ref().to_string_lossy()
+            )))?;
+            let plaintext = crypto_common::encryption::decrypt(&pass.into(), &parsed_data)
+                .context("Could not decrypt data.")?;
+            serde_json::from_slice(&plaintext).context("Could not parse decrypted data.")
+        }
+    }
+}
+
 /// Read id_use_data, deciding on how to parse based on the version.
 pub fn read_id_use_data<P: AsRef<Path> + Debug>(
     filename: P,
 ) -> io::Result<IdObjectUseData<Bls12, ExampleCurve>> {
-    let params: Versioned<serde_json::Value> = read_json_from_file(filename)?;
+    let params: Versioned<serde_json::Value> = match decrypt_input(filename) {
+        Ok(versioned_val) => versioned_val,
+        Err(e) => {
+            return Err(io::Error::new(io::ErrorKind::InvalidData, format!("{}", e)));
+        }
+    };
     match params.version {
         Version { value: 0 } => Ok(serde_json::from_value(params.value)?),
         other => Err(io::Error::new(

--- a/rust-bins/src/lib.rs
+++ b/rust-bins/src/lib.rs
@@ -61,23 +61,26 @@ pub fn read_id_object<P: AsRef<Path> + Debug>(
 }
 
 /// Encrypt data (if password is provided), and write the (encrypted) data to
-/// file
+/// file. Upon success, returns Ok(true) if data was encrypted and Ok(false) if
+/// not.
 pub fn output_possibly_encrypted<X: SerdeSerialize>(
     fname: &Path,
     data: &X,
-) -> Result<(), std::io::Error> {
+) -> Result<bool, std::io::Error> {
     let pass = ask_for_password_confirm(
         "Enter password to encrypt (leave empty for no encryption): ",
         true,
     )?;
     if pass.is_empty() {
         println!("No password supplied, so output will not be encrypted.");
-        write_json_to_file(fname, data)
+        write_json_to_file(fname, data)?;
+        Ok(false)
     } else {
         let plaintext = serde_json::to_vec(data).expect("JSON serialization does not fail.");
         let encrypted =
             crypto_common::encryption::encrypt(&pass.into(), &plaintext, &mut rand::thread_rng());
-        write_json_to_file(fname, &encrypted)
+        write_json_to_file(fname, &encrypted)?;
+        Ok(true)
     }
 }
 

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -490,6 +490,10 @@ pub struct YearMonth {
     pub month: u8,
 }
 
+impl ToString for YearMonth {
+    fn to_string(&self) -> String { format!("{:04}{:02}", self.year, self.month) }
+}
+
 impl SerdeSerialize for YearMonth {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -395,6 +395,9 @@ pub const ATTRIBUTE_NAMES: [&str; 14] = [
     "lei",
 ];
 
+/// Attribute tag for the LEI attribute.
+pub const ATTRIBUTE_TAG_LEI: AttributeTag = AttributeTag(13);
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 #[repr(transparent)]
 #[derive(SerdeSerialize, SerdeDeserialize)]

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -378,7 +378,7 @@ pub struct AttributeTag(pub u8);
 /// NB: The length of this list must be less than 256.
 /// This must be consistent with the value of attributeNames in
 /// haskell-src/Concordium/ID/Types.hs
-pub const ATTRIBUTE_NAMES: [&str; 13] = [
+pub const ATTRIBUTE_NAMES: [&str; 14] = [
     "firstName",
     "lastName",
     "sex",
@@ -392,6 +392,7 @@ pub const ATTRIBUTE_NAMES: [&str; 13] = [
     "idDocExpiresAt",
     "nationalIdNo",
     "taxIdNo",
+    "lei",
 ];
 
 #[derive(Debug, PartialEq, Eq, Clone)]
@@ -433,7 +434,7 @@ impl<'a> std::convert::From<AttributeTag> for AttributeStringTag {
         if v_usize < ATTRIBUTE_NAMES.len() {
             AttributeStringTag(ATTRIBUTE_NAMES[v_usize].to_owned())
         } else {
-            AttributeStringTag(format!("UNNAMED#{}", v))
+            AttributeStringTag(format!("UNNAMED#{}", v.0))
         }
     }
 }


### PR DESCRIPTION
## Purpose
To make two binaries for interaction between an enterprise and an identity provider in order to create an identity and an account.

## Changes

* A binary `user_cli` has been provided for the user's side of the process.
* A binary `identity_provider_cli` has been provided for the identity provider's side of the process.
* The existing binary `client` has been polished a bit.
* Two readmes have been added for the newly introduced binaries.

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

