### PR TITLE
Remove unused failure mode.

### DIFF
--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1892,7 +1892,6 @@ data RejectReason = ModuleNotWF -- ^Error raised when validating the Wasm module
                                       contractAddress :: !ContractAddress,
                                       receiveName :: !Wasm.ReceiveName,
                                       parameter :: !Wasm.Parameter}
-                  | NonExistentRewardAccount !AccountAddress -- ^Reward account desired by the baker does not exist.
                   | InvalidProof -- ^Proof that the baker owns relevant private keys is not valid.
                   | AlreadyABaker !BakerId -- ^Tried to add baker/delegator for an account that already has a baker
                   | NotABaker !AccountAddress -- ^Account is not a baker account
@@ -1998,7 +1997,6 @@ instance S.Serialize RejectReason where
       S.put contractAddress <>
       S.put receiveName <>
       S.put parameter
-    NonExistentRewardAccount addr -> S.putWord8 13 <> S.put addr
     InvalidProof -> S.putWord8 14
     AlreadyABaker bid -> S.putWord8 15 <> S.put bid
     NotABaker addr -> S.putWord8 16 <> S.put addr
@@ -2062,7 +2060,6 @@ instance S.Serialize RejectReason where
       receiveName <- S.get
       parameter <- S.get
       return RejectedReceive {..}
-    13 -> NonExistentRewardAccount <$> S.get
     14 -> return InvalidProof
     15 -> AlreadyABaker <$> S.get
     16 -> NotABaker <$> S.get

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -617,7 +617,6 @@ instance Arbitrary RejectReason where
               return OutOfEnergy,
               RejectedInit <$> arbitrary,
               RejectedReceive <$> arbitrary <*> genCAddress <*> genReceiveName <*> genParameter,
-              NonExistentRewardAccount <$> genAccountAddress,
               return InvalidProof,
               AlreadyABaker <$> genBakerId,
               NotABaker <$> genAccountAddress,


### PR DESCRIPTION
## Purpose

Cleanup unused failure mode.
This used to be used when bakers were handled differently, and they could
specify a separate reward account.

## Changes

Remove RejectReason variant that is no longer used.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.