### PR TITLE
Re-export for use in the SDK.

### DIFF
--- a/rust-src/id/src/lib.rs
+++ b/rust-src/id/src/lib.rs
@@ -27,6 +27,9 @@ pub use elgamal;
 /// Re-export of bulletproofs.
 pub use bulletproofs::range_proof;
 
+/// Re-export the PRF key generation functionality.
+pub use dodis_yampolskiy_prf;
+
 #[macro_use]
 extern crate crypto_common_derive;
 


### PR DESCRIPTION
## Purpose

Since PRF keys are needed/visible in credentials, it is useful to be able to just use them through the id crate, without having to import the prf crate manually.

Concretely this is useful in the rust SDK.

## Changes

Re-export the prf key crate from the id crate.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.