### PR TITLE
Change android built to use rust channel nightly and install tollchains

### DIFF
--- a/mobile_wallet/scripts/android.Jenkinsfile
+++ b/mobile_wallet/scripts/android.Jenkinsfile
@@ -29,6 +29,10 @@ pipeline {
                     # Move into folder
                     cd mobile_wallet
 
+                    # Setup rust to use nightly channel
+                    rustup default nightly
+                    rustup target add aarch64-linux-android armv7-linux-androideabi i686-linux-android x86_64-linux-android
+
                     # Build android
                     min_ver=29
                     cargo ndk --target aarch64-linux-android --platform ${min_ver} -- build --release


### PR DESCRIPTION
## Purpose

Fix the Android build, which was failing with 
    
    error: failed to parse manifest at `/root/.cargo/registry/src/github.com-1ecc6299db9ec823/zeroize_derive-1.2.0/Cargo.toml`
    
    Caused by:
      feature `resolver` is required
    
    this Cargo does not support nightly features, but if you
    switch to nightly channel you can add
    `cargo-features = ["resolver"]` to enable this feature

## Changes

Changed the android build to use the rust nightly channel, and reinstalled the required toolchains from that.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

