### PR TITLE
Speed up credential loading

### DIFF
--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -650,6 +650,9 @@ instance Serialize CredentialAccount where
         return $! NewAccount keys threshold
       _ -> fail "Input must be either a new account with a list of keys and threshold."
 
+-- |Values, as opposed to proofs, contained in a credential deployment. The type
+-- parameter @credTy@ determines the representation of credential registration
+-- IDs.
 data CredentialDeploymentValues' credTy = CredentialDeploymentValues {
   -- |Either an address of an existing account, or the list of keys the newly
   -- created account should have, together with a threshold for how many are needed

--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -304,23 +304,23 @@ instance FBS.FixedLength AccountEncryptionKeySize where
 -- relevant elliptic curve. As a result, this can only be used when the input is
 -- either trusted to be well-formed, or when checks will be done on it before
 -- the value is needed as an encryption key.
-newtype AccountEncryptionKeyRaw = AccountEncryptionKeyRaw (FBS.FixedByteString AccountEncryptionKeySize)
+newtype RawAccountEncryptionKey = RawAccountEncryptionKey (FBS.FixedByteString AccountEncryptionKeySize)
     deriving(Eq, Ord)
     deriving (Show, Serialize, FromJSON, ToJSON) via FBSHex AccountEncryptionKeySize
 
 -- |Reconstruct the account encryption key from the raw representation. This
 -- function is unsafe and will raise an exception if the input is not a valid
 -- account encryption key.
-unsafeEncryptionKeyFromRaw :: AccountEncryptionKeyRaw -> AccountEncryptionKey
-unsafeEncryptionKeyFromRaw (AccountEncryptionKeyRaw fbs) =
+unsafeEncryptionKeyFromRaw :: RawAccountEncryptionKey -> AccountEncryptionKey
+unsafeEncryptionKeyFromRaw (RawAccountEncryptionKey fbs) =
   case decode (FBS.toByteString fbs) of
     Left _ -> error "Precondition violation. Invalid encryption key."
     Right v -> v
 
 -- |Convert the encryption key to the raw one. This is relatively expensive
 -- since it involves constructing a canonical representation of the key.
-toRawEncryptionKey :: AccountEncryptionKey -> AccountEncryptionKeyRaw
-toRawEncryptionKey = AccountEncryptionKeyRaw . FBS.fromByteString . encode
+toRawEncryptionKey :: AccountEncryptionKey -> RawAccountEncryptionKey
+toRawEncryptionKey = RawAccountEncryptionKey . FBS.fromByteString . encode
 
 makeEncryptionKey :: GlobalContext -> CredentialRegistrationID -> AccountEncryptionKey
 makeEncryptionKey gc (RegIdCred ge) = AccountEncryptionKey (deriveElgamalPublicKey gc ge)

--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -931,11 +931,11 @@ type AccountCredential = AccountCredential' CredentialRegistrationID
 -- |Account credentials with a 'RawCredentialRegistrationID'. This has a
 -- slightly smaller memory footprint and is substantially quicker to
 -- deserialize.
-type AccountCredentialRaw = AccountCredential' RawCredentialRegistrationID
+type RawAccountCredential = AccountCredential' RawCredentialRegistrationID
 
 -- |Convert an account credential to a raw one. This is a relatively expensive
 -- function so should be used with care.
-toRawAccountCredential :: AccountCredential -> AccountCredentialRaw
+toRawAccountCredential :: AccountCredential -> RawAccountCredential
 toRawAccountCredential = fmap toRawCredRegId
 
 data CredentialType = Initial | Normal

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -628,7 +628,7 @@ newtype VoterPower = VoterPower AmountUnit
 -- |The identifier associated with an account.
 data AccountIdentifier =
   -- |Given credential registration id as an identifier.
-  CredRegID !CredentialRegistrationID
+  CredRegID !CredentialRegistrationIDRaw
   -- |Given address as an identifier. Multiple addresses may refer to the same account.
   | AccAddress !AccountAddress
   -- |Given index as an identifier.

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -597,7 +597,7 @@ data AccountInfo = AccountInfo
       aiAccountReleaseSchedule :: !AccountReleaseSummary,
       -- |The credentials on the account. This map must always contain a
       -- credential at credential index 0.
-      aiAccountCredentials :: !(Map.Map CredentialIndex (Versioned AccountCredentialRaw)),
+      aiAccountCredentials :: !(Map.Map CredentialIndex (Versioned RawAccountCredential)),
       -- |Number of credentials required to sign a valid transaction
       aiAccountThreshold :: !AccountThreshold,
       -- |The encrypted amount on the account

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -597,7 +597,7 @@ data AccountInfo = AccountInfo
       aiAccountReleaseSchedule :: !AccountReleaseSummary,
       -- |The credentials on the account. This map must always contain a
       -- credential at credential index 0.
-      aiAccountCredentials :: !(Map.Map CredentialIndex (Versioned AccountCredential)),
+      aiAccountCredentials :: !(Map.Map CredentialIndex (Versioned AccountCredentialRaw)),
       -- |Number of credentials required to sign a valid transaction
       aiAccountThreshold :: !AccountThreshold,
       -- |The encrypted amount on the account
@@ -654,7 +654,7 @@ instance FromJSON AccountInfo where
         -- credential.
         aiAccountAddress <-
             obj .:! "accountAddress" >>= \case
-                Nothing -> return (addressFromRegId (credId (vValue creatingCredential)))
+                Nothing -> return (addressFromRegIdRaw (credId (vValue creatingCredential)))
                 Just addr -> return addr
         aiStakingInfo <- accountStakingInfoFromJSON obj
         return AccountInfo{..}

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -377,7 +377,7 @@ instance HasCredentialType AccountCreation where
   {-# INLINE credentialType #-}
   credentialType = credentialType . credential
 
-instance CredentialValuesFields AccountCreation where
+instance CredentialValuesFields CredentialRegistrationID AccountCreation where
   {-# INLINE credId #-}
   credId = credId . credential
   {-# INLINE ipId #-}
@@ -391,7 +391,7 @@ instance HasCredentialType a => HasCredentialType (WithMetadata a) where
   {-# INLINE credentialType #-}
   credentialType = credentialType . wmdData
 
-instance CredentialValuesFields a => CredentialValuesFields (WithMetadata a) where
+instance CredentialValuesFields CredentialRegistrationID a => CredentialValuesFields CredentialRegistrationID (WithMetadata a) where
   {-# INLINE credId #-}
   credId = credId . wmdData
   {-# INLINE ipId #-}

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -568,7 +568,7 @@ data SenderPolicy = SenderPolicy {
   spItems :: ![(AttributeTag, AttributeValue)]
   }
 
-mkSenderPolicy :: AccountCredential -> SenderPolicy
+mkSenderPolicy :: AccountCredential' credTy -> SenderPolicy
 mkSenderPolicy ac =
     SenderPolicy{
        spCreatedAt = createdAtTs,


### PR DESCRIPTION
## Purpose

Auxiliary changes to speed up node startup.

## Changes

The main change is to make the types for account credentials and account encryption keys less strict when these are used in trusted contexts (e.g., when the value has already been verified). These are the "Raw" account encryption keys and "Raw" credential registration IDs.

The reason this is beneficial is that a raw value is substantially (orders of magnitude) cheaper to deserialize, as well as taking up around 1/3 of the space (for these two cases).

See https://github.com/Concordium/concordium-node/pull/377 for more details as to why this makes sense.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.