### PR TITLE
Rename L-pool to passive delegation in mobile wallet library

### DIFF
--- a/mobile_wallet/CHANGELOG.md
+++ b/mobile_wallet/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.12.0
+  - JSON serialization of the Rust type `DelegationTarget` has been updated to be consistent with the JSON serialization of the corresponding Haskell type, due to the renaming of L-Pool to passive delegation.
+
 ## 0.11.0
   - JSON serialization of the Rust type `DelegationTarget` has been updated to be consistent with the JSON serialization of the corresponding Haskell type.
   - JSON serialization of commission rates have been updated so that now they are given as the actual rate,

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -685,7 +685,7 @@ dependencies = [
 
 [[package]]
 name = "mobile_wallet"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "aggregate_sig",
  "anyhow",

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -175,12 +175,12 @@ The following fields are optional:
 
 - `"restakeEarnings"` ... bool indicating whether earnings should be restaked.
 
-- `"delegationTarget"` ... JSON indicating either delegation to the L-pool or to a baker pool.
+- `"delegationTarget"` ... JSON indicating either delegation a baker pool or passive delegation.
 
 The delegation target should either be of the form
 ```json
 {
-    "delegateType": "L-Pool"
+    "delegateType": "Passive"
 }
 ```
 or

--- a/rust-bins/wallet-notes/files/2-create_configure_delegation_transaction-input.json
+++ b/rust-bins/wallet-notes/files/2-create_configure_delegation_transaction-input.json
@@ -29,7 +29,7 @@
     "capital": "1000000",
     "restakeEarnings": true,
     "delegationTarget": {
-        "type": "delegateToLPool"
+        "delegateType": "Passive"
     }
   }
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              

--- a/rust-src/crypto_common/src/types.rs
+++ b/rust-src/crypto_common/src/types.rs
@@ -90,8 +90,8 @@ impl Serial for OpenStatus {
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
 #[serde(tag = "delegateType")]
 pub enum DelegationTarget {
-    #[serde(rename = "L-Pool")]
-    DelegateToLPool,
+    #[serde(rename = "Passive")]
+    DelegatePassive,
     #[serde(rename = "Baker")]
     DelegateToBaker {
         #[serde(rename = "bakerId")]
@@ -102,7 +102,7 @@ pub enum DelegationTarget {
 impl Serial for DelegationTarget {
     fn serial<B: Buffer>(&self, out: &mut B) {
         match *self {
-            DelegationTarget::DelegateToLPool => out
+            DelegationTarget::DelegatePassive => out
                 .write_u8(0)
                 .expect("Writing to a buffer should not fail."),
             DelegationTarget::DelegateToBaker { target_baker } => {

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -160,7 +160,7 @@ impl AccountAddress {
             data[29..].copy_from_slice(&counter.to_be_bytes()[1..]);
             Some(Self(data))
         } else {
-            return None;
+            None
         }
     }
 }


### PR DESCRIPTION
## Purpose

To rename L-pool to passive delegation.

## Changes

* Renamed field `DelegateToLPool` to `DelegatePassive` in the DelegationTarget type in crypto_common.
* Renamed JSON field from `L-Pool` to `Passive` in the DelegationTarget type in crypto_common and updated the README accordingly. 
* Updated example input files accordingly to renaming. 
* Increased version from 0.11.0 to 0.12.0
* Apparently clippy wasn't happy about a line of the form `return None;` in id/src/types.rs, so it is replaced by `None`. 

## Checklist

- [x] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

