### PR TITLE
Decrypt id-use-data if necessary.

### DIFF
--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -457,7 +457,7 @@ dependencies = [
  "hmac",
  "libc",
  "pairing",
- "pbkdf2",
+ "pbkdf2 0.9.0",
  "rand 0.7.3",
  "serde",
  "sha2 0.9.5",
@@ -1225,7 +1225,7 @@ dependencies = [
  "keygen_bls",
  "openssl-sys",
  "pairing",
- "pbkdf2",
+ "pbkdf2 0.8.0",
  "pedersen_scheme",
  "ps_sig",
  "rand 0.7.3",
@@ -1415,6 +1415,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d791538a6dcc1e7cb7fe6f6b58aca40e7f79403c45b2bc274008b5e647af1d8"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.3",
+ "subtle",
+]
+
+[[package]]
 name = "pbkdf2"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1423,7 +1434,19 @@ dependencies = [
  "base64ct",
  "crypto-mac",
  "hmac",
- "password-hash",
+ "password-hash 0.2.1",
+ "sha2 0.9.5",
+]
+
+[[package]]
+name = "pbkdf2"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
+dependencies = [
+ "crypto-mac",
+ "hmac",
+ "password-hash 0.3.2",
  "sha2 0.9.5",
 ]
 

--- a/rust-bins/src/bin/user_cli.rs
+++ b/rust-bins/src/bin/user_cli.rs
@@ -334,7 +334,7 @@ fn handle_create_credential(cc: CreateCredential) -> anyhow::Result<()> {
         &cc.id_object.display()
     ))?;
 
-    let data: Versioned<StoredData> = read_json_from_file(&cc.id_use_data).context(format!(
+    let data: Versioned<StoredData> = decrypt_input(&cc.id_use_data).context(format!(
         "Could not read identity object use data from {}.",
         cc.id_use_data.display()
     ))?;


### PR DESCRIPTION
## Purpose

To decrypt id-use-data if necessary when creating credentials

## Changes

* The `create-credential` command now decrypts the id-use-data if it is encrypted.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


