### PR TITLE
Rename field name from GTU to CCD.

### DIFF
--- a/rust-bins/src/bin/trace_account.rs
+++ b/rust-bins/src/bin/trace_account.rs
@@ -45,18 +45,18 @@ impl<'de> SerdeDeserialize<'de> for AmountDelta {
             .parse::<i128>()
             .map_err(|e| D::Error::custom(format!("Could not parse amount delta: {}", e)))?;
         if n >= 0 {
-            let microgtu: u64 = n
+            let microccd: u64 = n
                 .try_into()
                 .map_err(|_| D::Error::custom("Amount delta out of range."))?;
-            Ok(AmountDelta::PositiveAmount(Amount::from(microgtu)))
+            Ok(AmountDelta::PositiveAmount(Amount::from(microccd)))
         } else {
             let m = n
                 .checked_abs()
                 .ok_or_else(|| D::Error::custom("Amount delta out of range."))?;
-            let microgtu: u64 = m
+            let microccd: u64 = m
                 .try_into()
                 .map_err(|_| D::Error::custom("Amount delta out of range."))?;
-            Ok(AmountDelta::NegativeAmount(Amount::from(microgtu)))
+            Ok(AmountDelta::NegativeAmount(Amount::from(microccd)))
         }
     }
 }
@@ -493,7 +493,7 @@ fn trace_single_account(
                                     );
                                     assert!(before >= after);
                                     let amount = Amount {
-                                        microgtu: before.microgtu - after.microgtu,
+                                        microccd: before.microccd - after.microccd,
                                     };
                                     writeln!(
                                         writer,

--- a/rust-src/crypto_common/src/types.rs
+++ b/rust-src/crypto_common/src/types.rs
@@ -120,39 +120,39 @@ impl Serial for DelegationTarget {
 /// representation of this type uses a decimal separator with at most 6
 /// decimals.
 pub struct Amount {
-    pub microgtu: u64,
+    pub microccd: u64,
 }
 
 impl Amount {
     pub fn from_micro_ccd(micro_ccd: u64) -> Self {
         Self {
-            microgtu: micro_ccd,
+            microccd: micro_ccd,
         }
     }
 
     pub fn from_ccd(ccd: u64) -> Self {
         Self {
-            microgtu: ccd * 1_000_000,
+            microccd: ccd * 1_000_000,
         }
     }
 }
 
 impl From<Amount> for u64 {
-    fn from(x: Amount) -> Self { x.microgtu }
+    fn from(x: Amount) -> Self { x.microccd }
 }
 
 impl From<u64> for Amount {
-    fn from(microgtu: u64) -> Self { Amount { microgtu } }
+    fn from(microccd: u64) -> Self { Amount { microccd } }
 }
 
 impl Serial for Amount {
-    fn serial<B: crate::Buffer>(&self, out: &mut B) { self.microgtu.serial(out) }
+    fn serial<B: crate::Buffer>(&self, out: &mut B) { self.microccd.serial(out) }
 }
 
 impl Deserial for Amount {
     fn deserial<R: byteorder::ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
-        let microgtu = source.get()?;
-        Ok(Amount { microgtu })
+        let microccd = source.get()?;
+        Ok(Amount { microccd })
     }
 }
 
@@ -161,8 +161,8 @@ impl Add for Amount {
     type Output = Option<Amount>;
 
     fn add(self, rhs: Self) -> Self::Output {
-        let microgtu = self.microgtu.checked_add(rhs.microgtu)?;
-        Some(Amount { microgtu })
+        let microgtu = self.microccd.checked_add(rhs.microccd)?;
+        Some(Amount { microccd: microgtu })
     }
 }
 
@@ -172,8 +172,8 @@ impl Add<Option<Amount>> for Amount {
 
     fn add(self, rhs: Option<Amount>) -> Self::Output {
         let rhs = rhs?;
-        let microgtu = self.microgtu.checked_add(rhs.microgtu)?;
-        Some(Amount { microgtu })
+        let microgtu = self.microccd.checked_add(rhs.microccd)?;
+        Some(Amount { microccd: microgtu })
     }
 }
 
@@ -269,14 +269,14 @@ impl std::str::FromStr for Amount {
         for _ in 0..6 - after_dot {
             microgtu = microgtu.checked_mul(10).ok_or(AmountParseError::Overflow)?;
         }
-        Ok(Amount { microgtu })
+        Ok(Amount { microccd: microgtu })
     }
 }
 
 impl std::fmt::Display for Amount {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let high = self.microgtu / 1_000_000;
-        let low = self.microgtu % 1_000_000;
+        let high = self.microccd / 1_000_000;
+        let low = self.microccd % 1_000_000;
         if low == 0 {
             write!(f, "{}", high)
         } else {
@@ -288,7 +288,7 @@ impl std::fmt::Display for Amount {
 /// JSON instance serializes and deserializes in microgtu units.
 impl SerdeSerialize for Amount {
     fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
-        ser.serialize_str(&self.microgtu.to_string())
+        ser.serialize_str(&self.microccd.to_string())
     }
 }
 
@@ -298,7 +298,7 @@ impl<'de> SerdeDeserialize<'de> for Amount {
         let microgtu = s
             .parse::<u64>()
             .map_err(|e| serde::de::Error::custom(format!("{}", e)))?;
-        Ok(Amount { microgtu })
+        Ok(Amount { microccd: microgtu })
     }
 }
 

--- a/rust-src/encrypted_transfers/src/ffi.rs
+++ b/rust-src/encrypted_transfers/src/ffi.rs
@@ -81,11 +81,11 @@ unsafe extern "C" fn group_element_from_seed(
 #[no_mangle]
 unsafe extern "C" fn encrypt_amount_with_zero_randomness(
     ctx_ptr: *const GlobalContext<Group>,
-    microgtu: u64,
+    microccd: u64,
     out_high_ptr: *mut *const Cipher<Group>,
     out_low_ptr: *mut *const Cipher<Group>,
 ) {
-    let encrypted = encrypt_amount_with_fixed_randomness(from_ptr!(ctx_ptr), Amount { microgtu });
+    let encrypted = encrypt_amount_with_fixed_randomness(from_ptr!(ctx_ptr), Amount { microccd });
     *out_high_ptr = Box::into_raw(Box::new(encrypted.encryptions[1]));
     *out_low_ptr = Box::into_raw(Box::new(encrypted.encryptions[0]));
 }
@@ -99,7 +99,7 @@ unsafe extern "C" fn make_encrypted_transfer_data(
     receiver_pk_ptr: *const elgamal::PublicKey<Group>,
     sender_sk_ptr: *const elgamal::SecretKey<Group>,
     input_amount_ptr: *const AggregatedDecryptedAmount<Group>,
-    microgtu: u64,
+    microccd: u64,
     high_remaining: *mut *const Cipher<Group>,
     low_remaining: *mut *const Cipher<Group>,
     high_transfer: *mut *const Cipher<Group>,
@@ -122,7 +122,7 @@ unsafe extern "C" fn make_encrypted_transfer_data(
         &receiver_pk,
         &sender_sk,
         &input_amount,
-        Amount { microgtu },
+        Amount { microccd },
         &mut csprng,
     ) {
         Some(it) => it,
@@ -217,7 +217,7 @@ unsafe extern "C" fn make_sec_to_pub_data(
     ctx_ptr: *const GlobalContext<Group>,
     sender_sk_ptr: *const elgamal::SecretKey<Group>,
     input_amount_ptr: *const AggregatedDecryptedAmount<Group>,
-    microgtu: u64,
+    microccd: u64,
     high_remaining: *mut *const Cipher<Group>,
     low_remaining: *mut *const Cipher<Group>,
     out_index: *mut u64,
@@ -235,7 +235,7 @@ unsafe extern "C" fn make_sec_to_pub_data(
         &ctx,
         &sender_sk,
         &input_amount,
-        Amount { microgtu },
+        Amount { microccd },
         &mut csprng,
     ) {
         Some(it) => it,
@@ -268,7 +268,7 @@ unsafe extern "C" fn verify_sec_to_pub_transfer(
     initial_low_ptr: *const Cipher<Group>,
     remaining_high_ptr: *const Cipher<Group>,
     remaining_low_ptr: *const Cipher<Group>,
-    microgtu: u64,
+    microccd: u64,
     encrypted_agg_index: u64,
     transfer_proof_ptr: *const u8,
     transfer_proof_len: size_t,
@@ -296,7 +296,7 @@ unsafe extern "C" fn verify_sec_to_pub_transfer(
         return 0;
     };
 
-    let transfer_amount = Amount { microgtu };
+    let transfer_amount = Amount { microccd };
 
     let transfer_data = SecToPubAmountTransferData {
         remaining_amount,
@@ -319,7 +319,7 @@ unsafe extern "C" fn verify_sec_to_pub_transfer(
 unsafe extern "C" fn make_aggregated_decrypted_amount(
     encrypted_high_ptr: *const Cipher<Group>,
     encrypted_low_ptr: *const Cipher<Group>,
-    microgtu: u64,
+    microccd: u64,
     agg_index: u64,
 ) -> *mut AggregatedDecryptedAmount<Group> {
     let encrypted_high = from_ptr!(encrypted_high_ptr);
@@ -329,7 +329,7 @@ unsafe extern "C" fn make_aggregated_decrypted_amount(
     };
     Box::into_raw(Box::new(AggregatedDecryptedAmount {
         agg_encrypted_amount,
-        agg_amount: Amount { microgtu },
+        agg_amount: Amount { microccd },
         agg_index: agg_index.into(),
     }))
 }
@@ -365,7 +365,7 @@ unsafe extern "C" fn decrypt_amount(
     let amount = EncryptedAmount {
         encryptions: [*from_ptr!(low_ptr), *from_ptr!(high_ptr)],
     };
-    crate::decrypt_amount(from_ptr!(table_ptr), &sk, &amount).microgtu
+    crate::decrypt_amount(from_ptr!(table_ptr), &sk, &amount).microccd
 }
 
 /// # Safety
@@ -375,13 +375,13 @@ unsafe extern "C" fn decrypt_amount(
 unsafe extern "C" fn encrypt_amount(
     ctx_ptr: *const GlobalContext<Group>,
     pk_ptr: *const elgamal::PublicKey<Group>,
-    microgtu: u64,
+    microccd: u64,
     out_high_ptr: *mut *const Cipher<Group>,
     out_low_ptr: *mut *const Cipher<Group>,
 ) {
     let gc = from_ptr!(ctx_ptr);
     let pk = from_ptr!(pk_ptr);
-    let encrypted = crate::encrypt_amount(gc, &pk, Amount { microgtu }, &mut rand::thread_rng()).0;
+    let encrypted = crate::encrypt_amount(gc, &pk, Amount { microccd }, &mut rand::thread_rng()).0;
     *out_high_ptr = Box::into_raw(Box::new(encrypted.encryptions[1]));
     *out_low_ptr = Box::into_raw(Box::new(encrypted.encryptions[0]));
 }


### PR DESCRIPTION
## Purpose
Since the crypto common crate is used in the rust sdk it is not great we still have the GTU name.

Since a major release is coming up now is a good opportunity to change it.

## Changes

- rename microgtu to microccd as the AMount field type.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.