### PR TITLE
Create libraries for deterministic key derivation

### DIFF
--- a/mobile_wallet/CHANGELOG.md
+++ b/mobile_wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.13.0
+- Added function `get_identity_keys_and_randomness` for deriving IdCredSec, PrfKey and blinding randomness from a seed.
+- Added function `get_account_keys_and_randomness` for deriving signing key, verification key and attribute randomness from a seed.
+
 ## 0.12.0
   - JSON serialization of the Rust type `DelegationTarget` has been updated to be consistent with the JSON serialization of the corresponding Haskell type, due to the renaming of L-Pool to passive delegation.
 

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -741,14 +741,14 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 name = "key_derivation"
 version = "1.0.0"
 dependencies = [
+ "dodis_yampolskiy_prf",
  "ed25519-dalek",
  "ed25519_hd_key_derivation",
- "hex",
  "hmac 0.12.1",
  "id",
  "keygen_bls",
  "pairing",
- "regex",
+ "ps_sig",
  "serde",
  "sha2 0.10.2",
 ]

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -801,7 +801,7 @@ dependencies = [
 
 [[package]]
 name = "mobile_wallet"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aggregate_sig",
  "anyhow",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "hmac 0.12.1",
  "regex",
  "sha2 0.10.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -744,6 +745,7 @@ dependencies = [
  "ed25519_hd_key_derivation",
  "hex",
  "hmac 0.12.1",
+ "id",
  "keygen_bls",
  "pairing",
  "regex",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -22,6 +22,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +89,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
+ "generic-array 0.14.4",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array 0.14.4",
 ]
 
@@ -246,6 +264,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.4",
+ "typenum",
+]
+
+[[package]]
+name = "crypto-mac"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
+dependencies = [
+ "generic-array 0.14.4",
+ "subtle",
+]
+
+[[package]]
 name = "crypto_common"
 version = "0.1.0"
 dependencies = [
@@ -337,6 +375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dodis_yampolskiy_prf"
 version = "0.1.0"
 dependencies = [
@@ -389,6 +438,17 @@ dependencies = [
  "serde",
  "sha2 0.9.8",
  "zeroize",
+]
+
+[[package]]
+name = "ed25519_hd_key_derivation"
+version = "1.0.0"
+dependencies = [
+ "ed25519-dalek",
+ "hex",
+ "hmac 0.12.1",
+ "regex",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -562,6 +622,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
+dependencies = [
+ "digest 0.9.0",
+ "hmac 0.11.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
+dependencies = [
+ "crypto-mac",
+ "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "id"
 version = "0.1.0"
 dependencies = [
@@ -648,6 +737,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 
 [[package]]
+name = "key_derivation"
+version = "1.0.0"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519_hd_key_derivation",
+ "hex",
+ "hmac 0.12.1",
+ "keygen_bls",
+ "pairing",
+ "regex",
+ "serde",
+ "sha2 0.10.2",
+]
+
+[[package]]
+name = "keygen_bls"
+version = "2.0.0"
+dependencies = [
+ "curve_arithmetic",
+ "ff",
+ "hex",
+ "hkdf",
+ "pairing",
+ "sha2 0.9.8",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -705,6 +821,7 @@ dependencies = [
  "hex",
  "id",
  "jni",
+ "key_derivation",
  "libc",
  "pairing",
  "pedersen_scheme",
@@ -937,6 +1054,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d83f127d94bdbcda4c8cc2e50f6f84f4b611f69c902699ca385a39c3a75f9ff1"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49b3de9ec5dc0a3417da371aab17d729997c15010e7fd24ff707773a33bddb64"
+
+[[package]]
 name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1038,6 +1172,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -58,6 +58,10 @@ version = "0"
 path = "../rust-src/pedersen_scheme"
 version = "0"
 
+[dependencies.key_derivation]
+path = "../rust-src/key_derivation"
+version = "1.0.0"
+
 [dependencies.ps_sig]
 path = "../rust-src/ps_sig"
 version = "0"

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/mobile_wallet/android/mobile_wallet_lib/src/main/java/com/concordium/mobile_wallet_lib/wallet.kt
+++ b/mobile_wallet/android/mobile_wallet_lib/src/main/java/com/concordium/mobile_wallet_lib/wallet.kt
@@ -14,6 +14,8 @@ external fun combine_encrypted_amounts(input1: String, input2: String) : ReturnV
 external fun decrypt_encrypted_amount(input: String) : ReturnValue
 external fun check_account_address(input: String) : Boolean
 external fun link_check(input: String) : String
+external fun get_identity_keys_and_randomness(input: String) : ReturnValue
+external fun get_account_keys_and_randomness(input: String) : ReturnValue
 
 fun loadWalletLib() {
     System.loadLibrary("mobile_wallet")

--- a/mobile_wallet/mobile_wallet.h
+++ b/mobile_wallet/mobile_wallet.h
@@ -166,6 +166,36 @@ char *generate_baker_keys(uint8_t *success);
 uint64_t decrypt_encrypted_amount(const char *input_ptr, uint8_t *success);
 
 /**
+ * Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+ * UTF8-encoded string. The returned string must be freed by the caller by
+ * calling the function 'free_response_string'. In case of failure the function
+ * returns an error message as the response, and sets the 'success' flag to 0.
+ *
+ * See rust-bins/wallet-notes/README.md for the description of input and output
+ * formats.
+ *
+ * # Safety
+ * The input pointer must point to a null-terminated buffer, otherwise this
+ * function will fail in unspecified ways.
+ */
+char *get_identity_keys_and_randomness(const char *input_ptr, uint8_t *success);
+
+/**
+ * Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+ * UTF8-encoded string. The returned string must be freed by the caller by
+ * calling the function 'free_response_string'. In case of failure the function
+ * returns an error message as the response, and sets the 'success' flag to 0.
+ *
+ * See rust-bins/wallet-notes/README.md for the description of input and output
+ * formats.
+ *
+ * # Safety
+ * The input pointer must point to a null-terminated buffer, otherwise this
+ * function will fail in unspecified ways.
+ */
+char *get_account_keys_and_randomness(const char *input_ptr, uint8_t *success);
+
+/**
  * # Safety
  * This function is unsafe in the sense that if the argument pointer was not
  * Constructed via CString::into_raw its behaviour is undefined.

--- a/mobile_wallet/src/android.rs
+++ b/mobile_wallet/src/android.rs
@@ -6,6 +6,7 @@ use crate::{
     create_configure_delegation_transaction, create_credential, create_encrypted_transfer,
     create_id_request_and_private_data, create_pub_to_sec_transfer, create_sec_to_pub_transfer,
     create_transfer, decrypt_encrypted_amount, generate_accounts, generate_baker_keys,
+    get_account_keys_and_randomness, get_identity_keys_and_randomness,
 };
 use jni::{
     objects::{JClass, JString, JValue},
@@ -125,6 +126,84 @@ pub extern "system" fn Java_com_concordium_mobile_1wallet_1lib_WalletKt_generate
     let mut success: u8 = 127;
     let cstr_res = unsafe {
         let unsafe_res_ptr = generate_accounts(input_str.as_ptr(), &mut success);
+        if unsafe_res_ptr.is_null() {
+            return wrap_return_tuple(&env, 127, "Pointer returned from crypto library was NULL");
+        }
+        CString::from_raw(unsafe_res_ptr)
+    };
+
+    match cstr_res.to_str() {
+        Ok(str_ref) => wrap_return_tuple(&env, success, str_ref),
+        Err(e) => wrap_return_tuple(
+            &env,
+            127,
+            &format!("Could not read CString from crypto library {:?}", e),
+        ),
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_concordium_mobile_1wallet_1lib_WalletKt_get_1identity_1keys_1and_1randomness(
+    env: JNIEnv,
+    _: JClass,
+    input: JString,
+) -> jobject {
+    let input_str = match env.get_string(input) {
+        Ok(res_str) => res_str,
+        Err(e) => {
+            return wrap_return_tuple(
+                &env,
+                127,
+                &format!(
+                    "Could not read java.lang.String given as input due to {:?}",
+                    e
+                ),
+            )
+        }
+    };
+
+    let mut success: u8 = 127;
+    let cstr_res = unsafe {
+        let unsafe_res_ptr = get_identity_keys_and_randomness(input_str.as_ptr(), &mut success);
+        if unsafe_res_ptr.is_null() {
+            return wrap_return_tuple(&env, 127, "Pointer returned from crypto library was NULL");
+        }
+        CString::from_raw(unsafe_res_ptr)
+    };
+
+    match cstr_res.to_str() {
+        Ok(str_ref) => wrap_return_tuple(&env, success, str_ref),
+        Err(e) => wrap_return_tuple(
+            &env,
+            127,
+            &format!("Could not read CString from crypto library {:?}", e),
+        ),
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_concordium_mobile_1wallet_1lib_WalletKt_get_1account_1keys_1and_1randomness(
+    env: JNIEnv,
+    _: JClass,
+    input: JString,
+) -> jobject {
+    let input_str = match env.get_string(input) {
+        Ok(res_str) => res_str,
+        Err(e) => {
+            return wrap_return_tuple(
+                &env,
+                127,
+                &format!(
+                    "Could not read java.lang.String given as input due to {:?}",
+                    e
+                ),
+            )
+        }
+    };
+
+    let mut success: u8 = 127;
+    let cstr_res = unsafe {
+        let unsafe_res_ptr = get_account_keys_and_randomness(input_str.as_ptr(), &mut success);
         if unsafe_res_ptr.is_null() {
             return wrap_return_tuple(&env, 127, "Pointer returned from crypto library was NULL");
         }

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -824,7 +824,7 @@ fn get_account_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
             attribute_tag.0.into(),
         );
         let commitment_randomness_hex = hex::encode(commitment_randomness);
-        attribute_commitment_randomness.insert(attribute_tag, commitment_randomness_hex);
+        attribute_commitment_randomness.insert(attribute_tag.0, commitment_randomness_hex);
     }
 
     let response = json!({

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -831,7 +831,7 @@ fn get_account_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
     }
 
     let response = json!({
-        "signingKey": account_signing_key_hex,
+        "signKey": account_signing_key_hex,
         "verifyKey": account_verify_key_hex,
         "attributeCommitmentRandomness": attribute_commitment_randomness
     });

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -787,18 +787,15 @@ fn get_identity_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
     let identity_index = try_get(&v, "identityIndex")?;
 
     let id_cred_sec = wallet.get_id_cred_sec(identity_index)?;
-    let id_cred_sec_hex = hex::encode(id_cred_sec);
 
     let prf_key = wallet.get_prf_key(identity_index)?;
-    let prf_key_hex = hex::encode(prf_key);
 
     let blinding_randomness = wallet.get_blinding_randomness(identity_index)?;
-    let blinding_randomness_hex = hex::encode(blinding_randomness);
 
     let response = json!({
-        "idCredSec": id_cred_sec_hex,
-        "prfKey": prf_key_hex,
-        "blindingRandomness": blinding_randomness_hex
+        "idCredSec": base16_encode_string(&id_cred_sec),
+        "prfKey": base16_encode_string(&prf_key),
+        "blindingRandomness": base16_encode_string(&blinding_randomness)
     });
     Ok(to_string(&response)?)
 }
@@ -826,7 +823,7 @@ fn get_account_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
             account_credential_index,
             attribute_tag,
         )?;
-        let commitment_randomness_hex = hex::encode(commitment_randomness);
+        let commitment_randomness_hex = base16_encode_string(&commitment_randomness);
         attribute_commitment_randomness.insert(attribute_tag.0, commitment_randomness_hex);
     }
 

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -14,16 +14,18 @@ use ed25519_dalek::Signer;
 use either::Either::{Left, Right};
 use encrypted_transfers::encrypt_amount_with_fixed_randomness;
 use id::{account_holder, constants::AttributeKind, secret_sharing::Threshold, types::*};
+use key_derivation::{ConcordiumHdWallet, Net};
 use pairing::bls12_381::{Bls12, G1};
 use rand::thread_rng;
 use serde_json::{from_str, from_value, to_string, Value};
 use sha2::{Digest, Sha256};
 use std::{
     cmp::max,
-    collections::BTreeMap,
+    collections::{BTreeMap, HashMap},
     convert::TryInto,
     ffi::{CStr, CString},
     io::Cursor,
+    str::FromStr,
 };
 
 use crypto_common::types::KeyPair;
@@ -766,6 +768,73 @@ fn decrypt_encrypted_amount_aux(input: &str) -> anyhow::Result<Amount> {
     )
 }
 
+fn parse_wallet_input(v: &Value) -> anyhow::Result<ConcordiumHdWallet> {
+    let seed_hex: String = try_get(v, "seed")?;
+    let net: Net = try_get(v, "net")?;
+    let wallet = ConcordiumHdWallet {
+        seed: hex::decode(&seed_hex)?,
+        net,
+    };
+    Ok(wallet)
+}
+
+fn get_identity_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
+    let v: Value = from_str(&input)?;
+    let wallet = parse_wallet_input(&v)?;
+    let identity_index = try_get(&v, "identityIndex")?;
+
+    let id_cred_sec = wallet.get_id_cred_sec(identity_index);
+    let id_cred_sec_hex = hex::encode(id_cred_sec);
+
+    let prf_key = wallet.get_prf_key(identity_index);
+    let prf_key_hex = hex::encode(prf_key);
+
+    let blinding_randomness = wallet.get_blinding_randomness(identity_index);
+    let blinding_randomness_hex = hex::encode(blinding_randomness);
+
+    let response = json!({
+        "idCredSec": id_cred_sec_hex,
+        "prfKey": prf_key_hex,
+        "blindingRandomness": blinding_randomness_hex
+    });
+    Ok(to_string(&response)?)
+}
+
+fn get_account_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
+    let v: Value = from_str(&input)?;
+    let wallet = parse_wallet_input(&v)?;
+    let identity_index = try_get(&v, "identityIndex")?;
+    let account_credential_index = try_get(&v, "accountCredentialIndex")?;
+
+    let account_signing_key =
+        wallet.get_account_signing_key(identity_index, account_credential_index);
+    let account_signing_key_hex = hex::encode(account_signing_key);
+
+    let account_verify_key =
+        wallet.get_account_public_key(identity_index, account_credential_index);
+    let account_verify_key_hex = hex::encode(account_verify_key);
+
+    let mut attribute_commitment_randomness = HashMap::new();
+
+    for attribute_name in ATTRIBUTE_NAMES {
+        let attribute_tag = AttributeTag::from_str(attribute_name)?;
+        let commitment_randomness = wallet.get_attribute_commitment_randomness(
+            identity_index,
+            account_credential_index,
+            attribute_tag.0.into(),
+        );
+        let commitment_randomness_hex = hex::encode(commitment_randomness);
+        attribute_commitment_randomness.insert(attribute_tag, commitment_randomness_hex);
+    }
+
+    let response = json!({
+        "signingKey": account_signing_key_hex,
+        "verifyKey": account_verify_key_hex,
+        "attributeCommitmentRandomness": json!(attribute_commitment_randomness)
+    });
+    Ok(to_string(&response)?)
+}
+
 /// Set the flag to 0, and return a newly allocated string containing
 /// the error message. The returned string is NUL terminated.
 ///
@@ -1014,6 +1083,34 @@ make_wrapper!(
     /// The input pointer must point to a null-terminated buffer, otherwise this
     /// function will fail in unspecified ways.
     => generate_accounts -> generate_accounts_aux);
+
+make_wrapper!(
+    /// Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+    /// UTF8-encoded string. The returned string must be freed by the caller by
+    /// calling the function 'free_response_string'. In case of failure the function
+    /// returns an error message as the response, and sets the 'success' flag to 0.
+    ///
+    /// See rust-bins/wallet-notes/README.md for the description of input and output
+    /// formats.
+    ///
+    /// # Safety
+    /// The input pointer must point to a null-terminated buffer, otherwise this
+    /// function will fail in unspecified ways.
+    => get_identity_keys_and_randomness -> get_identity_keys_and_randomness_aux);
+
+make_wrapper!(
+    /// Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+    /// UTF8-encoded string. The returned string must be freed by the caller by
+    /// calling the function 'free_response_string'. In case of failure the function
+    /// returns an error message as the response, and sets the 'success' flag to 0.
+    ///
+    /// See rust-bins/wallet-notes/README.md for the description of input and output
+    /// formats.
+    ///
+    /// # Safety
+    /// The input pointer must point to a null-terminated buffer, otherwise this
+    /// function will fail in unspecified ways.
+    => get_account_keys_and_randomness -> get_account_keys_and_randomness_aux);
 
 /// Take pointers to a NUL-terminated UTF8-string and return a u64.
 ///

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -444,6 +444,57 @@ The return value is a a JSON array with JSON objects as entries. Each object has
 
 With meaning that can be discerned from their names.
 
+## get_identity_keys_and_randomness
+
+Semantics: Deterministically derives id_cred_sec, prf_key and blinding randomness for an identity.
+
+This function takes as input a NUL-terminated UTF8-encoded string. The string
+must be a valid JSON object with fields
+
+- `"seed"` ... the seed used to derive keys from, as a hex string.
+
+- `"net"` ... determines whether to derive keys for Mainnet or a testnet. Has to be "Mainnet" or "Testnet", all other values will fail.
+
+- `"identityIndex"` ... the index of the identity to derive keys and randomness for, a u32 value
+
+The returned value is a JSON object with the following fields:
+
+- `"idCredSec"` ... the id_cred_sec as a hex encoded string.
+
+- `"prfKey"` ... the prf_key as a hex encoded string.
+
+- `"blindingRandomness"` ... the blinding randomness as a hex encoded string.
+
+An example input to this request is in the file [get_identity_keys_and_randomness-input.json](files/get_identity_keys_and_randomness-input.json).
+An example output to this request is in the file [get_identity_keys_and_randomness-output.json](files/get_identity_keys_and_randomness-output.json).
+
+## get_account_keys_and_randomness
+
+Semantics: Deterministically derives signing key, verification key and attribute randomness for an account.
+
+This function takes as input a NUL-terminated UTF8-encoded string. The string
+must be a valid JSON object with fields
+
+- `"seed"` ... the seed used to derive keys from, as a hex string.
+
+- `"net"` ... determines whether to derive keys for Mainnet or a testnet. Has to be "Mainnet" or "Testnet", all other values will fail.
+
+- `"identityIndex"` ... the index of the identity to derive keys and randomness for, a u32 value
+
+- `"accountCredentialIndex"` ... the index of the account credential to derive keys and randomness for, a u32 value
+
+The returned value is a JSON object with the following fields:
+
+- `"signingKey"` ... the account signing key as a hex encoded string.
+
+- `"verifyKey"` ... the account verification key as a hex encoded string.
+
+- `"attributeCommitmentRandomness"` ... a map with attribute indices as keys and the corresponding attribute commitment randomness as values. 
+
+An example input to this request is in the file [get_account_keys_and_randomness-input.json](files/get_account_keys_and_randomness-input.json).
+An example output to this request is in the file [get_account_keys_and_randomness-output.json](files/get_account_keys_and_randomness-output.json).
+
+
 ## Example
 The [Example C program](example.c) that uses the library is available. This
 program reads a JSON file and passes it to the library, retrieving and printing

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -453,7 +453,7 @@ must be a valid JSON object with fields
 
 - `"seed"` ... the seed used to derive keys from, as a hex string.
 
-- `"net"` ... determines whether to derive keys for Mainnet or a testnet. Has to be "Mainnet" or "Testnet", all other values will fail.
+- `"net"` ... determines whether to derive keys for Mainnet or a Testnet. Has to be "Mainnet" or "Testnet", all other values will fail. Note that the value is case sensitive.
 
 - `"identityIndex"` ... the index of the identity to derive keys and randomness for, a u32 value
 
@@ -477,7 +477,7 @@ must be a valid JSON object with fields
 
 - `"seed"` ... the seed used to derive keys from, as a hex string.
 
-- `"net"` ... determines whether to derive keys for Mainnet or a testnet. Has to be "Mainnet" or "Testnet", all other values will fail.
+- `"net"` ... determines whether to derive keys for Mainnet or a Testnet. Has to be "Mainnet" or "Testnet", all other values will fail. Note that the value is case sensitive.
 
 - `"identityIndex"` ... the index of the identity to derive keys and randomness for, a u32 value
 

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -485,7 +485,7 @@ must be a valid JSON object with fields
 
 The returned value is a JSON object with the following fields:
 
-- `"signingKey"` ... the account signing key as a hex encoded string.
+- `"signKey"` ... the account signing key as a hex encoded string.
 
 - `"verifyKey"` ... the account verification key as a hex encoded string.
 

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -963,6 +963,8 @@ checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
 name = "key_derivation"
 version = "1.0.0"
 dependencies = [
+ "crypto_common",
+ "dodis_yampolskiy_prf",
  "ed25519-dalek",
  "ed25519_hd_key_derivation",
  "hex",
@@ -970,7 +972,7 @@ dependencies = [
  "id",
  "keygen_bls",
  "pairing",
- "regex",
+ "ps_sig",
  "serde",
  "sha2 0.10.2",
 ]

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -969,6 +969,7 @@ dependencies = [
  "keygen_bls",
  "pairing",
  "regex",
+ "serde",
  "sha2 0.10.2",
 ]
 

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -54,6 +54,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -135,6 +144,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
  "block-padding 0.2.1",
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
+dependencies = [
  "generic-array 0.14.5",
 ]
 
@@ -427,6 +445,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57952ca27b5e3606ff4dd79b0020231aaf9d6aa76dc05fd30137538c50bd3ce8"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
+]
+
+[[package]]
 name = "crypto-mac"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,7 +480,7 @@ dependencies = [
  "ff",
  "group",
  "hex",
- "hmac",
+ "hmac 0.11.0",
  "libc",
  "pairing",
  "pbkdf2",
@@ -557,6 +585,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "dodis_yampolskiy_prf"
 version = "0.1.0"
 dependencies = [
@@ -609,6 +648,16 @@ dependencies = [
  "serde",
  "sha2 0.9.9",
  "zeroize",
+]
+
+[[package]]
+name = "ed25519_hd_key_derivation"
+version = "1.0.0"
+dependencies = [
+ "hex",
+ "hmac 0.12.1",
+ "regex",
+ "sha2 0.10.2",
 ]
 
 [[package]]
@@ -794,7 +843,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01706d578d5c281058480e673ae4086a9f4710d8df1ad80a5b03e39ece5f886b"
 dependencies = [
  "digest 0.9.0",
- "hmac",
+ "hmac 0.11.0",
 ]
 
 [[package]]
@@ -805,6 +854,15 @@ checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
 dependencies = [
  "crypto-mac",
  "digest 0.9.0",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.3",
 ]
 
 [[package]]
@@ -1035,7 +1093,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f05894bce6a1ba4be299d0c5f29563e08af2bc18bb7d48313113bed71e904739"
 dependencies = [
  "crypto-mac",
- "hmac",
+ "hmac 0.11.0",
  "password-hash",
  "sha2 0.9.9",
 ]
@@ -1272,10 +1330,12 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 
@@ -1397,6 +1457,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug 0.3.0",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55deaec60f81eefe3cce0dc50bda92d6d8e88f2a27df7c5033b42afeb1ed2676"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.3",
 ]
 
 [[package]]

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -654,6 +654,7 @@ dependencies = [
 name = "ed25519_hd_key_derivation"
 version = "1.0.0"
 dependencies = [
+ "ed25519-dalek",
  "hex",
  "hmac 0.12.1",
  "regex",
@@ -956,6 +957,20 @@ name = "keccak"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c21572b4949434e4fc1e1978b99c5f77064153c59d998bf13ecd96fb5ecba7"
+
+[[package]]
+name = "key_derivation"
+version = "1.0.0"
+dependencies = [
+ "ed25519-dalek",
+ "ed25519_hd_key_derivation",
+ "hex",
+ "hmac 0.12.1",
+ "keygen_bls",
+ "pairing",
+ "regex",
+ "sha2 0.10.2",
+]
 
 [[package]]
 name = "keygen_bls"

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -659,6 +659,7 @@ dependencies = [
  "hmac 0.12.1",
  "regex",
  "sha2 0.10.2",
+ "thiserror",
 ]
 
 [[package]]
@@ -966,6 +967,7 @@ dependencies = [
  "ed25519_hd_key_derivation",
  "hex",
  "hmac 0.12.1",
+ "id",
  "keygen_bls",
  "pairing",
  "regex",

--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -17,5 +17,6 @@ members=[
    "random_oracle",
    "bulletproofs",
    "encrypted_transfers",
-   "keygen_bls"
+   "keygen_bls",
+   "ed25519_hd_key_derivation"
 ]

--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -18,5 +18,6 @@ members=[
    "bulletproofs",
    "encrypted_transfers",
    "keygen_bls",
-   "ed25519_hd_key_derivation"
+   "ed25519_hd_key_derivation",
+   "key_derivation"
 ]

--- a/rust-src/ed25519_hd_key_derivation/Cargo.toml
+++ b/rust-src/ed25519_hd_key_derivation/Cargo.toml
@@ -10,6 +10,7 @@ hex = "0.4.3"
 hmac = "0.12.1"
 sha2 = "0.10.2"
 regex = "1.5.5"
+ed25519-dalek = "=1.0"
 
 [lib]
 name = "ed25519_hd_key_derivation"

--- a/rust-src/ed25519_hd_key_derivation/Cargo.toml
+++ b/rust-src/ed25519_hd_key_derivation/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ed25519_hd_key_derivation"
+version = "1.0.0"
+authors = ["Concordium AG <developers@concordium.com>"]
+edition = "2018"
+license-file = "../../LICENSE"
+
+[dependencies]
+hex = "0.4.3"
+hmac = "0.12.1"
+sha2 = "0.10.2"
+regex = "1.5.5"
+
+[lib]
+name = "ed25519_hd_key_derivation"
+crate-type = ["rlib"]

--- a/rust-src/ed25519_hd_key_derivation/Cargo.toml
+++ b/rust-src/ed25519_hd_key_derivation/Cargo.toml
@@ -11,6 +11,7 @@ hmac = "0.12.1"
 sha2 = "0.10.2"
 regex = "1.5.5"
 ed25519-dalek = "=1.0"
+thiserror = "1.0"
 
 [lib]
 name = "ed25519_hd_key_derivation"

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -6,7 +6,7 @@ const ED25519_CURVE: &[u8; 12] = b"ed25519 seed";
 const HARDENED_OFFSET: u32 = 0x80000000;
 
 pub struct HdKeys {
-    key:        [u8; 32],
+    pub key:        [u8; 32],
     chain_code: [u8; 32],
 }
 
@@ -92,11 +92,14 @@ mod tests {
     const TEST_VECTOR_1_SEED: &str = "000102030405060708090a0b0c0d0e0f";
     const TEST_VECTOR_2_SEED: &str = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
 
-    fn assert_keys(seed: &str, path: &str, chain_code: &str, private_key: &str) {
+    fn assert_keys(seed: &str, path: &str, chain_code: &str, private_key: &str, public_key: &str) {
         let seed = hex::decode(seed).unwrap();
         let keys = derive(&path, &seed).unwrap();
+        let secret_key = ed25519_dalek::SecretKey::from_bytes(&keys.key).unwrap();
+        let public_key_derived = ed25519_dalek::PublicKey::from(&secret_key).to_bytes();
         assert_eq!(keys.chain_code.to_vec(), hex::decode(chain_code).unwrap());
         assert_eq!(keys.key.to_vec(), hex::decode(private_key).unwrap());
+        assert_eq!(public_key_derived.to_vec(), hex::decode(public_key).unwrap())
     }
 
     #[test]
@@ -147,6 +150,7 @@ mod tests {
             "m/0'",
             "8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69",
             "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3",
+            "8c8a13df77a28f3445213a0f432fde644acaa215fc72dcdf300d5efaa85d350c"
         );
     }
 
@@ -157,6 +161,7 @@ mod tests {
             "m/0'/1'",
             "a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14",
             "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2",
+            "1932a5270f335bed617d5b935c80aedb1a35bd9fc1e31acafd5372c30f5c1187"
         );
     }
 
@@ -167,6 +172,7 @@ mod tests {
             "m/0'/1'/2'",
             "2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c",
             "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9",
+            "ae98736566d30ed0e9d2f4486a64bc95740d89c7db33f52121f8ea8f76ff0fc1"
         );
     }
 
@@ -177,6 +183,7 @@ mod tests {
             "m/0'/1'/2'/2'",
             "8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc",
             "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662",
+            "8abae2d66361c879b900d204ad2cc4984fa2aa344dd7ddc46007329ac76c429c"
         );
     }
 
@@ -187,6 +194,7 @@ mod tests {
             "m/0'/1'/2'/2'/1000000000'",
             "68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230",
             "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793",
+            "3c24da049451555d51a7014a37337aa4e12d41e485abccfa46b47dfb2af54b7a"
         );
     }
 
@@ -213,6 +221,7 @@ mod tests {
             "m/0'",
             "0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d",
             "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635",
+            "86fab68dcb57aa196c77c5f264f215a112c22a912c10d123b0d03c3c28ef1037"
         );
     }
 
@@ -223,6 +232,7 @@ mod tests {
             "m/0'/2147483647'",
             "138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f",
             "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4",
+            "5ba3b9ac6e90e83effcd25ac4e58a1365a9e35a3d3ae5eb07b9e4d90bcf7506d"
         );
     }
 
@@ -233,6 +243,7 @@ mod tests {
             "m/0'/2147483647'/1'",
             "73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90",
             "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c",
+            "2e66aa57069c86cc18249aecf5cb5a9cebbfd6fadeab056254763874a9352b45"
         );
     }
 
@@ -243,6 +254,7 @@ mod tests {
             "m/0'/2147483647'/1'/2147483646'",
             "0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a",
             "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72",
+            "e33c0f7d81d843c572275f287498e8d408654fdf0d1e065b84e2e6f157aab09b"
         );
     }
 
@@ -253,6 +265,7 @@ mod tests {
             "m/0'/2147483647'/1'/2147483646'/2'",
             "5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4",
             "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d",
+            "47150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0"
         );
     }
 }

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -6,7 +6,7 @@ const ED25519_CURVE: &[u8; 12] = b"ed25519 seed";
 const HARDENED_OFFSET: u32 = 0x80000000;
 
 pub struct HdKeys {
-    pub key:        [u8; 32],
+    pub key:    [u8; 32],
     chain_code: [u8; 32],
 }
 
@@ -99,7 +99,10 @@ mod tests {
         let public_key_derived = ed25519_dalek::PublicKey::from(&secret_key).to_bytes();
         assert_eq!(keys.chain_code.to_vec(), hex::decode(chain_code).unwrap());
         assert_eq!(keys.key.to_vec(), hex::decode(private_key).unwrap());
-        assert_eq!(public_key_derived.to_vec(), hex::decode(public_key).unwrap())
+        assert_eq!(
+            public_key_derived.to_vec(),
+            hex::decode(public_key).unwrap()
+        )
     }
 
     #[test]
@@ -122,7 +125,7 @@ mod tests {
 
     #[test]
     pub fn test_derive_invalid_path() {
-        let invalid_path =  "m/4//146";
+        let invalid_path = "m/4//146";
         let seed = hex::decode("123456").unwrap();
         assert!(derive(&invalid_path, &seed).is_err());
     }
@@ -150,7 +153,7 @@ mod tests {
             "m/0'",
             "8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69",
             "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3",
-            "8c8a13df77a28f3445213a0f432fde644acaa215fc72dcdf300d5efaa85d350c"
+            "8c8a13df77a28f3445213a0f432fde644acaa215fc72dcdf300d5efaa85d350c",
         );
     }
 
@@ -161,7 +164,7 @@ mod tests {
             "m/0'/1'",
             "a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14",
             "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2",
-            "1932a5270f335bed617d5b935c80aedb1a35bd9fc1e31acafd5372c30f5c1187"
+            "1932a5270f335bed617d5b935c80aedb1a35bd9fc1e31acafd5372c30f5c1187",
         );
     }
 
@@ -172,7 +175,7 @@ mod tests {
             "m/0'/1'/2'",
             "2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c",
             "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9",
-            "ae98736566d30ed0e9d2f4486a64bc95740d89c7db33f52121f8ea8f76ff0fc1"
+            "ae98736566d30ed0e9d2f4486a64bc95740d89c7db33f52121f8ea8f76ff0fc1",
         );
     }
 
@@ -183,7 +186,7 @@ mod tests {
             "m/0'/1'/2'/2'",
             "8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc",
             "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662",
-            "8abae2d66361c879b900d204ad2cc4984fa2aa344dd7ddc46007329ac76c429c"
+            "8abae2d66361c879b900d204ad2cc4984fa2aa344dd7ddc46007329ac76c429c",
         );
     }
 
@@ -194,7 +197,7 @@ mod tests {
             "m/0'/1'/2'/2'/1000000000'",
             "68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230",
             "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793",
-            "3c24da049451555d51a7014a37337aa4e12d41e485abccfa46b47dfb2af54b7a"
+            "3c24da049451555d51a7014a37337aa4e12d41e485abccfa46b47dfb2af54b7a",
         );
     }
 
@@ -221,7 +224,7 @@ mod tests {
             "m/0'",
             "0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d",
             "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635",
-            "86fab68dcb57aa196c77c5f264f215a112c22a912c10d123b0d03c3c28ef1037"
+            "86fab68dcb57aa196c77c5f264f215a112c22a912c10d123b0d03c3c28ef1037",
         );
     }
 
@@ -232,7 +235,7 @@ mod tests {
             "m/0'/2147483647'",
             "138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f",
             "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4",
-            "5ba3b9ac6e90e83effcd25ac4e58a1365a9e35a3d3ae5eb07b9e4d90bcf7506d"
+            "5ba3b9ac6e90e83effcd25ac4e58a1365a9e35a3d3ae5eb07b9e4d90bcf7506d",
         );
     }
 
@@ -243,7 +246,7 @@ mod tests {
             "m/0'/2147483647'/1'",
             "73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90",
             "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c",
-            "2e66aa57069c86cc18249aecf5cb5a9cebbfd6fadeab056254763874a9352b45"
+            "2e66aa57069c86cc18249aecf5cb5a9cebbfd6fadeab056254763874a9352b45",
         );
     }
 
@@ -254,7 +257,7 @@ mod tests {
             "m/0'/2147483647'/1'/2147483646'",
             "0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a",
             "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72",
-            "e33c0f7d81d843c572275f287498e8d408654fdf0d1e065b84e2e6f157aab09b"
+            "e33c0f7d81d843c572275f287498e8d408654fdf0d1e065b84e2e6f157aab09b",
         );
     }
 
@@ -265,7 +268,7 @@ mod tests {
             "m/0'/2147483647'/1'/2147483646'/2'",
             "5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4",
             "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d",
-            "47150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0"
+            "47150c75db263559a70d5778bf36abbab30fb061ad69f69ece61a72b0cfa4fc0",
         );
     }
 }

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -1,0 +1,258 @@
+use hmac::{Hmac, Mac};
+use regex::Regex;
+use sha2::Sha512;
+
+const ED25519_CURVE: &[u8; 12] = b"ed25519 seed";
+const HARDENED_OFFSET: u32 = 0x80000000;
+
+pub struct HdKeys {
+    key:        [u8; 32],
+    chain_code: [u8; 32],
+}
+
+fn get_master_key_from_seed(seed: &[u8]) -> HdKeys {
+    let mut mac = Hmac::<Sha512>::new_from_slice(ED25519_CURVE).unwrap();
+    mac.update(&seed);
+    let i = mac.finalize().into_bytes();
+    let mut il = [0u8; 32];
+    il.clone_from_slice(&i[0..32]);
+    let mut ir = [0u8; 32];
+    ir.clone_from_slice(&i[32..64]);
+
+    HdKeys {
+        key:        il,
+        chain_code: ir,
+    }
+}
+
+fn ckd_priv(keys: HdKeys, index: u32) -> HdKeys {
+    if index & HARDENED_OFFSET == 0 {
+        panic!("Received a non-hardened index!");
+    }
+
+    let mut data = vec![0u8];
+    data.extend_from_slice(&keys.key);
+    data.extend_from_slice(&index.to_be_bytes());
+
+    let mut mac = Hmac::<Sha512>::new_from_slice(&keys.chain_code).unwrap();
+    mac.update(&data);
+    let i = mac.finalize().into_bytes();
+    let mut il = [0u8; 32];
+    il.clone_from_slice(&i[0..32]);
+    let mut ir = [0u8; 32];
+    ir.clone_from_slice(&i[32..64]);
+
+    HdKeys {
+        key:        il,
+        chain_code: ir,
+    }
+}
+
+fn is_valid_path(path: &str) -> bool {
+    let path_regex = Regex::new("^m(/[0-9]+')+$").unwrap();
+    if !path_regex.is_match(path) {
+        return false;
+    }
+
+    let segments: Vec<&str> = path.split('/').collect();
+    segments
+        .iter()
+        .skip(1)
+        .map(|seg| seg.replace("'", ""))
+        .all(|seg| seg.parse::<u32>().is_ok())
+}
+
+/// Derives hierarchical deterministic keys for ed25519 according to the SLIP0010 (https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
+/// specification.
+pub fn derive(path: &str, seed: &[u8]) -> Result<HdKeys, String> {
+    if !is_valid_path(path) {
+        return Err(String::from("Invalid derivation path"));
+    }
+
+    let master_key = get_master_key_from_seed(&seed);
+
+    let segments: Vec<&str> = path.split('/').collect();
+    let segments = segments
+        .iter()
+        .skip(1)
+        .map(|seg| seg.replace("'", ""))
+        .map(|seg| seg.parse::<u32>().unwrap())
+        .collect::<Vec<_>>();
+
+    let result: HdKeys = segments.iter().fold(master_key, |accum, index| {
+        ckd_priv(accum, *index + HARDENED_OFFSET)
+    });
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_VECTOR_1_SEED: &str = "000102030405060708090a0b0c0d0e0f";
+    const TEST_VECTOR_2_SEED: &str = "fffcf9f6f3f0edeae7e4e1dedbd8d5d2cfccc9c6c3c0bdbab7b4b1aeaba8a5a29f9c999693908d8a8784817e7b7875726f6c696663605d5a5754514e4b484542";
+
+    fn assert_keys(seed: &str, path: &str, chain_code: &str, private_key: &str) {
+        let seed = hex::decode(seed).unwrap();
+        let keys = derive(&path, &seed).unwrap();
+        assert_eq!(keys.chain_code.to_vec(), hex::decode(chain_code).unwrap());
+        assert_eq!(keys.key.to_vec(), hex::decode(private_key).unwrap());
+    }
+
+    #[test]
+    pub fn test_valid_path() {
+        let valid_path = "m/44'/919'";
+        assert!(is_valid_path(&valid_path));
+    }
+
+    #[test]
+    pub fn test_non_hardened_path() {
+        let non_hardened_path = "m/44'/919'/53100'/581";
+        assert!(!is_valid_path(&non_hardened_path));
+    }
+
+    #[test]
+    pub fn test_out_of_bounds_path() {
+        let out_of_bounds_index_path = "m/44'/919'/4294967296'";
+        assert!(!is_valid_path(&out_of_bounds_index_path));
+    }
+
+    #[test]
+    pub fn test_derive_invalid_path() {
+        let invalid_path =  "m/4//146";
+        let seed = hex::decode("123456").unwrap();
+        assert!(derive(&invalid_path, &seed).is_err());
+    }
+
+    #[test]
+    pub fn test_vector_1_m() {
+        let seed = hex::decode(TEST_VECTOR_1_SEED).unwrap();
+        let master_key = get_master_key_from_seed(&seed);
+        assert_eq!(
+            master_key.chain_code.to_vec(),
+            hex::decode("90046a93de5380a72b5e45010748567d5ea02bbf6522f979e05c0d8d8ca9fffb")
+                .unwrap()
+        );
+        assert_eq!(
+            master_key.key.to_vec(),
+            hex::decode("2b4be7f19ee27bbf30c667b642d5f4aa69fd169872f8fc3059c08ebae2eb19e7")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    pub fn test_vector_1_m_0() {
+        assert_keys(
+            TEST_VECTOR_1_SEED,
+            "m/0'",
+            "8b59aa11380b624e81507a27fedda59fea6d0b779a778918a2fd3590e16e9c69",
+            "68e0fe46dfb67e368c75379acec591dad19df3cde26e63b93a8e704f1dade7a3",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_1_m_0_1() {
+        assert_keys(
+            TEST_VECTOR_1_SEED,
+            "m/0'/1'",
+            "a320425f77d1b5c2505a6b1b27382b37368ee640e3557c315416801243552f14",
+            "b1d0bad404bf35da785a64ca1ac54b2617211d2777696fbffaf208f746ae84f2",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_1_m_0_1_2() {
+        assert_keys(
+            TEST_VECTOR_1_SEED,
+            "m/0'/1'/2'",
+            "2e69929e00b5ab250f49c3fb1c12f252de4fed2c1db88387094a0f8c4c9ccd6c",
+            "92a5b23c0b8a99e37d07df3fb9966917f5d06e02ddbd909c7e184371463e9fc9",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_1_m_0_1_2_2() {
+        assert_keys(
+            TEST_VECTOR_1_SEED,
+            "m/0'/1'/2'/2'",
+            "8f6d87f93d750e0efccda017d662a1b31a266e4a6f5993b15f5c1f07f74dd5cc",
+            "30d1dc7e5fc04c31219ab25a27ae00b50f6fd66622f6e9c913253d6511d1e662",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_1_m_0_1_2_2_1000000000() {
+        assert_keys(
+            TEST_VECTOR_1_SEED,
+            "m/0'/1'/2'/2'/1000000000'",
+            "68789923a0cac2cd5a29172a475fe9e0fb14cd6adb5ad98a3fa70333e7afa230",
+            "8f94d394a8e8fd6b1bc2f3f49f5c47e385281d5c17e65324b0f62483e37e8793",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m() {
+        let seed = hex::decode(TEST_VECTOR_2_SEED).unwrap();
+        let master_key = get_master_key_from_seed(&seed);
+        assert_eq!(
+            master_key.chain_code.to_vec(),
+            hex::decode("ef70a74db9c3a5af931b5fe73ed8e1a53464133654fd55e7a66f8570b8e33c3b")
+                .unwrap()
+        );
+        assert_eq!(
+            master_key.key.to_vec(),
+            hex::decode("171cb88b1b3c1db25add599712e36245d75bc65a1a5c9e18d76f9f2b1eab4012")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m_0() {
+        assert_keys(
+            TEST_VECTOR_2_SEED,
+            "m/0'",
+            "0b78a3226f915c082bf118f83618a618ab6dec793752624cbeb622acb562862d",
+            "1559eb2bbec5790b0c65d8693e4d0875b1747f4970ae8b650486ed7470845635",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m_0_2147483647() {
+        assert_keys(
+            TEST_VECTOR_2_SEED,
+            "m/0'/2147483647'",
+            "138f0b2551bcafeca6ff2aa88ba8ed0ed8de070841f0c4ef0165df8181eaad7f",
+            "ea4f5bfe8694d8bb74b7b59404632fd5968b774ed545e810de9c32a4fb4192f4",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m_0_2147483647_1() {
+        assert_keys(
+            TEST_VECTOR_2_SEED,
+            "m/0'/2147483647'/1'",
+            "73bd9fff1cfbde33a1b846c27085f711c0fe2d66fd32e139d3ebc28e5a4a6b90",
+            "3757c7577170179c7868353ada796c839135b3d30554bbb74a4b1e4a5a58505c",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m_0_2147483647_1_2147483646() {
+        assert_keys(
+            TEST_VECTOR_2_SEED,
+            "m/0'/2147483647'/1'/2147483646'",
+            "0902fe8a29f9140480a00ef244bd183e8a13288e4412d8389d140aac1794825a",
+            "5837736c89570de861ebc173b1086da4f505d4adb387c6a1b1342d5e4ac9ec72",
+        );
+    }
+
+    #[test]
+    pub fn test_vector_2_m_0_2147483647_1_2147483646_2() {
+        assert_keys(
+            TEST_VECTOR_2_SEED,
+            "m/0'/2147483647'/1'/2147483646'/2'",
+            "5d70af781f3a37b829f0d060924d5e960bdc02e85423494afc0b1a41bbe196d4",
+            "551d333177df541ad876a60ea71f00447931c0a9da16f227c11ea080d7391b8d",
+        );
+    }
+}

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -7,6 +7,9 @@ const ED25519_CURVE: &[u8; 12] = b"ed25519 seed";
 const HARDENED_OFFSET: u32 = 0x80000000;
 
 /// Harden a u32 value such that it can appear in a hardened path.
+/// Note that if the index is already hardened this function does nothing.
+/// See also [`checked_harden`] for a version which checks whether the value is
+/// not hardened.
 pub fn harden(index: u32) -> u32 { index | HARDENED_OFFSET }
 
 /// Check that the value is not yet hardened, and harden it.
@@ -76,9 +79,9 @@ fn ckd_priv(parent_keys: HdKeys, index: u32) -> Result<HdKeys, DeriveError> {
     })
 }
 
-/// Checks whether a given key derivation path is a valid key derivation
-/// path for the ed25519 SLIP0010 standard, and returns the path split
-/// into each index of the path with the hardening offset applied.
+/// Attempt to parse a given key derivation path as a path path for the ed25519
+/// SLIP0010 standard. If the path is valid return the indices on the path with
+/// with the hardening offset applied.
 ///
 /// A valid path is of the form
 ///

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -22,6 +22,10 @@ version = "1.0.0"
 path = "../keygen_bls"
 version = "2.0.0"
 
+[dependencies.id]
+path = "../id"
+version = "0"
+
 [lib]
 name = "key_derivation"
 crate-type = ["rlib"]

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "key_derivation"
+version = "1.0.0"
+authors = ["Concordium AG <developers@concordium.com>"]
+edition = "2018"
+license-file = "../../LICENSE"
+
+[dependencies]
+hex = "0.4.3"
+hmac = "0.12.1"
+sha2 = "0.10.2"
+regex = "1.5.5"
+pairing = "0.15"
+ed25519-dalek = "1.0.0"
+
+[dependencies.ed25519_hd_key_derivation]
+path = "../ed25519_hd_key_derivation"
+version = "1.0.0"
+
+[dependencies.keygen_bls]
+path = "../keygen_bls"
+version = "2.0.0"
+
+[lib]
+name = "key_derivation"
+crate-type = ["rlib"]

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -6,10 +6,8 @@ edition = "2018"
 license-file = "../../LICENSE"
 
 [dependencies]
-hex = "0.4.3"
 hmac = "0.12.1"
 sha2 = "0.10.2"
-regex = "1.5.5"
 pairing = "0.15"
 ed25519-dalek = "1.0.0"
 serde = "1.0"
@@ -22,6 +20,14 @@ version = "1.0.0"
 path = "../keygen_bls"
 version = "2.0.0"
 
+[dependencies.dodis_yampolskiy_prf]
+path = "../dodis_yampolskiy_prf"
+version = "0"
+
+[dependencies.ps_sig]
+path = "../ps_sig"
+version = "0"
+
 [dependencies.id]
 path = "../id"
 version = "0"
@@ -29,3 +35,10 @@ version = "0"
 [lib]
 name = "key_derivation"
 crate-type = ["rlib"]
+
+[dev-dependencies]
+hex = "0.4.3"
+
+[dev-dependencies.crypto_common]
+path = "../crypto_common"
+version = "0"

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -12,6 +12,7 @@ sha2 = "0.10.2"
 regex = "1.5.5"
 pairing = "0.15"
 ed25519-dalek = "1.0.0"
+serde = "1.0"
 
 [dependencies.ed25519_hd_key_derivation]
 path = "../ed25519_hd_key_derivation"

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -108,9 +108,9 @@ mod tests {
 
     #[test]
     pub fn account_signing_key() {
-        let id_cred_sec = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(55, 7);
         assert_eq!(
-            hex::encode(&id_cred_sec),
+            hex::encode(&signing_key),
             "b44f7320f156971927596f471a2302e5be8d3717a85bedfc5a0e2994615eea7d"
         );
     }
@@ -182,9 +182,9 @@ mod tests {
 
     #[test]
     pub fn testnet_account_signing_key() {
-        let id_cred_sec = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(55, 7);
         assert_eq!(
-            hex::encode(&id_cred_sec),
+            hex::encode(&signing_key),
             "67a5619aaa5d67b548f83c857c92024f57a9d902f273a62f283f2536fcb203aa"
         );
     }

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -1,4 +1,5 @@
-use ed25519_hd_key_derivation::derive;
+use ed25519_hd_key_derivation::{derive, DeriveError};
+use id::types::AttributeTag;
 use keygen_bls::keygen_bls;
 use pairing::bls12_381::FrRepr;
 use serde::Deserialize;
@@ -33,8 +34,21 @@ fn bls_key_bytes_from_seed(key_seed: [u8; 32]) -> [u8; 32] {
     bls_key
 }
 
+/// A structure that is used to derive private key material and randomness
+/// for identities and accounts.
+///
+/// The wallet should be used as a single point for deriving all required keys
+/// and randomness when creating identities and accounts, as it will allow for
+/// recovering the key material and randomness from just the seed.
 pub struct ConcordiumHdWallet {
-    pub seed: Vec<u8>,
+    /// The seed used as the basis for deriving keys. As all private keys are
+    /// derived from this seed it means that it should be considered private
+    /// and kept secret. The size is 64 bytes which corresponds to the seed
+    /// that is given by a 24-word BIP39 seed phrase.
+    pub seed: [u8; 64],
+    /// The type of blockchain network to derive keys for. Different key
+    /// derivation paths are used depending on the chosen network to avoid
+    /// collisions between a Testnet and Mainnet.
     pub net:  Net,
 }
 
@@ -45,48 +59,63 @@ impl ConcordiumHdWallet {
         derivation_path
     }
 
-    pub fn get_account_signing_key(&self, identity_index: u32, credential_index: u32) -> [u8; 32] {
-        let path = self.make_path(&format!("{}'/0'/{}'", identity_index, credential_index));
-        derive(&path, &self.seed).unwrap().key
+    pub fn get_account_signing_key(
+        &self,
+        identity_index: u32,
+        credential_counter: u32,
+    ) -> Result<[u8; 32], DeriveError> {
+        let path = self.make_path(&format!("{}'/0'/{}'", identity_index, credential_counter));
+        let private_key = match derive(&path, &self.seed) {
+            Ok(keys) => keys.private_key,
+            Err(e) => return Err(e),
+        };
+        Ok(private_key)
     }
 
-    pub fn get_account_public_key(&self, identity_index: u32, credential_index: u32) -> [u8; 32] {
-        let account_signing_key = self.get_account_signing_key(identity_index, credential_index);
+    pub fn get_account_public_key(
+        &self,
+        identity_index: u32,
+        credential_counter: u32,
+    ) -> Result<[u8; 32], DeriveError> {
+        let account_signing_key =
+            self.get_account_signing_key(identity_index, credential_counter)?;
         let secret_key = ed25519_dalek::SecretKey::from_bytes(&account_signing_key).unwrap();
         let public_key = ed25519_dalek::PublicKey::from(&secret_key);
-        public_key.to_bytes()
+        Ok(public_key.to_bytes())
     }
 
-    pub fn get_id_cred_sec(&self, identity_index: u32) -> [u8; 32] {
+    pub fn get_id_cred_sec(&self, identity_index: u32) -> Result<[u8; 32], DeriveError> {
         let path = self.make_path(&format!("{}'/2'", identity_index));
-        let id_cred_sec_seed = derive(&path, &self.seed).unwrap().key;
-        bls_key_bytes_from_seed(id_cred_sec_seed)
+        let id_cred_sec_seed = derive(&path, &self.seed)?.private_key;
+        Ok(bls_key_bytes_from_seed(id_cred_sec_seed))
     }
 
-    pub fn get_prf_key(&self, identity_index: u32) -> [u8; 32] {
+    pub fn get_prf_key(&self, identity_index: u32) -> Result<[u8; 32], DeriveError> {
         let path = self.make_path(&format!("{}'/3'", identity_index));
-        let prf_key_seed = derive(&path, &self.seed).unwrap().key;
-        bls_key_bytes_from_seed(prf_key_seed)
+        let prf_key_seed = derive(&path, &self.seed)?.private_key;
+        Ok(bls_key_bytes_from_seed(prf_key_seed))
     }
 
-    pub fn get_blinding_randomness(&self, identity_index: u32) -> [u8; 32] {
+    pub fn get_blinding_randomness(&self, identity_index: u32) -> Result<[u8; 32], DeriveError> {
         let path = self.make_path(&format!("{}'/4'", identity_index));
-        let blinding_randomness_seed = derive(&path, &self.seed).unwrap().key;
-        bls_key_bytes_from_seed(blinding_randomness_seed)
+        let blinding_randomness_seed = derive(&path, &self.seed)?.private_key;
+        Ok(bls_key_bytes_from_seed(blinding_randomness_seed))
     }
 
     pub fn get_attribute_commitment_randomness(
         &self,
         identity_index: u32,
-        credential_index: u32,
-        attribute_index: u32,
-    ) -> [u8; 32] {
+        credential_counter: u32,
+        attribute_tag: AttributeTag,
+    ) -> Result<[u8; 32], DeriveError> {
         let path = self.make_path(&format!(
             "{}'/5'/{}'/{}'",
-            identity_index, credential_index, attribute_index
+            identity_index, credential_counter, attribute_tag.0
         ));
-        let attribute_commitment_randomness_seed = derive(&path, &self.seed).unwrap().key;
-        bls_key_bytes_from_seed(attribute_commitment_randomness_seed)
+        let attribute_commitment_randomness_seed = derive(&path, &self.seed).unwrap().private_key;
+        Ok(bls_key_bytes_from_seed(
+            attribute_commitment_randomness_seed,
+        ))
     }
 }
 
@@ -95,12 +124,13 @@ mod tests {
     use super::*;
     use ed25519_dalek::*;
     use hex;
+    use std::convert::TryInto;
 
     const TEST_SEED_1: &str = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860";
 
     fn create_wallet(net: Net, seed: &str) -> ConcordiumHdWallet {
         let wallet = ConcordiumHdWallet {
-            seed: hex::decode(&seed).unwrap(),
+            seed: hex::decode(&seed).unwrap().try_into().unwrap(),
             net,
         };
         wallet
@@ -108,7 +138,9 @@ mod tests {
 
     #[test]
     pub fn account_signing_key() {
-        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_account_signing_key(55, 7)
+            .unwrap();
         assert_eq!(
             hex::encode(&signing_key),
             "b44f7320f156971927596f471a2302e5be8d3717a85bedfc5a0e2994615eea7d"
@@ -117,7 +149,9 @@ mod tests {
 
     #[test]
     pub fn account_public_key() {
-        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_public_key(341, 9);
+        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_account_public_key(341, 9)
+            .unwrap();
         assert_eq!(
             hex::encode(&public_key),
             "cc2f4d34bdd0d8e206cf1704516d7ce533f83773492f670144fcbeda33774c5c"
@@ -126,8 +160,12 @@ mod tests {
 
     #[test]
     pub fn account_signing_key_matches_public_key() {
-        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_public_key(0, 0);
-        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(0, 0);
+        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_account_public_key(0, 0)
+            .unwrap();
+        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_account_signing_key(0, 0)
+            .unwrap();
 
         let sk = ed25519_dalek::SecretKey::from_bytes(&signing_key).unwrap();
         let expanded_sk = ExpandedSecretKey::from(&sk);
@@ -144,7 +182,9 @@ mod tests {
 
     #[test]
     pub fn id_cred_sec() {
-        let id_cred_sec = create_wallet(Net::Mainnet, TEST_SEED_1).get_id_cred_sec(115);
+        let id_cred_sec = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_id_cred_sec(115)
+            .unwrap();
         assert_eq!(
             hex::encode(&id_cred_sec),
             "27db5d5c1e346670bd2d9b4235a180629c750b067a83942e55fc43303531c1aa"
@@ -153,7 +193,9 @@ mod tests {
 
     #[test]
     pub fn prf_key() {
-        let prf_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_prf_key(35);
+        let prf_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_prf_key(35)
+            .unwrap();
         assert_eq!(
             hex::encode(&prf_key),
             "1c8a30e2136dcc5e4f8b6fa359e908718d65ea2c2638d8fa6ff72c24d8ed3d68"
@@ -162,8 +204,9 @@ mod tests {
 
     #[test]
     pub fn blinding_randomness() {
-        let blinding_randomness =
-            create_wallet(Net::Mainnet, TEST_SEED_1).get_blinding_randomness(5713);
+        let blinding_randomness = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_blinding_randomness(5713)
+            .unwrap();
         assert_eq!(
             hex::encode(&blinding_randomness),
             "2924d5bc605cc06632e061cec491c1f6b476b3abe51e526f641bcea355cd8bf6"
@@ -172,8 +215,9 @@ mod tests {
 
     #[test]
     pub fn attribute_commitment_randomness() {
-        let attribute_commitment_randomness =
-            create_wallet(Net::Mainnet, TEST_SEED_1).get_attribute_commitment_randomness(0, 4, 0);
+        let attribute_commitment_randomness = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_attribute_commitment_randomness(0, 4, AttributeTag(0))
+            .unwrap();
         assert_eq!(
             hex::encode(&attribute_commitment_randomness),
             "462e12bbda5b58ac6e3be920d41adce8b9d0779c13c34913b1f61748f0bbf051"
@@ -182,7 +226,9 @@ mod tests {
 
     #[test]
     pub fn testnet_account_signing_key() {
-        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_account_signing_key(55, 7)
+            .unwrap();
         assert_eq!(
             hex::encode(&signing_key),
             "67a5619aaa5d67b548f83c857c92024f57a9d902f273a62f283f2536fcb203aa"
@@ -191,7 +237,9 @@ mod tests {
 
     #[test]
     pub fn testnet_account_public_key() {
-        let public_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_public_key(341, 9);
+        let public_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_account_public_key(341, 9)
+            .unwrap();
         assert_eq!(
             hex::encode(&public_key),
             "b90e8e5f45c1181e93d5cad6ad7414036538c6c806140cb4bf7957d8ff350004"
@@ -200,8 +248,12 @@ mod tests {
 
     #[test]
     pub fn testnet_account_signing_key_matches_public_key() {
-        let public_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_public_key(0, 0);
-        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(0, 0);
+        let public_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_account_public_key(0, 0)
+            .unwrap();
+        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_account_signing_key(0, 0)
+            .unwrap();
 
         let sk = ed25519_dalek::SecretKey::from_bytes(&signing_key).unwrap();
         let expanded_sk = ExpandedSecretKey::from(&sk);
@@ -218,7 +270,9 @@ mod tests {
 
     #[test]
     pub fn testnet_id_cred_sec() {
-        let id_cred_sec = create_wallet(Net::Testnet, TEST_SEED_1).get_id_cred_sec(115);
+        let id_cred_sec = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_id_cred_sec(115)
+            .unwrap();
         assert_eq!(
             hex::encode(&id_cred_sec),
             "719130a7429a69d1f673a7d051043e63ab237098928ffa2066bdddbc3f93bdb1"
@@ -227,7 +281,9 @@ mod tests {
 
     #[test]
     pub fn testnet_prf_key() {
-        let prf_key = create_wallet(Net::Testnet, TEST_SEED_1).get_prf_key(35);
+        let prf_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_prf_key(35)
+            .unwrap();
         assert_eq!(
             hex::encode(&prf_key),
             "623cc233afcdf8063800615d7b52aa535533f0ab054891b4f821e2912018a2fb"
@@ -236,8 +292,9 @@ mod tests {
 
     #[test]
     pub fn testnet_blinding_randomness() {
-        let blinding_randomness =
-            create_wallet(Net::Testnet, TEST_SEED_1).get_blinding_randomness(5713);
+        let blinding_randomness = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_blinding_randomness(5713)
+            .unwrap();
         assert_eq!(
             hex::encode(&blinding_randomness),
             "2d6093f16ce3cc2d1d7eca2c7c4c7a80449980b10baf0b3366dc70ba2564c7aa"
@@ -246,8 +303,9 @@ mod tests {
 
     #[test]
     pub fn testnet_attribute_commitment_randomness() {
-        let attribute_commitment_randomness =
-            create_wallet(Net::Testnet, TEST_SEED_1).get_attribute_commitment_randomness(0, 4, 0);
+        let attribute_commitment_randomness = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_attribute_commitment_randomness(0, 4, AttributeTag(0))
+            .unwrap();
         assert_eq!(
             hex::encode(&attribute_commitment_randomness),
             "50cb39a9009b36c8ce21fdedab9db520de300a6405e5ffe4786c3c75b09f9ae0"

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -1,0 +1,254 @@
+use ed25519_hd_key_derivation::derive;
+use keygen_bls::keygen_bls;
+use pairing::bls12_381::FrRepr;
+use std::fmt;
+
+pub enum Net {
+    Mainnet,
+    Testnet,
+}
+
+impl fmt::Display for Net {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Net::Mainnet => write!(f, "919"),
+            Net::Testnet => write!(f, "1"),
+        }
+    }
+}
+
+fn bls_key_bytes_from_seed(key_seed: [u8; 32]) -> [u8; 32] {
+    let bls_key_fr = keygen_bls(&key_seed, b"").unwrap();
+    let fr_repr = FrRepr::from(bls_key_fr);
+    let fr_repr_ref = fr_repr.as_ref();
+    let key_bytes: Vec<u8> = fr_repr_ref
+        .iter()
+        .rev()
+        .flat_map(|val| val.to_be_bytes())
+        .collect();
+    let mut bls_key = [0u8; 32];
+    bls_key.clone_from_slice(&key_bytes[0..32]);
+    bls_key
+}
+
+pub struct ConcordiumHdWallet {
+    seed: Vec<u8>,
+    net:  Net,
+}
+
+impl ConcordiumHdWallet {
+    fn make_path(&self, path: &str) -> String {
+        let root_path: &str = "m/44'";
+        let derivation_path = format!("{}/{}'/{}", root_path, &self.net, path);
+        derivation_path
+    }
+
+    pub fn get_account_signing_key(&self, identity_index: u32, credential_index: u32) -> [u8; 32] {
+        let path = self.make_path(&format!("{}'/0'/{}'", identity_index, credential_index));
+        derive(&path, &self.seed).unwrap().key
+    }
+
+    pub fn get_account_public_key(&self, identity_index: u32, credential_index: u32) -> [u8; 32] {
+        let account_signing_key = self.get_account_signing_key(identity_index, credential_index);
+        let secret_key = ed25519_dalek::SecretKey::from_bytes(&account_signing_key).unwrap();
+        let public_key = ed25519_dalek::PublicKey::from(&secret_key);
+        public_key.to_bytes()
+    }
+
+    pub fn get_id_cred_sec(&self, identity_index: u32) -> [u8; 32] {
+        let path = self.make_path(&format!("{}'/2'", identity_index));
+        let id_cred_sec_seed = derive(&path, &self.seed).unwrap().key;
+        bls_key_bytes_from_seed(id_cred_sec_seed)
+    }
+
+    pub fn get_prf_key(&self, identity_index: u32) -> [u8; 32] {
+        let path = self.make_path(&format!("{}'/3'", identity_index));
+        let prf_key_seed = derive(&path, &self.seed).unwrap().key;
+        bls_key_bytes_from_seed(prf_key_seed)
+    }
+
+    pub fn get_blinding_randomness(&self, identity_index: u32) -> [u8; 32] {
+        let path = self.make_path(&format!("{}'/4'", identity_index));
+        let blinding_randomness_seed = derive(&path, &self.seed).unwrap().key;
+        bls_key_bytes_from_seed(blinding_randomness_seed)
+    }
+
+    pub fn get_attribute_commitment_randomness(
+        &self,
+        identity_index: u32,
+        credential_index: u32,
+        attribute_index: u32,
+    ) -> [u8; 32] {
+        let path = self.make_path(&format!(
+            "{}'/5'/{}'/{}'",
+            identity_index, credential_index, attribute_index
+        ));
+        let attribute_commitment_randomness_seed = derive(&path, &self.seed).unwrap().key;
+        bls_key_bytes_from_seed(attribute_commitment_randomness_seed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ed25519_dalek::*;
+    use hex;
+
+    const TEST_SEED_1: &str = "efa5e27326f8fa0902e647b52449bf335b7b605adc387015ec903f41d95080eb71361cbc7fb78721dcd4f3926a337340aa1406df83332c44c1cdcfe100603860";
+
+    fn create_wallet(net: Net, seed: &str) -> ConcordiumHdWallet {
+        let wallet = ConcordiumHdWallet {
+            seed: hex::decode(&seed).unwrap(),
+            net,
+        };
+        wallet
+    }
+
+    #[test]
+    pub fn account_signing_key() {
+        let id_cred_sec = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        assert_eq!(
+            hex::encode(&id_cred_sec),
+            "b44f7320f156971927596f471a2302e5be8d3717a85bedfc5a0e2994615eea7d"
+        );
+    }
+
+    #[test]
+    pub fn account_public_key() {
+        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_public_key(341, 9);
+        assert_eq!(
+            hex::encode(&public_key),
+            "cc2f4d34bdd0d8e206cf1704516d7ce533f83773492f670144fcbeda33774c5c"
+        );
+    }
+
+    #[test]
+    pub fn account_signing_key_matches_public_key() {
+        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_public_key(0, 0);
+        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_account_signing_key(0, 0);
+
+        let sk = ed25519_dalek::SecretKey::from_bytes(&signing_key).unwrap();
+        let expanded_sk = ExpandedSecretKey::from(&sk);
+        let pk = ed25519_dalek::PublicKey::from_bytes(&public_key).unwrap();
+
+        let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
+        let signature = expanded_sk.sign(&data_to_sign, &pk);
+
+        pk.verify(&data_to_sign, &signature).expect(
+            "The public key should be able to verify the signature, otherwise the keys do not \
+             match.",
+        );
+    }
+
+    #[test]
+    pub fn id_cred_sec() {
+        let id_cred_sec = create_wallet(Net::Mainnet, TEST_SEED_1).get_id_cred_sec(115);
+        assert_eq!(
+            hex::encode(&id_cred_sec),
+            "27db5d5c1e346670bd2d9b4235a180629c750b067a83942e55fc43303531c1aa"
+        );
+    }
+
+    #[test]
+    pub fn prf_key() {
+        let prf_key = create_wallet(Net::Mainnet, TEST_SEED_1).get_prf_key(35);
+        assert_eq!(
+            hex::encode(&prf_key),
+            "1c8a30e2136dcc5e4f8b6fa359e908718d65ea2c2638d8fa6ff72c24d8ed3d68"
+        );
+    }
+
+    #[test]
+    pub fn blinding_randomness() {
+        let blinding_randomness =
+            create_wallet(Net::Mainnet, TEST_SEED_1).get_blinding_randomness(5713);
+        assert_eq!(
+            hex::encode(&blinding_randomness),
+            "2924d5bc605cc06632e061cec491c1f6b476b3abe51e526f641bcea355cd8bf6"
+        );
+    }
+
+    #[test]
+    pub fn attribute_commitment_randomness() {
+        let attribute_commitment_randomness =
+            create_wallet(Net::Mainnet, TEST_SEED_1).get_attribute_commitment_randomness(0, 4, 0);
+        assert_eq!(
+            hex::encode(&attribute_commitment_randomness),
+            "462e12bbda5b58ac6e3be920d41adce8b9d0779c13c34913b1f61748f0bbf051"
+        );
+    }
+
+    #[test]
+    pub fn testnet_account_signing_key() {
+        let id_cred_sec = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(55, 7);
+        assert_eq!(
+            hex::encode(&id_cred_sec),
+            "67a5619aaa5d67b548f83c857c92024f57a9d902f273a62f283f2536fcb203aa"
+        );
+    }
+
+    #[test]
+    pub fn testnet_account_public_key() {
+        let public_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_public_key(341, 9);
+        assert_eq!(
+            hex::encode(&public_key),
+            "b90e8e5f45c1181e93d5cad6ad7414036538c6c806140cb4bf7957d8ff350004"
+        );
+    }
+
+    #[test]
+    pub fn testnet_account_signing_key_matches_public_key() {
+        let public_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_public_key(0, 0);
+        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1).get_account_signing_key(0, 0);
+
+        let sk = ed25519_dalek::SecretKey::from_bytes(&signing_key).unwrap();
+        let expanded_sk = ExpandedSecretKey::from(&sk);
+        let pk = ed25519_dalek::PublicKey::from_bytes(&public_key).unwrap();
+
+        let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
+        let signature = expanded_sk.sign(&data_to_sign, &pk);
+
+        pk.verify(&data_to_sign, &signature).expect(
+            "The public key should be able to verify the signature, otherwise the keys do not \
+             match.",
+        );
+    }
+
+    #[test]
+    pub fn testnet_id_cred_sec() {
+        let id_cred_sec = create_wallet(Net::Testnet, TEST_SEED_1).get_id_cred_sec(115);
+        assert_eq!(
+            hex::encode(&id_cred_sec),
+            "719130a7429a69d1f673a7d051043e63ab237098928ffa2066bdddbc3f93bdb1"
+        );
+    }
+
+    #[test]
+    pub fn testnet_prf_key() {
+        let prf_key = create_wallet(Net::Testnet, TEST_SEED_1).get_prf_key(35);
+        assert_eq!(
+            hex::encode(&prf_key),
+            "623cc233afcdf8063800615d7b52aa535533f0ab054891b4f821e2912018a2fb"
+        );
+    }
+
+    #[test]
+    pub fn testnet_blinding_randomness() {
+        let blinding_randomness =
+            create_wallet(Net::Testnet, TEST_SEED_1).get_blinding_randomness(5713);
+        assert_eq!(
+            hex::encode(&blinding_randomness),
+            "2d6093f16ce3cc2d1d7eca2c7c4c7a80449980b10baf0b3366dc70ba2564c7aa"
+        );
+    }
+
+    #[test]
+    pub fn testnet_attribute_commitment_randomness() {
+        let attribute_commitment_randomness =
+            create_wallet(Net::Testnet, TEST_SEED_1).get_attribute_commitment_randomness(0, 4, 0);
+        assert_eq!(
+            hex::encode(&attribute_commitment_randomness),
+            "50cb39a9009b36c8ce21fdedab9db520de300a6405e5ffe4786c3c75b09f9ae0"
+        );
+    }
+}

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -1,8 +1,10 @@
 use ed25519_hd_key_derivation::derive;
 use keygen_bls::keygen_bls;
 use pairing::bls12_381::FrRepr;
+use serde::Deserialize;
 use std::fmt;
 
+#[derive(Deserialize)]
 pub enum Net {
     Mainnet,
     Testnet,
@@ -32,8 +34,8 @@ fn bls_key_bytes_from_seed(key_seed: [u8; 32]) -> [u8; 32] {
 }
 
 pub struct ConcordiumHdWallet {
-    seed: Vec<u8>,
-    net:  Net,
+    pub seed: Vec<u8>,
+    pub net:  Net,
 }
 
 impl ConcordiumHdWallet {


### PR DESCRIPTION
## Purpose
Add library support for the mobile wallets to derive identity and account keys from a seed phrase, as well as blinding  randomness and attribute commitment randomness.

## Changes
- Added a library (_ed25519_hd_key_derivation_) that implements [SLIP0010](https://github.com/satoshilabs/slips/blob/master/slip-0010.md) for ed25519 specifically.
- Added a library (_key_derivation_) that implements the Concordium key derivation as specified in the cryptographic blue paper.
    - Note that the tests for this library check keys against keys I have derived using a TypeScript implementation of the same key derivation scheme. I will be testing by deriving keys for the same paths in the Ledger repository afterwards as extra verification.
- Added Android and iOS wrappers for getting identity keys, blinding randomness, accounts keys and attribute randomness.
   - `get_identity_keys_and_randomness` returns `id_cred_sec`, `prf_key` and `blinding_randomness`
   - `get_account_keys_and_randomness` returns `signing_key`, `verify_key` and `attribute_randomness`. Note that attribute randomness for _all_ attributes will be returned.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.