### PR TITLE
Added a byte representation type for CredentialRegistrationID

### DIFF
--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -295,6 +295,12 @@ instance Ord CredentialRegistrationID where
 instance FromJSON CredentialRegistrationID where
   parseJSON = withText "Credential registration ID in base16" deserializeBase16
 
+newtype RawCredentialRegistrationID = RawCredRegId (FBS.FixedByteString RegIdSize)
+   deriving newtype (Eq, Ord, Show)
+
+toRawCredRegId :: CredentialRegistrationID -> RawCredentialRegistrationID
+toRawCredRegId = RawCredRegId . FBS.fromByteString . encode
+
 newtype Proofs = Proofs ShortByteString
     deriving(Eq)
     deriving(Show) via ByteStringHex

--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -296,7 +296,8 @@ instance FromJSON CredentialRegistrationID where
   parseJSON = withText "Credential registration ID in base16" deserializeBase16
 
 newtype RawCredentialRegistrationID = RawCredRegId (FBS.FixedByteString RegIdSize)
-   deriving newtype (Eq, Ord, Show)
+   deriving newtype (Eq, Ord)
+   deriving Show via (FBSHex RegIdSize)
 
 toRawCredRegId :: CredentialRegistrationID -> RawCredentialRegistrationID
 toRawCredRegId = RawCredRegId . FBS.fromByteString . encode

--- a/haskell-src/Data/FixedByteString.hs
+++ b/haskell-src/Data/FixedByteString.hs
@@ -31,7 +31,7 @@ class FixedLength a where
 -- is determined by the type parameter @a@, which should be an
 -- instance of 'FixedLength', as @fixedLength (undefined :: a)@.
 newtype FixedByteString a = FixedByteString ByteArray
-  deriving(Data, Typeable)
+  deriving (Data, Typeable, Show)
 
 -- |NB: We need to be very careful with compiler optimizations here.
 -- The issue is that newPinnedByteArray does not depend on f as the argument (only on f)

--- a/haskell-src/Data/FixedByteString.hs
+++ b/haskell-src/Data/FixedByteString.hs
@@ -31,7 +31,7 @@ class FixedLength a where
 -- is determined by the type parameter @a@, which should be an
 -- instance of 'FixedLength', as @fixedLength (undefined :: a)@.
 newtype FixedByteString a = FixedByteString ByteArray
-  deriving (Data, Typeable, Show)
+  deriving (Data, Typeable)
 
 -- |NB: We need to be very careful with compiler optimizations here.
 -- The issue is that newPinnedByteArray does not depend on f as the argument (only on f)


### PR DESCRIPTION
## Purpose

The changes made in https://github.com/Concordium/concordium-node/pull/366 depend on this PR.

## Changes

Defined `RawCredentialRegistrationID`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [X] I accept the above linked CLA.
