### PR TITLE
Fix a race condition in the identity provider service.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "identity-provider-service"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/identity-provider-service/Cargo.toml
+++ b/identity-provider-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-provider-service"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"


### PR DESCRIPTION
`remove_file` returns an error if the file does not exist. This, in combination with not checking whether a submission is still pending, can lead to a panic.

## Purpose

Fix a panic due to concurrent requests.

## Changes

Check whether the submission has already been marked finalized/deleted before attempting to delete it again.
Do this in the scope of an acquired lock.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.