### PR TITLE
Avoid loading genesis

### DIFF
--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -91,6 +91,9 @@ instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
         SP3 -> P3.putGenesisDataV5 . unGDP3
         SP4 -> P4.putGenesisDataV6 . unGDP4
 
+-- |Deserialize 'GenesisConfiguration' given the hash of the genesis. If
+-- 'GenesisData' is decodable (using its Serialize instance) from a given
+-- bytestring then 'getGenesisConfiguration' will also succeed parsing.
 getGenesisConfiguration :: SProtocolVersion pv -> BlockHash -> Get GenesisConfiguration
 getGenesisConfiguration spv genHash = case spv of
         SP1 -> P1.getGenesisConfigurationV3 genHash

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -171,6 +171,17 @@ getPVGenesisData = do
     6 -> PVGenesisData . GDP4 <$> P4.getGenesisDataV6
     n -> fail $ "Unsupported genesis version: " ++ show n
 
+-- |Assuming the same input as 'getPVGenesisData', return just the protocol version.
+getPVGenesisDataPV :: Get SomeProtocolVersion
+getPVGenesisDataPV = do
+  getVersion >>= \case
+    3 -> return $ SomeProtocolVersion SP1
+    4 -> return $ SomeProtocolVersion SP2
+    5 -> return $ SomeProtocolVersion SP3
+    6 -> return $ SomeProtocolVersion SP4
+    n -> fail $ "Unsupported genesis version: " ++ show n
+
+
 -- |Serialize genesis data with a version tag. This is a helper function that
 -- modulo types does exactly the same as 'putVersionedGenesisData' defined
 -- above.

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -12,6 +12,7 @@ module Concordium.Genesis.Data (
     module Concordium.Genesis.Data,
 ) where
 
+import Data.ByteString (ByteString)
 import Data.Function (on)
 import Data.Serialize
 
@@ -23,6 +24,7 @@ import qualified Concordium.Genesis.Data.P2 as P2
 import qualified Concordium.Genesis.Data.P3 as P3
 import qualified Concordium.Genesis.Data.P4 as P4
 import Concordium.Types
+import Concordium.Types.ProtocolVersion (SomeProtocolVersion)
 
 -- |Data family for genesis data.
 -- This has been chosen to be a data family so that the genesis data
@@ -124,6 +126,14 @@ genesisBlockHash = case protocolVersion @pv of
     SP2 -> P2.genesisBlockHash . unGDP2
     SP3 -> P3.genesisBlockHash . unGDP3
     SP4 -> P4.genesisBlockHash . unGDP4
+
+-- Original genesis hash
+firstGenesisBlockHash :: forall pv. IsProtocolVersion pv => GenesisData pv -> BlockHash
+firstGenesisBlockHash = case protocolVersion @pv of
+    SP1 -> P1.firstGenesisBlockHash . unGDP1
+    SP2 -> P2.firstGenesisBlockHash . unGDP2
+    SP3 -> P3.firstGenesisBlockHash . unGDP3
+    SP4 -> P4.firstGenesisBlockHash . unGDP4
 
 -- |A dependent pair of a protocol version and genesis data.
 data PVGenesisData = forall pv. IsProtocolVersion pv => PVGenesisData (GenesisData pv)

--- a/haskell-src/Concordium/Genesis/Data/Base.hs
+++ b/haskell-src/Concordium/Genesis/Data/Base.hs
@@ -94,6 +94,10 @@ instance Serialize CoreGenesisParameters where
 -- The intention is that this structured can always be deserialized from a
 -- serialized @GenesisData@ provided the hash of the genesis data is known.
 data GenesisConfiguration = GenesisConfiguration {
+  -- |The tag used when deserializing genesis data. This determines the variant
+  -- of the genesis data that is to be deserialized. The allowed values depend
+  -- on the protocol version. For each protocol there is a function
+  -- 'genesisVariantTag' that determines the allowed values for this tag.
   _gcTag :: !Word8,
   -- |Genesis parameters.
   _gcCore :: !CoreGenesisParameters,
@@ -112,6 +116,8 @@ instance BasicGenesisData GenesisConfiguration where
   gdFinalizationParameters = gdFinalizationParameters . _gcCore
   gdEpochLength = gdEpochLength . _gcCore
 
+-- |Serialize genesis configuration. This is done in such a way that
+-- 'getGenesisConfiguration' can parse it.
 putGenesisConfiguration :: Putter GenesisConfiguration
 putGenesisConfiguration GenesisConfiguration{..} = put _gcTag <> put _gcCore <> put _gcFirstGenesis <> put _gcCurrentHash
 

--- a/haskell-src/Concordium/Genesis/Data/Base.hs
+++ b/haskell-src/Concordium/Genesis/Data/Base.hs
@@ -54,6 +54,23 @@ data CoreGenesisParameters = CoreGenesisParameters
     }
     deriving (Eq, Show)
 
+-- |Extract the core genesis parameters.
+coreGenesisParameters :: BasicGenesisData gd => gd -> CoreGenesisParameters
+coreGenesisParameters gd = CoreGenesisParameters{
+    genesisTime = gdGenesisTime gd,
+    genesisSlotDuration = gdSlotDuration gd,
+    genesisEpochLength = gdEpochLength gd,
+    genesisFinalizationParameters = gdFinalizationParameters gd,
+    genesisMaxBlockEnergy = gdMaxBlockEnergy gd
+    }
+
+instance BasicGenesisData CoreGenesisParameters where
+  gdGenesisTime = genesisTime
+  gdSlotDuration = genesisSlotDuration
+  gdMaxBlockEnergy = genesisMaxBlockEnergy
+  gdFinalizationParameters = genesisFinalizationParameters
+  gdEpochLength = genesisEpochLength
+
 instance Serialize CoreGenesisParameters where
     put CoreGenesisParameters{..} = do
         put genesisTime

--- a/haskell-src/Concordium/Genesis/Data/P1.hs
+++ b/haskell-src/Concordium/Genesis/Data/P1.hs
@@ -127,3 +127,8 @@ genesisBlockHash GDP1Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
     put genesisPreviousGenesis
     put genesisTerminalBlock
     put genesisStateHash
+
+-- |The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: GenesisDataP1 -> BlockHash
+firstGenesisBlockHash GDP1Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
+firstGenesisBlockHash other@GDP1Initial{} = genesisBlockHash other

--- a/haskell-src/Concordium/Genesis/Data/P1.hs
+++ b/haskell-src/Concordium/Genesis/Data/P1.hs
@@ -78,6 +78,13 @@ getGenesisDataV3 =
         _ -> fail "Unrecognised genesis data type"
 
 -- |Deserialize genesis configuration from the serialized genesis data.
+--
+-- Note that this will not consume the entire genesis data, only the initial
+-- prefix. In particular, in case of initial genesis data it will not read the
+-- genesis state.
+--
+-- The argument is the hash of the genesis data from which the configuration is
+-- to be read.
 getGenesisConfigurationV3 :: BlockHash -> Get GenesisConfiguration
 getGenesisConfigurationV3 genHash = do
     getWord8 >>= \case

--- a/haskell-src/Concordium/Genesis/Data/P1.hs
+++ b/haskell-src/Concordium/Genesis/Data/P1.hs
@@ -4,6 +4,7 @@
 module Concordium.Genesis.Data.P1 where
 
 import Data.Serialize
+import Data.Word
 
 import Concordium.Common.Version
 import qualified Concordium.Crypto.SHA256 as Hash
@@ -76,6 +77,29 @@ getGenesisDataV3 =
         1 -> GDP1Regenesis <$> getRegenesisData
         _ -> fail "Unrecognised genesis data type"
 
+-- |Deserialize genesis configuration from the serialized genesis data.
+getGenesisConfigurationV3 :: BlockHash -> Get GenesisConfiguration
+getGenesisConfigurationV3 genHash = do
+    getWord8 >>= \case
+        0 -> do
+            _gcCore <- get
+            return GenesisConfiguration{
+                _gcTag = 0,
+                _gcCurrentHash = genHash,
+                _gcFirstGenesis = genHash,
+                ..
+                }
+        1 -> do
+          _gcCore <- get
+          _gcFirstGenesis <- get
+          return GenesisConfiguration{
+            _gcTag = 1,
+            _gcCurrentHash = genHash,
+            ..
+            }
+        _ -> fail "Unrecognised genesis data type"
+
+
 -- |Serialize genesis data in the V3 format.
 putGenesisDataV3 :: Putter GenesisDataP1
 putGenesisDataV3 GDP1Initial{..} = do
@@ -132,3 +156,8 @@ genesisBlockHash GDP1Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
 firstGenesisBlockHash :: GenesisDataP1 -> BlockHash
 firstGenesisBlockHash GDP1Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
 firstGenesisBlockHash other@GDP1Initial{} = genesisBlockHash other
+
+-- |Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP1 -> Word8
+genesisVariantTag GDP1Initial{} = 0
+genesisVariantTag GDP1Regenesis{} = 1

--- a/haskell-src/Concordium/Genesis/Data/P2.hs
+++ b/haskell-src/Concordium/Genesis/Data/P2.hs
@@ -4,6 +4,7 @@
 module Concordium.Genesis.Data.P2 where
 
 import Data.Serialize
+import Data.Word
 
 import Concordium.Common.Version
 import qualified Concordium.Crypto.SHA256 as Hash
@@ -63,6 +64,28 @@ putGenesisDataV4 GDP2Regenesis{..} = do
   putWord8 1
   putRegenesisData genesisRegenesis
 
+-- |Deserialize genesis configuration from the serialized genesis data.
+getGenesisConfigurationV4 :: BlockHash -> Get GenesisConfiguration
+getGenesisConfigurationV4 genHash = do
+    getWord8 >>= \case
+        0 -> do
+            _gcCore <- get
+            return GenesisConfiguration{
+                _gcTag = 0,
+                _gcCurrentHash = genHash,
+                _gcFirstGenesis = genHash,
+                ..
+                }
+        1 -> do
+          _gcCore <- get
+          _gcFirstGenesis <- get
+          return GenesisConfiguration{
+            _gcTag = 1,
+            _gcCurrentHash = genHash,
+            ..
+            }
+        _ -> fail "Unrecognised genesis data type"
+
 -- |Deserialize genesis data with a version tag. The expected version tag is 4
 -- and this must be distinct from version tags of other genesis data formats.
 getVersionedGenesisData :: Get GenesisDataP2
@@ -112,3 +135,8 @@ genesisBlockHash GDP2Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
 firstGenesisBlockHash :: GenesisDataP2 -> BlockHash
 firstGenesisBlockHash GDP2Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
 firstGenesisBlockHash other@GDP2Initial{} = genesisBlockHash other
+
+-- |Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP2 -> Word8
+genesisVariantTag GDP2Initial{} = 0
+genesisVariantTag GDP2Regenesis{} = 1

--- a/haskell-src/Concordium/Genesis/Data/P2.hs
+++ b/haskell-src/Concordium/Genesis/Data/P2.hs
@@ -107,3 +107,8 @@ genesisBlockHash GDP2Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
     put genesisPreviousGenesis
     put genesisTerminalBlock
     put genesisStateHash
+
+-- |The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: GenesisDataP2 -> BlockHash
+firstGenesisBlockHash GDP2Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
+firstGenesisBlockHash other@GDP2Initial{} = genesisBlockHash other

--- a/haskell-src/Concordium/Genesis/Data/P2.hs
+++ b/haskell-src/Concordium/Genesis/Data/P2.hs
@@ -65,6 +65,13 @@ putGenesisDataV4 GDP2Regenesis{..} = do
   putRegenesisData genesisRegenesis
 
 -- |Deserialize genesis configuration from the serialized genesis data.
+--
+-- Note that this will not consume the entire genesis data, only the initial
+-- prefix. In particular, in case of initial genesis data it will not read the
+-- genesis state.
+--
+-- The argument is the hash of the genesis data from which the configuration is
+-- to be read.
 getGenesisConfigurationV4 :: BlockHash -> Get GenesisConfiguration
 getGenesisConfigurationV4 genHash = do
     getWord8 >>= \case

--- a/haskell-src/Concordium/Genesis/Data/P3.hs
+++ b/haskell-src/Concordium/Genesis/Data/P3.hs
@@ -4,6 +4,7 @@
 module Concordium.Genesis.Data.P3 where
 
 import Data.Serialize
+import Data.Word
 
 import Concordium.Common.Version
 import qualified Concordium.Crypto.SHA256 as Hash
@@ -63,6 +64,28 @@ putGenesisDataV5 GDP3Regenesis{..} = do
   putWord8 1
   putRegenesisData genesisRegenesis
 
+-- |Deserialize genesis configuration from the serialized genesis data.
+getGenesisConfigurationV5 :: BlockHash -> Get GenesisConfiguration
+getGenesisConfigurationV5 genHash = do
+    getWord8 >>= \case
+        0 -> do
+            _gcCore <- get
+            return GenesisConfiguration{
+                _gcTag = 0,
+                _gcCurrentHash = genHash,
+                _gcFirstGenesis = genHash,
+                ..
+                }
+        1 -> do
+          _gcCore <- get
+          _gcFirstGenesis <- get
+          return GenesisConfiguration{
+            _gcTag = 1,
+            _gcCurrentHash = genHash,
+            ..
+            }
+        _ -> fail "Unrecognised genesis data type"
+
 -- |Deserialize genesis data with a version tag. The expected version tag is 5
 -- and this must be distinct from version tags of other genesis data formats.
 getVersionedGenesisData :: Get GenesisDataP3
@@ -112,3 +135,8 @@ genesisBlockHash GDP3Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
 firstGenesisBlockHash :: GenesisDataP3 -> BlockHash
 firstGenesisBlockHash GDP3Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
 firstGenesisBlockHash other@GDP3Initial{} = genesisBlockHash other
+
+-- |Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP3 -> Word8
+genesisVariantTag GDP3Initial{} = 0
+genesisVariantTag GDP3Regenesis{} = 1

--- a/haskell-src/Concordium/Genesis/Data/P3.hs
+++ b/haskell-src/Concordium/Genesis/Data/P3.hs
@@ -65,6 +65,13 @@ putGenesisDataV5 GDP3Regenesis{..} = do
   putRegenesisData genesisRegenesis
 
 -- |Deserialize genesis configuration from the serialized genesis data.
+--
+-- Note that this will not consume the entire genesis data, only the initial
+-- prefix. In particular, in case of initial genesis data it will not read the
+-- genesis state.
+--
+-- The argument is the hash of the genesis data from which the configuration is
+-- to be read.
 getGenesisConfigurationV5 :: BlockHash -> Get GenesisConfiguration
 getGenesisConfigurationV5 genHash = do
     getWord8 >>= \case

--- a/haskell-src/Concordium/Genesis/Data/P3.hs
+++ b/haskell-src/Concordium/Genesis/Data/P3.hs
@@ -107,3 +107,8 @@ genesisBlockHash GDP3Regenesis{genesisRegenesis=RegenesisData{..}} = BlockHash .
     put genesisPreviousGenesis
     put genesisTerminalBlock
     put genesisStateHash
+
+-- |The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: GenesisDataP3 -> BlockHash
+firstGenesisBlockHash GDP3Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
+firstGenesisBlockHash other@GDP3Initial{} = genesisBlockHash other

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -164,6 +164,13 @@ putGenesisDataV6 GDP4MigrateFromP3{..} = do
     put genesisMigration
 
 -- |Deserialize genesis configuration from the serialized genesis data.
+--
+-- Note that this will not consume the entire genesis data, only the initial
+-- prefix. In particular, in case of initial genesis data it will not read the
+-- genesis state.
+--
+-- The argument is the hash of the genesis data from which the configuration is
+-- to be read.
 getGenesisConfigurationV6 :: BlockHash -> Get GenesisConfiguration
 getGenesisConfigurationV6 genHash = do
     getWord8 >>= \case

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -218,3 +218,9 @@ genesisBlockHash GDP4MigrateFromP3{genesisRegenesis = RegenesisData{..}, ..} = B
     put genesisTerminalBlock
     put genesisStateHash
     put genesisMigration
+
+-- |The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: GenesisDataP4 -> BlockHash
+firstGenesisBlockHash GDP4Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
+firstGenesisBlockHash GDP4MigrateFromP3{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
+firstGenesisBlockHash other@GDP4Initial{} = genesisBlockHash other

--- a/haskell-src/Concordium/Genesis/Data/P4.hs
+++ b/haskell-src/Concordium/Genesis/Data/P4.hs
@@ -6,6 +6,7 @@
 module Concordium.Genesis.Data.P4 where
 
 import Data.Serialize
+import Data.Word
 
 import Concordium.Common.Version
 import qualified Concordium.Crypto.SHA256 as Hash
@@ -162,6 +163,36 @@ putGenesisDataV6 GDP4MigrateFromP3{..} = do
     putRegenesisData genesisRegenesis
     put genesisMigration
 
+-- |Deserialize genesis configuration from the serialized genesis data.
+getGenesisConfigurationV6 :: BlockHash -> Get GenesisConfiguration
+getGenesisConfigurationV6 genHash = do
+    getWord8 >>= \case
+        0 -> do
+            _gcCore <- get
+            return GenesisConfiguration{
+                _gcTag = 0,
+                _gcCurrentHash = genHash,
+                _gcFirstGenesis = genHash,
+                ..
+                }
+        1 -> do
+          _gcCore <- get
+          _gcFirstGenesis <- get
+          return GenesisConfiguration{
+            _gcTag = 1,
+            _gcCurrentHash = genHash,
+            ..
+            }
+        2 -> do
+          _gcCore <- get
+          _gcFirstGenesis <- get
+          return GenesisConfiguration{
+            _gcTag = 2,
+            _gcCurrentHash = genHash,
+            ..
+            }
+        _ -> fail "Unrecognised genesis data type"
+
 -- |Deserialize genesis data with a version tag. The expected version tag is 6
 -- and this must be distinct from version tags of other genesis data formats.
 getVersionedGenesisData :: Get GenesisDataP4
@@ -224,3 +255,9 @@ firstGenesisBlockHash :: GenesisDataP4 -> BlockHash
 firstGenesisBlockHash GDP4Regenesis{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
 firstGenesisBlockHash GDP4MigrateFromP3{genesisRegenesis=RegenesisData{..}} = genesisFirstGenesis
 firstGenesisBlockHash other@GDP4Initial{} = genesisBlockHash other
+
+-- |Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP4 -> Word8
+genesisVariantTag GDP4Initial{} = 0
+genesisVariantTag GDP4Regenesis{} = 1
+genesisVariantTag GDP4MigrateFromP3{} = 2

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE TypeFamilies #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
 -- |This module contains the 'ProtocolVersion' datatype, which enumerates the


### PR DESCRIPTION
## Purpose

This PR has auxiliary type definitions and helper functions in support of https://github.com/Concordium/concordium-node/issues/340

## Changes

The main change is the introduction of `GenesisConfiguration` which contains data that consensus needs for running.
This is much less data (in general) than what is contained in the genesis block, since the latter contains the serialization of the block state.

I chose to add this type here and not in the consensus package since it is tightly related to the GenesisData type. In particular it is crucial that serialization of both are kept in sync so that GenesisConfiguration can always be deserialized from the serialization of GenesisData.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.