### PR TITLE
Adds AccountIdentifier type.

### DIFF
--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -60,6 +60,7 @@ module Concordium.Types (
   minNonce,
   AccountVerificationKey,
   AccountIndex(..),
+  AccountIdentifier(..),
 
   -- * Smart contracts
   ModuleRef(..),
@@ -506,6 +507,15 @@ newtype VoterPower = VoterPower AmountUnit
 -- 'BakerId'.
 newtype AccountIndex = AccountIndex Word64
     deriving (Eq, Ord, Num, Enum, Bounded, Real, Hashable, Read, Show, Integral, FromJSON, ToJSON, Bits) via Word64
+
+-- |The identifier associated with an account.
+data AccountIdentifier =
+  -- |Given credential registration id as an identifier.
+  CID !CredentialRegistrationID
+  -- |Given address as an identifier. Multiple addresses may refer to the same account.
+  | AA !AccountAddress
+  -- |Given index as an identifier.
+  | AI !AccountIndex
 
 instance S.Serialize AccountIndex where
     get = AccountIndex <$> G.getWord64be


### PR DESCRIPTION
It is a wrapper type for other types used to identify accounts.

## Purpose

To help identify/query accounts with multiple types.

## Changes

Adds `AccountIdentifier` type.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
