### PR TITLE
Functions for checking public credentials in regard to a `hash`

### DIFF
--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -155,8 +155,18 @@ data AccountInformation = AccountInformation {
   aiThreshold :: !AccountThreshold 
 } deriving(Eq, Show, Ord)
 
+
+-- |SHA256 hashing instance for `AccountInformation`
+-- Security considerations: It is crucial to use a cryptographic secure hash instance for `AccountInformation`.
+-- The caller must be able to use the resulting hash in security critical application code.
+-- Currently the computed hash is used to short circuit the signature verification check of transactions. 
 instance HashableTo SHA256.Hash AccountInformation where
   getHash = SHA256.hash . encode
+
+-- |Check that the account information matches the given SHA256 hash.
+-- Note. See above for more information.
+matchesAccountInformation :: AccountInformation -> SHA256.Hash -> Bool
+matchesAccountInformation ai h = getHash ai == h
 
 getCredentialPublicKeys :: AccountCredential -> CredentialPublicKeys
 getCredentialPublicKeys (InitialAC icdv) = icdvAccount icdv

--- a/haskell-src/Concordium/Types/Updates.hs
+++ b/haskell-src/Concordium/Types/Updates.hs
@@ -631,8 +631,17 @@ instance Serialize UpdateKeysCollection where
     put level2Keys
   get = UpdateKeysCollection <$> get <*> get <*> get
 
+-- |SHA256 hashing instance for `UpdateKeysCollection`
+-- Security considerations: It is crucial to use a cryptographic secure hash instance for `UpdateKeysCollection`.
+-- The caller must be able to use the resulting hash in security critical application code.
+-- Currently the computed hash is used to short circuit the signature verification check of transactions. 
 instance HashableTo SHA256.Hash UpdateKeysCollection where
   getHash = SHA256.hash . encode
+
+-- |Check that the update keys collection matches the given SHA256 hash.
+-- Note. See above for more information.
+matchesUpdateKeysCollection :: UpdateKeysCollection -> SHA256.Hash -> Bool
+matchesUpdateKeysCollection ukc h = getHash ukc == h  
 
 instance Monad m => MHashableTo m SHA256.Hash UpdateKeysCollection where
 


### PR DESCRIPTION
## Purpose

As part of https://github.com/Concordium/concordium-node/pull/217 the `Scheduler` now relies on checking that the hashes of `AccountInformation` and `UpdateKeysCollection` matches the current ones on the chain.

This is security critical code thus the two checks deserved being their own functions (with appropriate commentary) instead of inline checks. 


## Changes

Introduced `matchesAccountInformation` and `matchesUpdateKeysCollection` functions for checking if a given `AccountInformation` matches the given `hash` and vice versa for `UpdateKeysCollection`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

