### PR TITLE
Identity provider service fail

### DIFF
--- a/identity-provider-service/README.md
+++ b/identity-provider-service/README.md
@@ -59,17 +59,25 @@ the Android emulator calls the host machine.
 
 |Method|URL|Description|
 |---|---|---|
-|GET (+POST)|`http://[hostname]:[provider_port]/v0/api/identity`|The endpoint the wallet calls to initiate the version 0 identity creation flow. It performs validation of the incoming request and if valid forwards the user to the identity verifier service.|
+|GET (+POST)|`http://[hostname]:[provider_port]/api/v0/identity`|The endpoint the wallet calls to initiate the version 0 identity creation flow. It performs validation of the incoming request and if valid forwards the user to the identity verifier service.|
 |GET|`http://[hostname]:[provider_port]/api/v1/identity`|The endpoint the wallet calls to initiate the version 1 identity creation flow. It performs validation of the incoming request and if valid forwards the user to the identity verifier service.|
 |GET|`http://[hostname]:[provider_port]/api/v0/identity/create/{base_16_encoded_id_cred_pub_hash}`|Endpoint that the identity verifier forwards the user to after having validated their attributes. If the user has created a valid set of attributes, then this endpoint will ensure that an identity is created.|
 |GET|`http://[hostname]:[provider_port]/api/v1/identity/create/{base_16_encoded_id_cred_pub_hash}`|Endpoint that the identity verifier forwards the user to after having validated their attributes in the version 1 flow. If the user has created a valid set of attributes, then this endpoint will ensure that an identity is created.|
 |GET|`http://[hostname]:[provider_port]/api/v0/identity/{base_16_encoded_id_cred_pub_hash}`|The endpoint that exposes access to created identity objects. The caller will be redirected to this URL after creation of an identity object, so that they can retrieve it.|
 |GET|`http://[hostname]:[provider_port]/api/v1/identity/{base_16_encoded_id_cred_pub_hash}`|The endpoint that exposes access to created identity objects. The caller will be redirected to this URL after creation of an identity object, so that they can retrieve it.|
-|GET|`http://[hostname]:[verifier_port]/api/{v0|v1}/verify/{base_16_encoded_id_cred_pub_hash}/{signature}`|An endpoint that simulates an identity verifier. The endpoint presents an HTML form where the user can submit their attributes which will always be accepted. In a real world application the attributes would have to be verified.|
+|GET|`http://[hostname]:[verifier_port]/api/{v0\|v1}/verify/{base_16_encoded_id_cred_pub_hash}/{signature}`|An endpoint that simulates an identity verifier. The endpoint presents an HTML form where the user can submit their attributes which will always be accepted. In a real world application the attributes would have to be verified.|
 |POST|`http://[hostname]:[verifier_port]/api/submit/`|Accepts submissions from the HTML for served by the verifier. The attributes are saved to a file database. No verification of the attributes are performed for the POC.|
 |GET|`http://[hostname]:[verifier_port]/api/verify/attributes/{id_cred_pub}`|Provides read access to saved attributes. The identity provider accesses this endpoint to get attributes, and assumes that if an attribute list exists, then the user has been verified successfully.|
 
 The POST method is only there for historical reasons. The GET method is the one in use.
+
+The following are endpoints added for testing purposes, and are not necessarily part of the reference implementation.
+
+|Method|URL|Description|
+|---|---|---|
+|GET|`http://[hostname]:[provider_port]/api/{v0\|v1}/identity/fail/{base_16_encoded_id_cred_pub_hash}?delay={seconds_delay}`|Endpoint that the identity verifier forwards the user to for a failed identity. The delay parameter specifies how many seconds until the request should fail.|
+|GET|`http://[hostname]:[provider_port]/api/identity/retrieve_failed/{delay_until}`| Endpoint that the identity verifier forwards the user to for a failed identity.|
+
 
 The `state` field of the initial `GET` request should be urlencoded string
 containing valid JSON of the form

--- a/identity-provider-service/README.md
+++ b/identity-provider-service/README.md
@@ -77,6 +77,7 @@ The following are endpoints added for testing purposes, and are not necessarily 
 |---|---|---|
 |GET|`http://[hostname]:[provider_port]/api/{v0\|v1}/identity/fail/{base_16_encoded_id_cred_pub_hash}?delay={seconds_delay}`|Endpoint that the identity verifier forwards the user to for a failed identity. The delay parameter specifies how many seconds until the request should fail.|
 |GET|`http://[hostname]:[provider_port]/api/identity/retrieve_failed/{delay_until}`| Endpoint that the identity verifier forwards the user to for a failed identity.|
+|GET|`http://[hostname]:[provider_port]/api/broken/identity`| Endpoint that a user can use to simulate a bad request. Returns a status code 400.|
 
 
 The `state` field of the initial `GET` request should be urlencoded string

--- a/identity-provider-service/README.md
+++ b/identity-provider-service/README.md
@@ -76,7 +76,7 @@ The following are endpoints added for testing purposes, and are not necessarily 
 |Method|URL|Description|
 |---|---|---|
 |GET|`http://[hostname]:[provider_port]/api/{v0\|v1}/identity/fail/{base_16_encoded_id_cred_pub_hash}?delay={seconds_delay}`|Endpoint that the identity verifier forwards the user to for a failed identity. The delay parameter specifies how many seconds until the request should fail.|
-|GET|`http://[hostname]:[provider_port]/api/identity/retrieve_failed/{delay_until}`| Endpoint that the identity verifier forwards the user to for a failed identity.|
+|GET|`http://[hostname]:[provider_port]/api/identity/retrieve_failed/{delay_until}`| Endpoint that the identity verifier forwards the user to for a failed identity. delay\_until should be a unix timestamp (in seconds) and while current time before than delay_until, the response will be a pending token. |
 |GET|`http://[hostname]:[provider_port]/api/broken/identity`| Endpoint that a user can use to simulate a bad request. Returns a status code 400.|
 
 

--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -8,8 +8,8 @@ world scenario the attributes will be derived from the identity verification pro
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <style>
-    input[type=text], select {
-      width: 100%;
+   input[type=text], input[type=number], input[type=month], select {
+       width: 100%;
       padding: 12px 20px;
       margin: 8px 0;
       display: inline-block;
@@ -39,6 +39,14 @@ world scenario the attributes will be derived from the identity verification pro
       padding: 20px;
     }
   </style>
+  <script>
+   document.addEventListener('DOMContentLoaded', function() {
+       let date = new Date();
+       let month = `${date.getMonth() + 1}`.padStart(2, "0");
+       let year = date.getFullYear() + 1;
+       document.getElementById("expiry").value = `${year}-${month}`
+   });
+  </script>
 </head>
 <body>
   <div>
@@ -51,9 +59,12 @@ world scenario the attributes will be derived from the identity verification pro
 
         <label for="fail">Fail identity</label>
         <input type="checkbox" id="fail" name="fail" value="True">
+        <br/>
         <label for="fail_delay">Delay until fail</label>
         <input type="number" id="fail_delay" name="fail_delay" value="10">
-        <br/>
+
+        <label for="expiry">Identity expiry</label>
+        <input type="month" id="expiry" name="expiry" required="required">
 
         <label for="fname">First Name</label>
         <input type="text" id="fname" name="firstName" value="John">

--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -49,6 +49,12 @@ world scenario the attributes will be derived from the identity verification pro
         <input type="hidden" id="endpointversion" name="endpoint_version" value="$endpoint_version$">
         <input type="hidden" id="idcredpubsignature" name="id_cred_pub_signature" value="$id_cred_pub_signature$">
 
+        <label for="fail">Fail identity</label>
+        <input type="checkbox" id="fail" name="fail" value="True">
+        <label for="fail_delay">Delay until fail</label>
+        <input type="number" id="fail_delay" name="fail_delay" value="10">
+        <br/>
+
         <label for="fname">First Name</label>
         <input type="text" id="fname" name="firstName" value="John">
 

--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -60,7 +60,7 @@ world scenario the attributes will be derived from the identity verification pro
         <label for="fail">Fail identity</label>
         <input type="checkbox" id="fail" name="fail" value="True">
         <br/>
-        <label for="fail_delay">Delay until fail</label>
+        <label for="fail_delay">Seconds to delay before failing identity</label>
         <input type="number" id="fail_delay" name="fail_delay" value="10">
 
         <label for="expiry">Identity expiry</label>

--- a/identity-provider-service/src/bin/identity_verifier.rs
+++ b/identity-provider-service/src/bin/identity_verifier.rs
@@ -127,14 +127,24 @@ async fn main() {
                         }
                     };
 
+                    let endpoint_version = match input.get("endpoint_version") {
+                        Some(version) => version.clone(),
+                        None => {
+                            return Response::builder()
+                                .status(StatusCode::BAD_REQUEST)
+                                .body("endpoint_version not present.".to_string());
+                        }
+                    };
+                    input.remove("endpoint_version");
+
                     if input.get("fail").is_some() {
                         let delay = input
                             .get("fail_delay")
                             .cloned()
                             .unwrap_or_else(|| "10".to_string());
                         let location = format!(
-                            "{}api/identity/fail/{}?delay={}",
-                            id_provider_url, id_cred_pub_hash, delay
+                            "{}api/{}/identity/fail/{}?delay={}",
+                            id_provider_url, endpoint_version, id_cred_pub_hash, delay
                         );
                         return Response::builder()
                             .header(LOCATION, location)
@@ -159,16 +169,6 @@ async fn main() {
                         }
                     };
                     input.remove("id_cred_pub_signature");
-
-                    let endpoint_version = match input.get("endpoint_version") {
-                        Some(version) => version.clone(),
-                        None => {
-                            return Response::builder()
-                                .status(StatusCode::BAD_REQUEST)
-                                .body("endpoint_version not present.".to_string());
-                        }
-                    };
-                    input.remove("endpoint_version");
 
                     let identity_endpoint = if endpoint_version.eq("v0") {
                         "v0/identity"

--- a/identity-provider-service/src/bin/main.rs
+++ b/identity-provider-service/src/bin/main.rs
@@ -847,10 +847,7 @@ async fn main() -> anyhow::Result<()> {
             move |version: String, id_cred_pub_hash: String, query: HashMap<String, String>| {
                 let delay = query
                     .get("delay")
-                    .map(|d| match d.parse::<u64>() {
-                        Ok(v) => Some(v),
-                        _ => None,
-                    })
+                    .map(|d| d.parse::<u64>().ok())
                     .flatten()
                     .unwrap_or(10);
 
@@ -1776,8 +1773,7 @@ async fn create_failed_identity(
         "api/identity/retrieve_failed/{}",
         chrono::offset::Utc::now().timestamp() as u64 + delay
     ));
-    let call
-        back_location = redirect_uri + "#code_uri=" + retrieve_url.as_str();
+    let callback_location = redirect_uri + "#code_uri=" + retrieve_url.as_str();
 
     info!("Identity was successfully created. Returning URI where it can be retrieved.");
 


### PR DESCRIPTION
## Purpose

Introduce failing capabilities to the internal test identity provider

## Changes

- Add endpoint that returns bad request.
- Add options when picking attributes to:
  - Fail identity
  - Pick how long the failing identity should be pending
  - Pick expiry of the identity

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas