### PR TITLE
Fix JSON serialization of AR records.

### DIFF
--- a/idiss-csharp/CHANGELOG.md
+++ b/idiss-csharp/CHANGELOG.md
@@ -1,0 +1,7 @@
+# 1.0.1
+
+Fix JSON serialization of AR records.
+
+# 1.0.0
+
+Initial release

--- a/idiss-csharp/IdissLib/IdissLib.csproj
+++ b/idiss-csharp/IdissLib/IdissLib.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
 </Project>

--- a/idiss-csharp/IdissLib/Types.cs
+++ b/idiss-csharp/IdissLib/Types.cs
@@ -136,7 +136,7 @@ namespace IdissLib
         public string idCredPub { get; set; }
         public Dictionary<string, IpArData> arData { get; set; }
         public byte maxAccounts { get; set; }
-        public byte threshold { get; set; }
+        public byte revocationThreshold { get; set; }
     }
 
     /// A wrapper around the InitialCredentialDeploymentInfo class.

--- a/idiss-csharp/IdissLibTest/IdissTests.cs
+++ b/idiss-csharp/IdissLibTest/IdissTests.cs
@@ -46,6 +46,9 @@ namespace IdissLibTest
                 var expected = new AccountAddress("3XqeZafxX5vpcUb6hLW98gYwdMxAsPWG5CkkijW98ZMptvej3y");
                 Assert.AreEqual(result, expected);
                 var idCreation = Idiss.CreateIdentityObject(ipInfo, alist, request, expiry, ipKeys);
+                Assert.AreEqual(request.idObjectRequest.value.choiceArData.threshold,
+                                idCreation.arRecord.value.revocationThreshold,
+                                "AR record does not have the correct anonymity revocation threshold.");
             }
             catch (RequestValidationException e)
             {


### PR DESCRIPTION
## Purpose

Fix JSON serialization of AR records.

## Changes

Since JSON serialization is derived the field names must match what is expected from the formatting of the anonymity revocation threshold.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.