### PR TITLE
Sync calls

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -53,6 +53,7 @@ library
       Concordium.Genesis.Data.P1
       Concordium.Genesis.Data.P2
       Concordium.Genesis.Data.P3
+      Concordium.Genesis.Data.P4
       Concordium.Genesis.Parameters
       Concordium.ID.Account
       Concordium.ID.AnonymityRevoker

--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -74,6 +74,7 @@ library
       Concordium.Types.Execution.TH
       Concordium.Types.HashableTo
       Concordium.Types.IdentityProviders
+      Concordium.Types.InvokeContract
       Concordium.Types.Parameters
       Concordium.Types.ProtocolVersion
       Concordium.Types.ProtocolVersion.TH

--- a/haskell-bins/genesis/Genesis.hs
+++ b/haskell-bins/genesis/Genesis.hs
@@ -29,6 +29,7 @@ import Concordium.Genesis.Data
 import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
 import qualified Concordium.Genesis.Data.P3 as P3
+import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.Base as GDBase
 import Concordium.Types.IdentityProviders
 import Concordium.Types.AnonymityRevokers
@@ -177,6 +178,7 @@ main = cmdArgsRun mode >>=
                                -- for why we assign these versions to P1 and P2 genesis
                                4 -> return $ PVGenesisData . GDP2 $ P2.parametersToGenesisData params
                                5 -> return $ PVGenesisData . GDP3 $ P3.parametersToGenesisData params
+                               6 -> return $ PVGenesisData . GDP4 $ P4.parametersToGenesisData params
                                n -> do
                                  putStrLn $ "Unsupported genesis data version: " ++ show n
                                  exitFailure
@@ -202,6 +204,9 @@ main = cmdArgsRun mode >>=
                 SP3 -> case gdata of
                   GDP3 P3.GDP3Regenesis{..} -> printRegenesis P3 genesisRegenesis
                   gd@(GDP3 P3.GDP3Initial{..}) -> printInitial P3 (genesisBlockHash gd) genesisCore genesisInitialState
+                SP4 -> case gdata of
+                  GDP4 P4.GDP4Regenesis{..} -> printRegenesis P3 genesisRegenesis
+                  gd@(GDP4 P4.GDP4Initial{..}) -> printInitial P4 (genesisBlockHash gd) genesisCore genesisInitialState
 
 printRegenesis :: ProtocolVersion -> RegenesisData -> IO ()
 printRegenesis pv RegenesisData{genesisCore=CoreGenesisParameters{..},..} = do

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE GADTs #-}
 {-|
   Module      : Concordium.Contants
   Description : Constants for serialization, various limits, etc.
@@ -5,16 +6,20 @@
 module Concordium.Constants where
 
 import Data.Word
+import Concordium.Types.ProtocolVersion
 
 -- |Maximum number of incoming encrypted amounts on an account before we start
 -- aggregating the oldest one.
 maxNumIncoming :: Int
 maxNumIncoming = 32
 
--- |Maximum size of a transaction payload.
--- NB: This must accommodate all payload types.
-maxPayloadSize :: Word32
-maxPayloadSize = 100 * 1024 -- 100kB
+-- |Maximum size of a transaction payload allowed by each protocol version.
+-- NB: This must accommodate all payload types valid in that protocol version.
+maxPayloadSize :: SProtocolVersion pv -> Word32
+maxPayloadSize SP1 = 100 * 1024 -- 100kB
+maxPayloadSize SP2 = 100 * 1024 -- 100kB
+maxPayloadSize SP3 = 100 * 1024 -- 100kB
+maxPayloadSize SP4 = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, +4 for the length, +4 for the module version
 
 -- * Web assembly related constants
 

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -39,4 +39,3 @@ maxWasmModuleSizeV1 = 8 * 65536 -- 512kB
 -- Must stay in sync with MAX_FUNC_NAME_SIZE from wasm-transform.
 maxFuncNameSize :: Int
 maxFuncNameSize = 100
-

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -22,9 +22,13 @@ maxPayloadSize = 100 * 1024 -- 100kB
 maxParameterLen :: Word16
 maxParameterLen = 1024
 
--- |Maximum module size.
-maxWasmModuleSize :: Word32
-maxWasmModuleSize = 65536 -- 64kB
+-- |Maximum module size of a V0 module.
+maxWasmModuleSizeV0 :: Word32
+maxWasmModuleSizeV0 = 65536 -- 64kB
+
+-- |Maximum module size of a V1 module.
+maxWasmModuleSizeV1 :: Word32
+maxWasmModuleSizeV1 = 8 * 65536 -- 512kB
 
 -- |Maximum byte size of function names.
 -- Must stay in sync with MAX_FUNC_NAME_SIZE from wasm-transform.

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -20,6 +20,7 @@ import Concordium.Genesis.Data.Base
 import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
 import qualified Concordium.Genesis.Data.P3 as P3
+import qualified Concordium.Genesis.Data.P4 as P4
 import Concordium.Types
 
 -- |Data family for genesis data.
@@ -30,32 +31,38 @@ data family GenesisData (pv :: ProtocolVersion)
 newtype instance GenesisData 'P1 = GDP1 {unGDP1 :: P1.GenesisDataP1}
 newtype instance GenesisData 'P2 = GDP2 {unGDP2 :: P2.GenesisDataP2}
 newtype instance GenesisData 'P3 = GDP3 {unGDP3 :: P3.GenesisDataP3}
+newtype instance GenesisData 'P4 = GDP4 {unGDP4 :: P4.GenesisDataP4}
 
 instance (IsProtocolVersion pv) => BasicGenesisData (GenesisData pv) where
     gdGenesisTime = case protocolVersion @pv of
         SP1 -> gdGenesisTime . unGDP1
         SP2 -> gdGenesisTime . unGDP2
         SP3 -> gdGenesisTime . unGDP3
+        SP4 -> gdGenesisTime . unGDP4
     {-# INLINE gdGenesisTime #-}
     gdSlotDuration = case protocolVersion @pv of
         SP1 -> gdSlotDuration . unGDP1
         SP2 -> gdSlotDuration . unGDP2
         SP3 -> gdSlotDuration . unGDP3
+        SP4 -> gdSlotDuration . unGDP4
     {-# INLINE gdSlotDuration #-}
     gdMaxBlockEnergy = case protocolVersion @pv of
         SP1 -> gdMaxBlockEnergy . unGDP1
         SP2 -> gdMaxBlockEnergy . unGDP2
         SP3 -> gdMaxBlockEnergy . unGDP3
+        SP4 -> gdMaxBlockEnergy . unGDP4
     {-# INLINE gdMaxBlockEnergy #-}
     gdFinalizationParameters = case protocolVersion @pv of
         SP1 -> gdFinalizationParameters . unGDP1
         SP2 -> gdFinalizationParameters . unGDP2
         SP3 -> gdFinalizationParameters . unGDP3
+        SP4 -> gdFinalizationParameters . unGDP4
     {-# INLINE gdFinalizationParameters #-}
     gdEpochLength = case protocolVersion @pv of
         SP1 -> gdEpochLength . unGDP1
         SP2 -> gdEpochLength . unGDP2
         SP3 -> gdEpochLength . unGDP3
+        SP4 -> gdEpochLength . unGDP4
     {-# INLINE gdEpochLength #-}
 
 instance (IsProtocolVersion pv) => Eq (GenesisData pv) where
@@ -63,16 +70,19 @@ instance (IsProtocolVersion pv) => Eq (GenesisData pv) where
         SP1 -> (==) `on` unGDP1
         SP2 -> (==) `on` unGDP2
         SP3 -> (==) `on` unGDP3
+        SP4 -> (==) `on` unGDP4
 
 instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
     get = case protocolVersion @pv of
         SP1 -> GDP1 <$> P1.getGenesisDataV3
         SP2 -> GDP2 <$> P2.getGenesisDataV4
         SP3 -> GDP3 <$> P3.getGenesisDataV5
+        SP4 -> GDP4 <$> P4.getGenesisDataV6
     put = case protocolVersion @pv of
         SP1 -> P1.putGenesisDataV3 . unGDP1
         SP2 -> P2.putGenesisDataV4 . unGDP2
         SP3 -> P3.putGenesisDataV5 . unGDP3
+        SP4 -> P4.putGenesisDataV6 . unGDP4
 
 -- |Deserialize genesis data with a version tag.
 -- See `putVersionedGenesisData` for details of the version tag.
@@ -81,6 +91,7 @@ getVersionedGenesisData = case protocolVersion @pv of
     SP1 -> GDP1 <$> P1.getVersionedGenesisData
     SP2 -> GDP2 <$> P2.getVersionedGenesisData
     SP3 -> GDP3 <$> P3.getVersionedGenesisData
+    SP4 -> GDP4 <$> P4.getVersionedGenesisData
 
 -- |Serialize genesis data with a version tag.
 -- Each version tag must be specific to a protocol version, though more than one version tag can
@@ -99,6 +110,7 @@ putVersionedGenesisData = case protocolVersion @pv of
     SP1 -> P1.putVersionedGenesisData . unGDP1
     SP2 -> P2.putVersionedGenesisData . unGDP2
     SP3 -> P3.putVersionedGenesisData . unGDP3
+    SP4 -> P4.putVersionedGenesisData . unGDP4
 
 -- |Generate the block hash of a genesis block with the given genesis data.
 -- This is based on the presumption that a block hash is computed from a byte string
@@ -108,6 +120,7 @@ genesisBlockHash = case protocolVersion @pv of
     SP1 -> P1.genesisBlockHash . unGDP1
     SP2 -> P2.genesisBlockHash . unGDP2
     SP3 -> P3.genesisBlockHash . unGDP3
+    SP4 -> P4.genesisBlockHash . unGDP4
 
 -- |A dependent pair of a protocol version and genesis data.
 data PVGenesisData = forall pv. IsProtocolVersion pv => PVGenesisData (GenesisData pv)
@@ -122,6 +135,7 @@ getPVGenesisData = do
     3 -> PVGenesisData . GDP1 <$> P1.getGenesisDataV3
     4 -> PVGenesisData . GDP2 <$> P2.getGenesisDataV4
     5 -> PVGenesisData . GDP3 <$> P3.getGenesisDataV5
+    6 -> PVGenesisData . GDP4 <$> P4.getGenesisDataV6
     n -> fail $ "Unsupported genesis version: " ++ show n
 
 -- |Serialize genesis data with a version tag. This is a helper function that

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -1,0 +1,107 @@
+-- |This module defines the genesis data fromat for the 'P4' protocol version.
+module Concordium.Genesis.Data.P4 where
+
+import Data.Serialize
+
+import Concordium.Common.Version
+import qualified Concordium.Crypto.SHA256 as Hash
+import Concordium.Genesis.Data.Base
+import Concordium.Genesis.Parameters
+import Concordium.Types
+
+-- |Genesis data for the P4 protocol version. The initial variant is here
+-- because it might be used in the future, at present it is not used.
+data GenesisDataP4
+    = GDP4Initial {
+      -- |The immutable genesis parameters.
+      genesisCore :: !CoreGenesisParameters,
+      -- |Serialized initial block state.
+      -- NB: This block state contains some of the same values as 'genesisCore', and they should match.
+      genesisInitialState :: !GenesisState
+    }
+    | GDP4Regenesis { genesisRegenesis :: !RegenesisData }
+    deriving (Eq, Show)
+
+_core :: GenesisDataP4 -> CoreGenesisParameters
+_core GDP4Initial{..} = genesisCore
+_core GDP4Regenesis{genesisRegenesis=RegenesisData{..}} = genesisCore
+
+instance BasicGenesisData GenesisDataP4 where
+    gdGenesisTime = genesisTime . _core
+    {-# INLINE gdGenesisTime #-}
+    gdSlotDuration = genesisSlotDuration . _core
+    {-# INLINE gdSlotDuration #-}
+    gdMaxBlockEnergy = genesisMaxBlockEnergy . _core
+    {-# INLINE gdMaxBlockEnergy #-}
+    gdFinalizationParameters = genesisFinalizationParameters . _core
+    {-# INLINE gdFinalizationParameters #-}
+    gdEpochLength = genesisEpochLength . _core
+    {-# INLINE gdEpochLength #-}
+
+-- |Deserialize genesis data in the V5 format.
+getGenesisDataV6 :: Get GenesisDataP4
+getGenesisDataV6 =
+    getWord8 >>= \case
+        0 -> do
+            genesisCore <- get
+            genesisInitialState <- get
+            return GDP4Initial{..}
+        1 -> do
+            genesisRegenesis <- getRegenesisData
+            return GDP4Regenesis{..}
+        _ -> fail "Unrecognized P4 genesis data type."
+
+-- |Serialize genesis data in the V6 format.
+putGenesisDataV6 :: Putter GenesisDataP4
+putGenesisDataV6 GDP4Initial{..} = do
+  putWord8 0
+  put genesisCore
+  put genesisInitialState
+putGenesisDataV6 GDP4Regenesis{..} = do
+  putWord8 1
+  putRegenesisData genesisRegenesis
+
+-- |Deserialize genesis data with a version tag. The expected version tag is 5
+-- and this must be distinct from version tags of other genesis data formats.
+getVersionedGenesisData :: Get GenesisDataP4
+getVersionedGenesisData =
+    getVersion >>= \case
+        6 -> getGenesisDataV6
+        n -> fail $ "Unsupported genesis data version for P4 genesis: " ++ show n
+
+-- |Serialize genesis data with a version tag.
+-- This will use the V5 format.
+putVersionedGenesisData :: Putter GenesisDataP4
+putVersionedGenesisData gd = do
+    putVersion 6
+    putGenesisDataV6 gd
+
+parametersToGenesisData :: GenesisParameters -> GenesisDataP4
+parametersToGenesisData = uncurry GDP4Initial . parametersToState
+
+-- |Compute the block hash of the genesis block with the given genesis data.
+-- Every block hash is derived from a message that begins with the block slot,
+-- which is 0 for genesis blocks.
+--
+-- NB: For the regenesis variant the serialized state is not included in the
+-- block hash, only the state hash is. This makes it possible to optimize the
+-- format in the future since it does not have protocol defined meaning. In
+-- contrast, for the initial P4 genesis the initial state is hashed as is.
+genesisBlockHash :: GenesisDataP4 -> BlockHash
+genesisBlockHash GDP4Initial{..} = BlockHash . Hash.hashLazy . runPutLazy $ do
+  put genesisSlot
+  put P4
+  putWord8 0 -- initial variant
+  put genesisCore
+  put genesisInitialState
+genesisBlockHash GDP4Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P4
+    putWord8 1 -- regenesis variant
+    -- NB: 'putRegenesisData' is not used since the state serialization does not go into computing the hash.
+    -- Only the state hash is used.
+    put genesisCore
+    put genesisFirstGenesis
+    put genesisPreviousGenesis
+    put genesisTerminalBlock
+    put genesisStateHash

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -1,4 +1,4 @@
--- |This module defines the genesis data fromat for the 'P4' protocol version.
+-- |This module defines the genesis data format for the 'P4' protocol version.
 module Concordium.Genesis.Data.P4 where
 
 import Data.Serialize
@@ -61,7 +61,7 @@ putGenesisDataV6 GDP4Regenesis{..} = do
   putWord8 1
   putRegenesisData genesisRegenesis
 
--- |Deserialize genesis data with a version tag. The expected version tag is 5
+-- |Deserialize genesis data with a version tag. The expected version tag is 6
 -- and this must be distinct from version tags of other genesis data formats.
 getVersionedGenesisData :: Get GenesisDataP4
 getVersionedGenesisData =
@@ -70,7 +70,7 @@ getVersionedGenesisData =
         n -> fail $ "Unsupported genesis data version for P4 genesis: " ++ show n
 
 -- |Serialize genesis data with a version tag.
--- This will use the V5 format.
+-- This will use the V6 format.
 putVersionedGenesisData :: Putter GenesisDataP4
 putVersionedGenesisData gd = do
     putVersion 6

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -38,7 +38,7 @@ instance BasicGenesisData GenesisDataP4 where
     gdEpochLength = genesisEpochLength . _core
     {-# INLINE gdEpochLength #-}
 
--- |Deserialize genesis data in the V5 format.
+-- |Deserialize genesis data in the V6 format.
 getGenesisDataV6 :: Get GenesisDataP4
 getGenesisDataV6 =
     getWord8 >>= \case

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -488,8 +488,7 @@ getPayload spv size = S.isolate (fromIntegral size) (S.bytesRead >>= go)
             n -> fail $ "unsupported transaction type '" ++ show n ++ "'"
         supportMemo = case spv of
           SP1 -> False
-          SP2 -> True
-          SP3 -> True
+          _ -> True
 
 -- |Builds a set from a list of ascending elements.
 -- Fails if the elements are not ordered or a duplicate is encountered.

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1264,6 +1264,7 @@ data FailureKind = InsufficientFunds -- ^The sender account's amount is not suff
                  | DuplicateAccountRegistrationID !IDTypes.CredentialRegistrationID
                  | InvalidUpdateTime -- ^The update timeout is later than the effective time
                  | ExceedsMaxCredentialDeployments -- ^The block contains more than the limit of credential deployments
+                 | InvalidPayloadSize -- ^Payload size exceeds maximum allowed for the protocol version.
       deriving(Eq, Show)
 
 data TxResult = TxValid !TransactionSummary | TxInvalid !FailureKind

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -379,6 +379,14 @@ getPayload spv size = S.isolate (fromIntegral size) (S.bytesRead >>= go)
   where go start = G.getWord8 >>= \case
             0 -> do
               dmMod <- S.get
+              -- in protocol 1..3 only version 0 modules were supported
+              -- and this was checked during serialization
+              let onlyVersion0 = case spv of
+                    SP1 -> True
+                    SP2 -> True
+                    SP3 -> True
+                    _ -> False
+              when (onlyVersion0 && Wasm.getVersion dmMod /= Wasm.V0) $ fail "Unsupported Wasm version"
               return DeployModule{..}
             1 -> do
               icAmount <- S.get

--- a/haskell-src/Concordium/Types/InvokeContract.hs
+++ b/haskell-src/Concordium/Types/InvokeContract.hs
@@ -1,0 +1,84 @@
+-- |Types related to simulating contract invocations.
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE NumericUnderscores #-}
+module Concordium.Types.InvokeContract
+  ( ContractContext(..)
+  , InvokeContractResult(..)
+  ) where
+
+import qualified Data.Aeson as AE
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.Text.Encoding as Text
+
+
+import qualified Concordium.Wasm as Wasm
+import Concordium.Types (Address, Amount, ContractAddress, Energy)
+import Concordium.Types.Execution (Event, RejectReason)
+
+data ContractContext = ContractContext {
+  -- |Invoker of the contract. If this is not supplied then the contract will be
+  -- invoked, by an account with address 0, no credentials and sufficient amount
+  -- of CCD to cover the transfer amount. If given, the relevant address must
+  -- exist in the blockstate.
+  ccInvoker :: !(Maybe Address),
+  -- |Contract to invoke.
+  ccContract :: !ContractAddress,
+  -- |Amount to invoke the contract with.
+  ccAmount :: !Amount,
+  -- |Which entrypoint to invoke.
+  ccMethod :: !Wasm.ReceiveName,
+  -- |And with what parameter.
+  ccParameter :: !Wasm.Parameter,
+  -- |And what amount of energy to allow for execution.
+  ccEnergy :: !Energy
+  }
+
+-- |This FromJSON instance defaults a number of values if they are not given
+-- - energy defaults to maximum possible
+-- - amount defaults to 0
+-- - parameter defaults to the empty one
+instance AE.FromJSON ContractContext where
+  parseJSON = AE.withObject "ContractContext" $ \obj -> do
+    ccInvoker <- obj AE..:? "invoker"
+    ccContract <- obj AE..: "contract"
+    ccAmount <- obj AE..:? "amount" AE..!= 0
+    ccMethod <- obj AE..: "method"
+    ccParameter <- obj AE..:? "parameter" AE..!= Wasm.emptyParameter
+    ccEnergy <- obj AE..:? "energy" AE..!= 10_000_000
+    return ContractContext{..}
+
+data InvokeContractResult =
+  -- |Contract execution failed for the given reason.
+  Failure {
+      rcrReason :: !RejectReason,
+      -- |Energy used by the execution.
+      rcrUsedEnergy :: !Energy
+      }
+  -- |Contract execution succeeded.
+  | Success {
+      -- |If invoking a V0 contract this is Nothing, otherwise it is
+      -- the return value produced by the call.
+      rcrReturnValue :: !(Maybe BS.ByteString),
+      -- |Events produced by contract execution.
+      rcrEvents :: ![Event],
+      -- |Energy used by the execution.
+      rcrUsedEnergy :: !Energy
+      }
+
+instance AE.ToJSON InvokeContractResult where
+  toJSON Failure{..} = AE.object [
+    "tag" AE..= AE.String "failure",
+    "reason" AE..= rcrReason,
+    "usedEnergy" AE..= rcrUsedEnergy
+    ]
+  toJSON Success{..} = AE.object [
+    "tag" AE..= AE.String "success",
+    ("returnValue",
+     case rcrReturnValue of
+      Nothing -> AE.Null
+      Just rv -> AE.String . Text.decodeUtf8 . BS16.encode $ rv),
+    "events" AE..= rcrEvents,
+    "usedEnergy" AE..= rcrUsedEnergy
+    ]

--- a/haskell-src/Concordium/Types/InvokeContract.hs
+++ b/haskell-src/Concordium/Types/InvokeContract.hs
@@ -48,7 +48,7 @@ data ContractContext = ContractContext {
   }
 
 -- |This FromJSON instance defaults a number of values if they are not given
--- - energy defaults to maximum possible
+-- - energy defaults to 'defaultInvokeEnergy'
 -- - amount defaults to 0
 -- - parameter defaults to the empty one
 instance AE.FromJSON ContractContext where

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE KindSignatures #-}
 
 -- |This module contains the 'ProtocolVersion' datatype, which enumerates the
@@ -28,6 +29,7 @@ data ProtocolVersion
     = P1
     | P2
     | P3
+    | P4
     deriving (Eq, Show, Ord)
 
 -- |The singleton type associated with 'ProtocolVersion'.
@@ -37,16 +39,19 @@ data SProtocolVersion (pv :: ProtocolVersion) where
     SP1 :: SProtocolVersion 'P1
     SP2 :: SProtocolVersion 'P2
     SP3 :: SProtocolVersion 'P3
+    SP4 :: SProtocolVersion 'P4
 
 protocolVersionToWord64 :: ProtocolVersion -> Word64
 protocolVersionToWord64 P1 = 1
 protocolVersionToWord64 P2 = 2
 protocolVersionToWord64 P3 = 3
+protocolVersionToWord64 P4 = 4
 
 protocolVersionFromWord64 :: MonadFail m => Word64 -> m ProtocolVersion
 protocolVersionFromWord64 1 = return P1
 protocolVersionFromWord64 2 = return P2
 protocolVersionFromWord64 3 = return P3
+protocolVersionFromWord64 4 = return P4
 protocolVersionFromWord64 v = fail $ "Unknown protocol version: " ++ show v
 
 instance Serialize ProtocolVersion where
@@ -80,11 +85,16 @@ instance IsProtocolVersion 'P3 where
     protocolVersion = SP3
     {-# INLINE protocolVersion #-}
 
+instance IsProtocolVersion 'P4 where
+    protocolVersion = SP4
+    {-# INLINE protocolVersion #-}
+
 -- |Demote an 'SProtocolVersion' to a 'ProtocolVersion'.
 demoteProtocolVersion :: SProtocolVersion pv -> ProtocolVersion
 demoteProtocolVersion SP1 = P1
 demoteProtocolVersion SP2 = P2
 demoteProtocolVersion SP3 = P3
+demoteProtocolVersion SP4 = P4
 
 -- |An existentially quantified protocol version.
 data SomeProtocolVersion where
@@ -96,3 +106,4 @@ promoteProtocolVersion :: ProtocolVersion -> SomeProtocolVersion
 promoteProtocolVersion P1 = SomeProtocolVersion SP1
 promoteProtocolVersion P2 = SomeProtocolVersion SP2
 promoteProtocolVersion P3 = SomeProtocolVersion SP3
+promoteProtocolVersion P4 = SomeProtocolVersion SP4

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -163,7 +163,7 @@ instance Serialize WasmModule where
 
   get = do
     wasmVersion <- getWord32be
-    unless (wasmVersion == 0) $ fail "Unsupported Wasm module version."
+    unless (wasmVersion <= 1) $ fail $ "Unsupported Wasm module version: " ++ show wasmVersion
     wasmSource <- get
     return WasmModule{..}
 

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -109,7 +109,6 @@ import Data.Hashable
 import Data.Int (Int32)
 import qualified Data.Map.Strict as Map
 import Data.Serialize
-import qualified Data.Set as Set
 import qualified Data.Text as Text
 import Data.Text(Text)
 import qualified Data.Text.Encoding as Text

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -49,8 +49,8 @@ module Concordium.Wasm (
   unsafeUseModuleSourceAsCStringLen,
   moduleSourceLength,
   WasmModule(..),
-  getModuleSource,
-  getVersion,
+  wasmVersion,
+  wasmSource,
   WasmModuleV(..),
   getModuleRef,
   WasmVersion(..),
@@ -70,7 +70,7 @@ module Concordium.Wasm (
   contractAndFunctionName,
   EntrypointName(..),
   isValidEntrypointName,
-  makeReceiveName,
+  uncheckedMakeReceiveName,
   Parameter(..),
   emptyParameter,
 
@@ -144,17 +144,25 @@ import Concordium.Utils.Serialization
 data WasmVersion = V0 | V1
   deriving(Eq, Show)
 
+-- |Map the WasmVersion to a 32-bit word for serialization.
 wasmVersionToWord :: WasmVersion -> Word32
 wasmVersionToWord V0 = 0
 wasmVersionToWord V1 = 1
 
+-- |Converse to 'wasmVersionToWord'.
+wordToWasmVersion :: Word32 -> Maybe WasmVersion
+wordToWasmVersion 0 = Just V0
+wordToWasmVersion 1 = Just V1
+wordToWasmVersion _ = Nothing
+
 instance Serialize WasmVersion where
   put = putWord32be . wasmVersionToWord
 
-  get = getWord32be >>= \case
-    0 -> return V0
-    1 -> return V1
-    n -> fail $ "Unrecognized Wasm version " ++ show n
+  get = do
+    w <- getWord32be
+    case wordToWasmVersion w of
+      Just wv -> return wv
+      Nothing -> fail $ "Unrecognized Wasm version number " ++ show w
 
 instance AE.ToJSON WasmVersion where
   toJSON = AE.toJSON . wasmVersionToWord
@@ -162,10 +170,9 @@ instance AE.ToJSON WasmVersion where
 instance AE.FromJSON WasmVersion where
   parseJSON v = do
     word <- AE.parseJSON v
-    case word :: Word32 of
-      0 -> return V0
-      1 -> return V1
-      _ -> fail $ "Unsupported Wasm version " ++ show word
+    case wordToWasmVersion word of
+      Just wv -> return wv
+      Nothing -> fail $ "Unsupported Wasm version " ++ show word
 
 -- |These type aliases are provided for convenience to avoid having to enable
 -- DataKinds everywhere we need wasm version.
@@ -213,27 +220,15 @@ unsafeUseModuleSourceAsCStringLen = unsafeUseAsCStringLen . moduleSource
 moduleSourceLength :: ModuleSource v -> Word64
 moduleSourceLength = fromIntegral . BS.length . moduleSource
 
--- |Get the WasmVersion of a WasmModule.
-getVersion :: WasmModule -> WasmVersion
-getVersion = \case
-  WasmModuleV0 _ -> V0
-  WasmModuleV1 _ -> V1
-
--- |Get the raw ModuleSource from a WasmModule.
-getModuleSource :: WasmModule -> ByteString
-getModuleSource = \case
-  WasmModuleV0 wmv -> moduleSource . wmvSource $ wmv
-  WasmModuleV1 wmv -> moduleSource . wmvSource $ wmv
-
 -- |A versioned module source. The serialization instance of this type, in contrast to ModuleSource,
 -- records the version that was used.
 newtype WasmModuleV (v :: WasmVersion) = WasmModuleV { wmvSource :: ModuleSource v }
     deriving (Eq, Show)
 
 instance IsWasmVersion v => Serialize (WasmModuleV v) where
-  put (WasmModuleV wasmSource) = case getWasmVersion @v of
-    SV0 -> put V0 <> put wasmSource
-    SV1 -> put V1 <> put wasmSource
+  put (WasmModuleV ws) = case getWasmVersion @v of
+    SV0 -> put V0 <> put ws
+    SV1 -> put V1 <> put ws
 
   get = case getWasmVersion @v of
     SV0 -> get >>= \case
@@ -254,11 +249,23 @@ getModuleRef wm = case getWasmVersion @v of
   SV0 -> ModuleRef (getHash wm)
   SV1 -> ModuleRef (getHash wm)
 
+-- |Get the WasmVersion of a WasmModule.
+wasmVersion :: WasmModule -> WasmVersion
+wasmVersion = \case
+  WasmModuleV0 _ -> V0
+  WasmModuleV1 _ -> V1
+
+-- |Get the raw ModuleSource from a WasmModule.
+wasmSource :: WasmModule -> ByteString
+wasmSource = \case
+  WasmModuleV0 wmv -> moduleSource . wmvSource $ wmv
+  WasmModuleV1 wmv -> moduleSource . wmvSource $ wmv
+
 instance Serialize WasmModule where
-  put (WasmModuleV0 wasmSource) =
-    put wasmSource
-  put (WasmModuleV1 wasmSource) =
-    put wasmSource
+  put (WasmModuleV0 ws) =
+    put ws
+  put (WasmModuleV1 ws) =
+    put ws
 
   get = do
     get >>= \case
@@ -343,13 +350,16 @@ newtype EntrypointName = EntrypointName { entrypointName :: Text }
 -- |Check whether the given text is a valid entrypoint name.
 -- This is the case if
 --
--- * length is <= maxFuncNameSize
+-- * length is < maxFuncNameSize
 -- * all characters are valid ascii characters in alphanumeric or punctuation classes
+-- 
+-- Note that these are necessary, but not sufficient, conditions for this
+-- entrypoint name to be an entrypoint name of any contract.
 isValidEntrypointName :: Text -> Bool
 isValidEntrypointName proposal =
   -- The limit is specified in bytes, but Text.length returns the number of chars.
   -- This is not a problem, as we only allow ASCII.
-  let hasValidLength = Text.length proposal <= maxFuncNameSize
+  let hasValidLength = Text.length proposal < maxFuncNameSize
       hasValidCharacters = Text.all (\c -> isAscii c && (isAlphaNum c || isPunctuation c)) proposal
   in hasValidLength && hasValidCharacters
 
@@ -363,9 +373,10 @@ instance Serialize EntrypointName where
               | otherwise -> fail $ "Not a valid entrypoint name: " ++ Text.unpack t
 
 
--- |Make a receive name from an init name and an entrypoint name.
-makeReceiveName :: InitName -> EntrypointName -> ReceiveName
-makeReceiveName iName EntrypointName{..} = ReceiveName (initContractName iName <> "." <> entrypointName)
+-- |Make a receive name from an init name and an entrypoint name. This does not check that the
+-- resulting receive name is valid. It could be too long.
+uncheckedMakeReceiveName :: InitName -> EntrypointName -> ReceiveName
+uncheckedMakeReceiveName iName EntrypointName{..} = ReceiveName (initContractName iName <> "." <> entrypointName)
 
 -- |Extract the contract name from the init function name.
 initContractName :: InitName -> Text

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -49,6 +49,8 @@ module Concordium.Wasm (
   unsafeUseModuleSourceAsCStringLen,
   moduleSourceLength,
   WasmModule(..),
+  getModuleSource,
+  getVersion,
   WasmModuleV(..),
   getModuleRef,
   WasmVersion(..),
@@ -196,6 +198,18 @@ unsafeUseModuleSourceAsCStringLen = unsafeUseAsCStringLen . moduleSource
 
 moduleSourceLength :: ModuleSource v -> Word64
 moduleSourceLength = fromIntegral . BS.length . moduleSource
+
+-- |Get the WasmVersion of a WasmModule.
+getVersion :: WasmModule -> WasmVersion
+getVersion = \case
+  WasmModuleV0 _ -> V0
+  WasmModuleV1 _ -> V1
+
+-- |Get the raw ModuleSource from a WasmModule.
+getModuleSource :: WasmModule -> ByteString
+getModuleSource = \case
+  WasmModuleV0 wmv -> moduleSource . wmvSource $ wmv
+  WasmModuleV1 wmv -> moduleSource . wmvSource $ wmv
 
 -- |A versioned module source. The serialization instance of this type, in contrast to ModuleSource,
 -- records the version that was used.

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -61,6 +61,7 @@ module Concordium.Wasm (
   isValidReceiveName,
   contractAndFunctionName,
   Parameter(..),
+  emptyParameter,
 
   -- *** Contract state
   ContractState(..),
@@ -257,6 +258,10 @@ instance Serialize ReceiveName where
 newtype Parameter = Parameter { parameter :: ShortByteString }
     deriving(Eq, Show)
     deriving(AE.ToJSON, AE.FromJSON) via ByteStringHex
+
+-- |Parameter of size 0.
+emptyParameter :: Parameter
+emptyParameter = Parameter BSS.empty
 
 instance Serialize Parameter where
   put = putShortByteStringWord16 . parameter

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DerivingVia, GADTs, ScopedTypeVariables, OverloadedStrings #-}
+{-# LANGUAGE DerivingVia, GADTs, ScopedTypeVariables, OverloadedStrings, DataKinds, KindSignatures, TypeApplications #-}
 {-|
 Module      : Concordium.Wasm
 Description : Types used in the smart contract framework.
@@ -35,7 +35,8 @@ execution is successful, then an 'ActionsTree' is returned together with the new
 module Concordium.Wasm (
   -- * Constants
   maxParameterLen,
-  maxWasmModuleSize,
+  maxWasmModuleSizeV0,
+  maxWasmModuleSizeV1,
 
   -- * Modules
   -- ** Binary module
@@ -48,7 +49,12 @@ module Concordium.Wasm (
   unsafeUseModuleSourceAsCStringLen,
   moduleSourceLength,
   WasmModule(..),
+  WasmModuleV(..),
   getModuleRef,
+  WasmVersion(..),
+  IsWasmVersion(..),
+  SWasmVersion(..),
+  V0, V1,
 
   -- *** Methods
   --
@@ -131,49 +137,118 @@ import Concordium.Utils.Serialization
 
 --------------------------------------------------------------------------------
 
+-- |Supported versions of Wasm modules. This version defines available host
+-- functions, their semantics, and limitations of contracts.
+data WasmVersion = V0 | V1
+  deriving(Eq, Show)
+
+instance Serialize WasmVersion where
+  put V0 = putWord32be 0
+  put V1 = putWord32be 1
+
+  get = getWord32be >>= \case
+    0 -> return V0
+    1 -> return V1
+    n -> fail $ "Unrecognized Wasm version " ++ show n
+
+-- |These type aliases are provided for convenience to avoid having to enable
+-- DataKinds everywhere we need wasm version.
+type V0 = 'V0
+type V1 = 'V1
+
+-- |Boilerplate to allow using the supplied version type parameter as a term.
+data SWasmVersion (v :: WasmVersion) where
+  SV0 :: SWasmVersion 'V0
+  SV1 :: SWasmVersion 'V1
+
+-- A typeclass that allows to pass SWasmVersion implicitly to computations via a
+-- constraint.
+class IsWasmVersion (v :: WasmVersion) where
+  getWasmVersion :: SWasmVersion v
+
+instance IsWasmVersion 'V0 where
+  getWasmVersion = SV0
+
+instance IsWasmVersion 'V1 where
+  getWasmVersion = SV1
+
+
 -- | The source of a contract in binary wasm format.
-newtype ModuleSource = ModuleSource { moduleSource :: ByteString }
+newtype ModuleSource (v :: WasmVersion) = ModuleSource { moduleSource :: ByteString }
   deriving (Eq, Show)
 
-instance Serialize ModuleSource where
+instance Serialize (ModuleSource V0)  where
   get = do
     len <- getWord32be
-    unless (len <= maxWasmModuleSize) $ fail "Maximum module size exceeded."
+    unless (len <= maxWasmModuleSizeV0) $ fail "Maximum module size exceeded."
     ModuleSource <$> getByteString (fromIntegral len)
   put = putByteStringWord32 . moduleSource
 
-unsafeUseModuleSourceAsCStringLen :: ModuleSource -> (CStringLen -> IO a) -> IO a
+instance Serialize (ModuleSource V1)  where
+  get = do
+    len <- getWord32be
+    unless (len <= maxWasmModuleSizeV1) $ fail "Maximum module size exceeded."
+    ModuleSource <$> getByteString (fromIntegral len)
+  put = putByteStringWord32 . moduleSource
+
+unsafeUseModuleSourceAsCStringLen :: ModuleSource v -> (CStringLen -> IO a) -> IO a
 unsafeUseModuleSourceAsCStringLen = unsafeUseAsCStringLen . moduleSource
 
-moduleSourceLength :: ModuleSource -> Word64
+moduleSourceLength :: ModuleSource v -> Word64
 moduleSourceLength = fromIntegral . BS.length . moduleSource
 
--- |Web assembly module in binary format.
-data WasmModule = WasmModule {
-  -- |Version of the Wasm standard and on-chain API this module corresponds to.
-  wasmVersion :: !Word32,
-  -- |Source in binary wasm format.
-  wasmSource :: !ModuleSource
-  } deriving(Eq, Show)
+-- |A versioned module source. The serialization instance of this type, in contrast to ModuleSource,
+-- records the version that was used.
+newtype WasmModuleV (v :: WasmVersion) = WasmModuleV { wmvSource :: ModuleSource v }
+    deriving (Eq, Show)
 
-getModuleRef :: WasmModule -> ModuleRef
-getModuleRef wm = ModuleRef (getHash wm)
+instance IsWasmVersion v => Serialize (WasmModuleV v) where
+  put (WasmModuleV wasmSource) = case getWasmVersion @v of
+    SV0 -> put V0 <> put wasmSource
+    SV1 -> put V1 <> put wasmSource
+
+  get = case getWasmVersion @v of
+    SV0 -> get >>= \case
+      V0 -> WasmModuleV <$> get
+      _ -> fail "Expecting a V0 module."
+    SV1 -> get >>= \case
+      V1 -> WasmModuleV <$> get
+      _ -> fail "Expecting a V1 module."
+
+-- |A module of either version 0 or 1.
+data WasmModule =
+  WasmModuleV0 (WasmModuleV V0)
+  | WasmModuleV1 (WasmModuleV V1)
+  deriving(Eq, Show)
+
+getModuleRef :: forall v . IsWasmVersion v => WasmModuleV v -> ModuleRef
+getModuleRef wm = case getWasmVersion @v of
+  SV0 -> ModuleRef (getHash wm)
+  SV1 -> ModuleRef (getHash wm)
 
 instance Serialize WasmModule where
-  put WasmModule{..} =
-    putWord32be wasmVersion <>
+  put (WasmModuleV0 wasmSource) =
+    put wasmSource
+  put (WasmModuleV1 wasmSource) =
     put wasmSource
 
   get = do
-    wasmVersion <- getWord32be
-    unless (wasmVersion <= 1) $ fail $ "Unsupported Wasm module version: " ++ show wasmVersion
-    wasmSource <- get
-    return WasmModule{..}
+    get >>= \case
+      V0 -> WasmModuleV0 . WasmModuleV <$> get
+      V1 -> WasmModuleV1 . WasmModuleV <$> get
 
 instance HashableTo H.Hash WasmModule where
-  -- Hash the serialization directly, perhaps this needs to be revisited in the
-  -- future.
-  getHash wm = H.hash (encode wm)
+  -- Hash the serialization directly.
+  getHash (WasmModuleV0 wm) = getHash wm
+  getHash (WasmModuleV1 wm) = getHash wm
+
+instance HashableTo H.Hash (WasmModuleV V0) where
+  -- Hash the serialization directly.
+  getHash (WasmModuleV wm) = H.hash (encode V0 <> encode wm)
+
+instance HashableTo H.Hash (WasmModuleV V1) where
+  -- Hash the serialization directly.
+  getHash (WasmModuleV wm) = H.hash (encode V1 <> encode wm)
 
 --------------------------------------------------------------------------------
 

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -116,7 +116,8 @@ genPayload = oneof [genDeployModule,
           n <- choose (0,1000)
           BS.pack <$> vector n
 
-        genDeployModule = DeployModule <$> (WasmModule 0 . ModuleSource <$> genByteString)
+        genDeployModule = oneof [DeployModule <$> (WasmModuleV0 . WasmModuleV . ModuleSource <$> genByteString),
+                                 DeployModule <$> (WasmModuleV1 . WasmModuleV . ModuleSource <$> genByteString)]
 
         genInit = do
           icAmount <- Amount <$> arbitrary

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -85,21 +85,22 @@ genParameter = do
   n <- choose (0,1000)
   Parameter . BSS.pack <$> vector n
 
-genPayload :: Gen Payload
-genPayload = oneof [genDeployModule,
-                    genInit,
-                    genUpdate,
-                    genTransfer,
-                    genCredentialUpdate,
-                    genAddBaker,
-                    genRemoveBaker,
-                    genUpdateBakerStake,
-                    genUpdateBakerRestakeEarnings,
-                    genUpdateBakerKeys,
-                    genUpdateCredentialKeys,
-                    genTransferToEncrypted,
-                    genRegisterData
-                    ]
+genPayload :: ProtocolVersion -> Gen Payload
+genPayload pv = oneof [
+  genDeployModule,
+  genInit,
+  genUpdate,
+  genTransfer,
+  genCredentialUpdate,
+  genAddBaker,
+  genRemoveBaker,
+  genUpdateBakerStake,
+  genUpdateBakerRestakeEarnings,
+  genUpdateBakerKeys,
+  genUpdateCredentialKeys,
+  genTransferToEncrypted,
+  genRegisterData
+  ]
   where
         genCredentialUpdate = do
           maxNumCredentials <- choose (0,255)
@@ -116,8 +117,12 @@ genPayload = oneof [genDeployModule,
           n <- choose (0,1000)
           BS.pack <$> vector n
 
-        genDeployModule = oneof [DeployModule <$> (WasmModuleV0 . WasmModuleV . ModuleSource <$> genByteString),
-                                 DeployModule <$> (WasmModuleV1 . WasmModuleV . ModuleSource <$> genByteString)]
+        genDeployModule =
+          let genV0 = DeployModule <$> (WasmModuleV0 . WasmModuleV . ModuleSource <$> genByteString)
+              genV1 = DeployModule <$> (WasmModuleV1 . WasmModuleV . ModuleSource <$> genByteString)
+          in if pv <= P3 then -- protocol versions <= 3 only allow version 0 Wasm modules.
+               genV0
+             else oneof [genV0, genV1]
 
         genInit = do
           icAmount <- Amount <$> arbitrary
@@ -251,7 +256,7 @@ testSerializeEncryptedTransfer = property $ \gen gen1 seed1 seed2 -> forAll genA
   let agg = makeAggregatedDecryptedAmount (encryptAmountZeroRandomness globalContext gen) gen (EncryptedAmountAggIndex gen1)
   let amount = gen `div` 2
   Just eatd <- run (makeEncryptedAmountTransferData globalContext (_elgamalPublicKey public) private agg amount)
-  return (checkPayload (EncryptedAmountTransfer addr eatd))
+  return (checkPayload SP1 (EncryptedAmountTransfer addr eatd))
 
 testSecToPubTransfer :: Property
 testSecToPubTransfer = property $ \gen gen1 seed1 -> monadicIO $ do
@@ -259,7 +264,7 @@ testSecToPubTransfer = property $ \gen gen1 seed1 -> monadicIO $ do
   let agg = makeAggregatedDecryptedAmount (encryptAmountZeroRandomness globalContext gen) gen (EncryptedAmountAggIndex gen1)
   let amount = gen `div` 2
   Just eatd <- run (makeSecToPubAmountTransferData globalContext private agg amount)
-  return (checkPayload (TransferToPublic eatd))
+  return (checkPayload SP1 (TransferToPublic eatd))
 
 
 groupIntoSize :: Int64 -> [Char]
@@ -271,21 +276,23 @@ groupIntoSize s =
               ub = 10^(nd+1) :: Int
           in show lb ++ " -- " ++ show ub ++ "kB"
 
-checkPayload :: Payload -> Property
-checkPayload e = let bs = S.runPut $ putPayload e
-                 in case S.runGet (getPayload SP1 (fromIntegral (BS.length bs))) bs of
-                      Left err -> counterexample err False
-                      Right e' -> label (groupIntoSize (fromIntegral (BS.length bs))) $ e === e'
+checkPayload :: SProtocolVersion pv -> Payload -> Property
+checkPayload spv e = let bs = S.runPut $ putPayload e
+                     in case S.runGet (getPayload spv (fromIntegral (BS.length bs))) bs of
+                          Left err -> counterexample err False
+                          Right e' -> label (groupIntoSize (fromIntegral (BS.length bs))) $ e === e'
 
 tests :: Spec
 tests = do
   describe "Payload serialization tests" $ do
-    test 25 1000
-    test 50 500
+    test SP1 25 1000
+    test SP2 50 500
+    test SP3 50 500
+    test SP4 50 500
   describe "Encrypted transfer payloads" $ do
     specify "Encrypted transfer" $ testSerializeEncryptedTransfer
     specify "Transfer to public" $ testSecToPubTransfer
- where test size num =
+ where test spv size num =
          modifyMaxSuccess (const num) $
-           specify ("Payload serialization with size = " ++ show size ++ ":") $
-           forAll (resize size $ genPayload) checkPayload
+           specify ("Payload serialization for protocol " ++ show (demoteProtocolVersion spv) ++ " with size = " ++ show size ++ ":") $
+           forAll (resize size (genPayload (demoteProtocolVersion spv))) (checkPayload spv)

--- a/haskell-tests/Types/TransactionGen.hs
+++ b/haskell-tests/Types/TransactionGen.hs
@@ -3,6 +3,7 @@ module Types.TransactionGen where
 
 import Test.QuickCheck
 
+import Concordium.Types.ProtocolVersion
 import Concordium.Types.Transactions
 import Concordium.Crypto.SignatureScheme
 import Concordium.Crypto.FFIDataTypes
@@ -44,7 +45,7 @@ genAccountAddress = AccountAddress . FBS.pack <$> vector accountAddressSize
 genTransactionHeader :: Gen TransactionHeader
 genTransactionHeader = do
   thSender <- genAccountAddress
-  thPayloadSize <- PayloadSize <$> choose (0, maxPayloadSize)
+  thPayloadSize <- PayloadSize <$> choose (0, maxPayloadSize SP4)
   thNonce <- Nonce <$> arbitrary
   thEnergyAmount <- Energy <$> arbitrary
   thExpiry <- TransactionTime <$> arbitrary

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -86,8 +86,8 @@ instance Arbitrary Event where
     arbitrary =
         oneof
             [ ModuleDeployed <$> genModuleRef,
-              ContractInitialized <$> genModuleRef <*> genCAddress <*> genAmount <*> genInitName <*> listOf genContractEvent,
-              Updated <$> genCAddress <*> genAddress <*> genAmount <*> genParameter <*> genReceiveName <*> listOf genContractEvent,
+              ContractInitialized <$> genModuleRef <*> genCAddress <*> genAmount <*> genInitName <*> genWasmVersion <*> listOf genContractEvent,
+              Updated <$> genCAddress <*> genAddress <*> genAmount <*> genParameter <*> genReceiveName <*> genWasmVersion <*> listOf genContractEvent,
               Transferred <$> genAddress <*> genAmount <*> genAddress,
               AccountCreated <$> genAccountAddress,
               CredentialDeployed <$> genCredentialId <*> genAccountAddress,
@@ -106,9 +106,12 @@ instance Arbitrary Event where
               genTransferredWithSchedule,
               genCredentialsUpdated,
               DataRegistered <$> genRegisteredData,
-              TransferMemo <$> genMemo
+              TransferMemo <$> genMemo,
+              Interrupted <$> genCAddress <*> listOf genContractEvent,
+              Resumed <$> genCAddress <*> arbitrary
             ]
       where
+        genWasmVersion = elements [Wasm.V0, Wasm.V1]
         genBakerAdded = do
             ebaBakerId <- genBakerId
             ebaAccount <- genAccountAddress

--- a/rust-bins/docs/user-cli.md
+++ b/rust-bins/docs/user-cli.md
@@ -17,7 +17,7 @@ To generate a request to the identity provider together with some auxiliary data
 ```console
 user_cli generate-request --cryptographic-parameters cryptographic-parameters.json \
                           --ars ars.json \
-                          --ip-info ip-info.json
+                          --ip-info ip-info.json \
                           --initial-keys-out initial-keys.json \ # keys of the initial account together with its address.
                           --id-use-data-out id-use-data.json \ # data that enables use of the identity object
                           --request-out request.json # request to send to the identity provider
@@ -40,7 +40,7 @@ To create a credential use the following command.
 ```console
 user_cli create-credential --id-use-data id-use-data.json \
                            --id-object id-object.json \
-                           --keys-out account-keys.json
+                           --keys-out account-keys.json \
                            --credential-out credential.json
 ```
 You will have to select whether to reveal the LEI, which was optional when creating the identity object. Use the space key to select and deselect list entries. 


### PR DESCRIPTION
## Purpose

Auxiliary types to support V1 version of smart contracts with synchronous contract calls.

## Changes

- Introduce an "Entrypoint" type analogous to contract name and receive name. This is used when invoking a V1 contract since the name of the contract is already known from the address.
- Introduce new events that can result from contract execution.
- P4 boilerplate. This will have to change by the time of release of P4 node, but is needed to get any testing done of the features.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
