### PR TITLE
Fix dummy transaction cost accounting

### DIFF
--- a/haskell-src/Concordium/Types/DummyData.hs
+++ b/haskell-src/Concordium/Types/DummyData.hs
@@ -75,7 +75,7 @@ makeTransferTransaction (fromKP, fromAddress) toAddress amount n =
             thNonce = n,
             thSender = fromAddress,
             -- The cost needs to be in-line with that in the scheduler
-            thEnergyAmount = Cost.baseCost (fromIntegral $ payloadSize payload) 1 + Cost.simpleTransferCost,
+            thEnergyAmount = Cost.baseCost (transactionHeaderSize + fromIntegral (payloadSize payload)) 1 + Cost.simpleTransferCost,
             thExpiry = dummyMaxTransactionExpiryTime,
             thPayloadSize = payloadSize payload
         }

--- a/haskell-src/Concordium/Types/DummyData.hs
+++ b/haskell-src/Concordium/Types/DummyData.hs
@@ -11,6 +11,7 @@ import Concordium.Types
 import Concordium.Types.Transactions
 import Concordium.Types.Execution
 import Concordium.ID.Types
+import qualified Concordium.Cost as Cost
 
 
 {-# WARNING dummyblockPointer "Do not use in production." #-}
@@ -68,13 +69,13 @@ bakerAggregationKey n = fst (randomBlsSecretKey (mkStdGen n))
 -- NB: The cost needs to be in-line with that defined in the scheduler.
 makeTransferTransaction :: (Sig.KeyPair, AccountAddress) -> AccountAddress -> Amount -> Nonce -> BlockItem
 makeTransferTransaction (fromKP, fromAddress) toAddress amount n =
-  normalTransaction . fromAccountTransaction 0 . signTransactionSingle fromKP header $ payload
+  normalTransaction . fromAccountTransaction (TransactionTime maxBound) . signTransactionSingle fromKP header $ payload
     where
         header = TransactionHeader{
             thNonce = n,
             thSender = fromAddress,
             -- The cost needs to be in-line with that in the scheduler
-            thEnergyAmount = 6 + 1 * 53 + 0,
+            thEnergyAmount = Cost.baseCost (fromIntegral $ payloadSize payload) 1 + Cost.simpleTransferCost,
             thExpiry = dummyMaxTransactionExpiryTime,
             thPayloadSize = payloadSize payload
         }


### PR DESCRIPTION
## Purpose

This fixes incorrect cost accounting in the function `Concordium.Types.DummyData.makeTransferTransaction`.

## Changes

The cost accounting is handled using functions from `Concordium.Cost` instead of hard-coded values.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.