### PR TITLE
Fix potential overflow when calculating with leverage bounds

### DIFF
--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -527,8 +527,13 @@ instance FromJSON LeverageFactor where
     return $ LeverageFactor r
 
 -- |Apply a leverage factor to a capital amount.
+-- If the computed amount would be larger than the maximum amount, this returns 'maxBound'.
 applyLeverageFactor :: LeverageFactor -> Amount -> Amount
-applyLeverageFactor leverage (Amount amt) = Amount (truncate (theLeverageFactor leverage * (amt % 1)))
+applyLeverageFactor (LeverageFactor leverage) (Amount amt)
+  | preAmount > toInteger (maxBound :: Amount) = maxBound
+  | otherwise = fromInteger preAmount
+  where
+    preAmount = (toInteger (numerator leverage) * toInteger amt) `div` toInteger (denominator leverage)
 
 -- |A bound on the relative share of the total staked capital that a baker can have as its stake.
 -- This is required to be greater than 0.


### PR DESCRIPTION
## Purpose

Fixes #162

## Changes

`applyLeverageFactor` is revised to avoid overflowing by performing the calculation with (unbounded sized) `Integer`s. If the outcome exceeds the maximum representable `Amount`, it is capped at the maximum `Amount`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
