### PR TITLE
Added several Arbitrary instances

### DIFF
--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -225,7 +225,7 @@ import Lens.Micro.Platform
 
 import Text.Read (readMaybe)
 
-import Test.QuickCheck ( Arbitrary )
+import Test.QuickCheck ( Arbitrary, choose )
 import Test.QuickCheck.Arbitrary (Arbitrary(arbitrary))
 
 -- |A value equipped with its hash.
@@ -279,7 +279,7 @@ type LotteryPower = Ratio Amount
 -- This wrapper will be used by both @AmountFraction@ and @ElectionDifficulty@.
 -- It was agreed in tokenomics discussions to be sufficient.
 newtype PartsPerHundredThousands = PartsPerHundredThousands { partsPerHundredThousand :: Word32 }
-  deriving newtype (Eq, Ord, Num, Real, Enum, Integral, Arbitrary)
+  deriving newtype (Eq, Ord, Num, Real, Enum, Integral)
 
 hundredThousand :: Word32
 hundredThousand = 100000
@@ -306,6 +306,9 @@ instance FromJSON PartsPerHundredThousands where
     unless (v >= 0 && v <= fromIntegral hundredThousand) $ fail "Fraction out of bounds"
     return (PartsPerHundredThousands (fromIntegral v))
   parseJSON _ = fail "Expected number"
+
+instance Arbitrary PartsPerHundredThousands where
+  arbitrary = PartsPerHundredThousands <$> choose (0, hundredThousand)
 
 -- |Make a 'PartsPerHundredThousands'.
 makePartsPerHundredThousands

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -538,7 +538,11 @@ instance Monad m => MHashableTo m Hash.Hash MintRate
 instance Arbitrary MintRate where
   arbitrary = do
     mrMantissa <- arbitrary
-    mrExponent <- arbitrary
+    let mantissaDigits = ceiling . logBase (10 :: Double) . fromIntegral $ mrMantissa
+    -- By making the exponent no less than the number of decimal digits in the mantissa, we assure
+    -- that the mint rate value stays below 1. As per comment for the `MintRate` definition,
+    -- exponents above 29 aren't used in practice.
+    mrExponent <- choose (mantissaDigits, 29)
     return MintRate{..}
 
 -- |Compute an amount minted at a given rate.

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -225,6 +225,9 @@ import Lens.Micro.Platform
 
 import Text.Read (readMaybe)
 
+import Test.QuickCheck ( Arbitrary )
+import Test.QuickCheck.Arbitrary (Arbitrary(arbitrary))
+
 -- |A value equipped with its hash.
 data Hashed' h a = Hashed {_unhashed :: a, _hashed :: h}
 
@@ -276,7 +279,7 @@ type LotteryPower = Ratio Amount
 -- This wrapper will be used by both @AmountFraction@ and @ElectionDifficulty@.
 -- It was agreed in tokenomics discussions to be sufficient.
 newtype PartsPerHundredThousands = PartsPerHundredThousands { partsPerHundredThousand :: Word32 }
-  deriving newtype (Eq, Ord, Num, Real, Enum, Integral)
+  deriving newtype (Eq, Ord, Num, Real, Enum, Integral, Arbitrary)
 
 hundredThousand :: Word32
 hundredThousand = 100000
@@ -529,6 +532,12 @@ instance HashableTo Hash.Hash MintRate where
 
 instance Monad m => MHashableTo m Hash.Hash MintRate
 
+instance Arbitrary MintRate where
+  arbitrary = do
+    mrMantissa <- arbitrary
+    mrExponent <- arbitrary
+    return MintRate{..}
+
 -- |Compute an amount minted at a given rate.
 -- The amount is rounded down to the nearest microGTU.
 mintAmount :: MintRate -> Amount -> Amount
@@ -537,7 +546,7 @@ mintAmount mr = fromInteger . (`div` (10 ^ mrExponent mr)) . (toInteger (mrManti
 
 -- |A fraction in [0,1] of an 'Amount', represented as parts per 100000.
 newtype AmountFraction = AmountFraction { rfPartsPerHundredThousands :: PartsPerHundredThousands }
-  deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, S.Serialize)
+  deriving newtype (Eq, Ord, Show, ToJSON, FromJSON, S.Serialize, Arbitrary)
 
 makeAmountFraction
    :: Word32

--- a/haskell-src/Concordium/Types/Block.hs
+++ b/haskell-src/Concordium/Types/Block.hs
@@ -10,11 +10,12 @@ import Data.Word
 import Database.Persist.Class
 import Database.Persist.Sql
 import qualified Data.Serialize as S
+import Test.QuickCheck
 
 -- *Types that are morally part of the consensus, but need to be exposed in
 -- other parts of the system as well, e.g., in smart contracts.
 
-newtype Slot = Slot {theSlot :: Word64} deriving newtype (Eq, Ord, Num, Real, Enum, Integral, Show, Read, S.Serialize, FromJSON, ToJSON)
+newtype Slot = Slot {theSlot :: Word64} deriving newtype (Eq, Ord, Num, Real, Enum, Integral, Show, Read, S.Serialize, FromJSON, ToJSON, Arbitrary)
 
 -- |The slot number of the genesis block (0).
 genesisSlot :: Slot

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -105,8 +105,8 @@ instance IsChainParametersVersion cpv => HashableTo Hash.Hash (MintDistribution 
 
 instance Arbitrary (MintDistribution 'ChainParametersV1) where
   arbitrary = do
-    mps <- vector 2 `suchThat` (\[x, y] -> isJust $ addAmountFraction x y)
-    return $ MintDistribution MintPerSlotForCPV0None (mps !! 0) (mps !! 1)
+    (x, y) <- arbitrary `suchThat` (\(x, y) -> isJust $ addAmountFraction x y)
+    return $ MintDistribution MintPerSlotForCPV0None x y
 
 instance (Monad m, IsChainParametersVersion cpv) => MHashableTo m Hash.Hash (MintDistribution cpv)
 

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -20,6 +20,8 @@ import Data.Serialize
 import Data.Word
 import Data.Maybe
 import Lens.Micro.Platform
+import Test.QuickCheck.Arbitrary
+import Test.QuickCheck.Gen
 
 import qualified Concordium.Crypto.SHA256 as Hash
 import Concordium.ID.Parameters
@@ -100,6 +102,11 @@ instance IsChainParametersVersion cpv => Serialize (MintDistribution cpv) where
 
 instance IsChainParametersVersion cpv => HashableTo Hash.Hash (MintDistribution cpv) where
   getHash = Hash.hash . encode
+
+instance Arbitrary (MintDistribution 'ChainParametersV1) where
+  arbitrary = do
+    mps <- vector 2 `suchThat` (\[x, y] -> isJust $ addAmountFraction x y)
+    return $ MintDistribution MintPerSlotForCPV0None (mps !! 0) (mps !! 1)
 
 instance (Monad m, IsChainParametersVersion cpv) => MHashableTo m Hash.Hash (MintDistribution cpv)
 


### PR DESCRIPTION
## Purpose

Tests added in https://github.com/Concordium/concordium-node/pull/335 require several types to have instances of `Arbitrary`.

## Changes

`AmountFraction`, `Slot`, `MintDistribution`, `PartsPerHundredThousand` got instances of Arbitrary.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
