### PR TITLE
When generating account keys, output them in a format compatible with genesis.

### DIFF
--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -865,8 +865,8 @@ fn handle_create_credential(cc: CreateCredential) {
         let ki = cc.key_index.map_or(KeyIndex(0), KeyIndex);
         let mut credentials = BTreeMap::new();
         let mut randomness = BTreeMap::new();
-        // NB: We insert the reference to the credential here so as to avoid cloning
-        // (which is not implemented for the type)
+        // we insert a credential without proofs, to be compatible with the genesis
+        // tool, and concordium-client import.
         credentials.insert(ki, cdi_no_proofs);
         randomness.insert(ki, &commitments_randomness);
         (Versioned::new(VERSION_0, credentials), randomness)

--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -855,6 +855,10 @@ fn handle_create_credential(cc: CreateCredential) {
 
     let address = AccountAddress::new(&cdi.values.cred_id);
 
+    let cdi_no_proofs = AccountCredentialWithoutProofs::Normal {
+        cdv:         cdi.values.clone(),
+        commitments: cdi.proofs.id_proofs.commitments.clone(),
+    };
     let cdi = AccountCredential::Normal { cdi };
 
     let (versioned_credentials, randomness_map) = {
@@ -863,7 +867,7 @@ fn handle_create_credential(cc: CreateCredential) {
         let mut randomness = BTreeMap::new();
         // NB: We insert the reference to the credential here so as to avoid cloning
         // (which is not implemented for the type)
-        credentials.insert(ki, &cdi);
+        credentials.insert(ki, cdi_no_proofs);
         randomness.insert(ki, &commitments_randomness);
         (Versioned::new(VERSION_0, credentials), randomness)
     };


### PR DESCRIPTION
## Purpose

Consistency of outputss between genesis tool and the id-client.

## Changes

Output credential with commitments only, without proofs. Note that the credential is output separately, so there is no loss of information.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.