### PR TITLE
Make clippy return a non-zero error code upon any warnings.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -96,11 +96,11 @@ jobs:
     # (the step is probably too fast for that to make sense though).
     - name: Run cargo clippy on all targets
       run: |
-        cargo clippy --manifest-path rust-src/Cargo.toml --workspace
-        cargo clippy --manifest-path rust-bins/Cargo.toml --workspace --features=vendored-ssl
-        cargo clippy --manifest-path idiss/Cargo.toml
-        cargo clippy --manifest-path mobile_wallet/Cargo.toml
-        cargo clippy --manifest-path identity-provider-service/Cargo.toml --workspace --features=vendored-ssl
+        cargo clippy --manifest-path rust-src/Cargo.toml --workspace -- -Dclippy::all
+        cargo clippy --manifest-path rust-bins/Cargo.toml --workspace --features=vendored-ssl -- -Dclippy::all
+        cargo clippy --manifest-path idiss/Cargo.toml --all-features -- -Dclippy::all
+        cargo clippy --manifest-path mobile_wallet/Cargo.toml -- -Dclippy::all
+        cargo clippy --manifest-path identity-provider-service/Cargo.toml --workspace --features=vendored-ssl -- -Dclippy::all
 
     # HASKELL #
 


### PR DESCRIPTION
## Purpose

Ensure clippy failure fails the CI run.

## Changes

Deny all clippy warnings.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.