### PR TITLE
Use RawCredentialRegistrationID in AccountIdentifier

### DIFF
--- a/haskell-src/Concordium/ID/Types.hs
+++ b/haskell-src/Concordium/ID/Types.hs
@@ -298,6 +298,7 @@ instance FromJSON CredentialRegistrationID where
 newtype RawCredentialRegistrationID = RawCredRegId (FBS.FixedByteString RegIdSize)
    deriving newtype (Eq, Ord)
    deriving Show via (FBSHex RegIdSize)
+   deriving Serialize via (FBSHex RegIdSize)
 
 toRawCredRegId :: CredentialRegistrationID -> RawCredentialRegistrationID
 toRawCredRegId = RawCredRegId . FBS.fromByteString . encode

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -628,7 +628,7 @@ newtype VoterPower = VoterPower AmountUnit
 -- |The identifier associated with an account.
 data AccountIdentifier =
   -- |Given credential registration id as an identifier.
-  CredRegID !CredentialRegistrationID
+  CredRegID !RawCredentialRegistrationID
   -- |Given address as an identifier. Multiple addresses may refer to the same account.
   | AccAddress !AccountAddress
   -- |Given index as an identifier.


### PR DESCRIPTION
## Purpose

Followup to https://github.com/Concordium/concordium-base/pull/165

Required in the context of https://github.com/Concordium/concordium-node/pull/366/files/9cd10116a4cb25167486060edc6f9d27d26e9cd1#r886047507

## Changes

Changed the `CredRegId` field type in `AccountIdentifier` to `RawCredentialRegistrationID`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
