### PR TITLE
Update Rust to 1.62, address new clippy warnings.

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -50,7 +50,7 @@ jobs:
       matrix:
         plan:
         - ghc: 9.0.2 # used as cache key only; stack uses the one specified in stack.yaml
-          rust: 1.53
+          rust: 1.62
 
     steps:
     - name: Checkout

--- a/.github/workflows/rustfmt.yaml
+++ b/.github/workflows/rustfmt.yaml
@@ -33,7 +33,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "nightly-2021-06-09-x86_64-unknown-linux-gnu"
+        - rust: "nightly-2022-06-09-x86_64-unknown-linux-gnu"
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ See documentation for
 
 In order to build the components in this repository you need
 - The [cargo](https://doc.rust-lang.org/cargo/) tool for building the Rust
-components. The currently supported version is 1.53. Others may work, but we
+components. The currently supported version is 1.62. Others may work, but we
 do not regularly test with them. The easiest way to install it is via the
 [rustup](https://rustup.rs/) tool.
 - The [Haskell Stack](https://docs.haskellstack.org/en/stable/README/) tool for
@@ -118,7 +118,7 @@ already exists.
 
 ## Rust workflow
 
-We use **stable version** of rust, 1.53, to compile the code. This is the
+We use **stable version** of rust, 1.62, to compile the code. This is the
 minimal supported version.
 
 The CI is configured to check two things

--- a/identity-provider-service/src/bin/identity_verifier.rs
+++ b/identity-provider-service/src/bin/identity_verifier.rs
@@ -215,7 +215,7 @@ async fn main() {
                     }
 
                     let expiry = match input.get("expiry") {
-                        Some(i) => i.replace("-", ""),
+                        Some(i) => i.replace('-', ""),
                         None => {
                             return Response::builder()
                                 .status(StatusCode::BAD_REQUEST)

--- a/identity-provider-service/src/bin/main.rs
+++ b/identity-provider-service/src/bin/main.rs
@@ -849,7 +849,7 @@ async fn main() -> anyhow::Result<()> {
         .and(warp::query())
         .and_then(
             move |version: String, id_cred_pub_hash: String, query: HashMap<String, String>| {
-                let delay = match query.get("delay").map(|d| d.parse::<i64>().ok()).flatten() {
+                let delay = match query.get("delay").and_then(|d| d.parse::<i64>().ok()) {
                     Some(d) => d,
                     None => {
                         warn!("No delay query parameter present at identity/fail");
@@ -1956,8 +1956,9 @@ mod tests {
     // Destroy DB generated folders after test
     impl Drop for DB {
         fn drop(&mut self) {
-            fs::remove_dir_all(&self.root);
-            fs::remove_dir_all(&self.backup_root);
+            // ignore errors for drop
+            let _ = fs::remove_dir_all(&self.root);
+            let _ = fs::remove_dir_all(&self.backup_root);
         }
     }
 

--- a/rust-src/bulletproofs/benches/benches.rs
+++ b/rust-src/bulletproofs/benches/benches.rs
@@ -54,9 +54,9 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
            * ,7,4,15,15,2,15,5,4,4,5,6,8,12,13,10,8 */
     ];
 
-    for j in 0..usize::from(m) {
+    for &v in v_vec.iter().take(m.into()) {
         let r = Randomness::generate(rng);
-        let v_scalar = SomeCurve::scalar_from_u64(v_vec[j]);
+        let v_scalar = SomeCurve::scalar_from_u64(v);
         let v_value = Value::<SomeCurve>::new(v_scalar);
         let com = keys.hide(&v_value, &r);
         randomness.push(r);
@@ -139,8 +139,8 @@ fn compare_inner_product_proof(c: &mut Criterion) {
     c.bench_function("Naive inner product proof.", move |b| {
         b.iter(|| {
             let mut y_inv_i = SomeField::one();
-            for i in 0..n {
-                H_prime.push(H[i].mul_by_scalar(&y_inv_i));
+            for h in H.iter().take(n) {
+                H_prime.push(h.mul_by_scalar(&y_inv_i));
                 y_inv_i.mul_assign(&y_inv);
             }
             prove_inner_product(&mut transcript, &G_vec, &H_prime, &Q, &a_vec, &b_vec);

--- a/rust-src/bulletproofs/src/range_proof.rs
+++ b/rust-src/bulletproofs/src/range_proof.rs
@@ -789,6 +789,7 @@ mod tests {
             &vec![C::Scalar::zero(); nm],
         );
 
+        #[allow(clippy::manual_map)]
         let rangeproof = match proof {
             Some(ip_proof) => Some(RangeProof {
                 A,
@@ -829,7 +830,7 @@ mod tests {
         let B = v_keys.g;
         let B_tilde = v_keys.h;
         let m = commitments.len();
-        for V in commitments.clone() {
+        for V in commitments {
             transcript.append_message(b"Vj", &V.0);
         }
         let A = proof.A;
@@ -955,7 +956,7 @@ mod tests {
         }
 
         // println!("Verifier's P' = {:?}", P_prime);
-        let second: bool = verify_inner_product(transcript, &G, &H_prime, &P_prime, &Q, &ip_proof); // Very expensive
+        let second: bool = verify_inner_product(transcript, &G, &H_prime, &P_prime, &Q, ip_proof); // Very expensive
         second
     }
 
@@ -1035,7 +1036,7 @@ mod tests {
         let mut H_scalars: Vec<C::Scalar> = Vec::with_capacity(G.len());
         let mut y_i = C::Scalar::one();
         let z_2_m = z_vec(z, 2, m);
-        let verification_scalars = verify_scalars(transcript, G.len(), &ip_proof);
+        let verification_scalars = verify_scalars(transcript, G.len(), ip_proof);
         if verification_scalars.is_none() {
             return false;
         }
@@ -1146,7 +1147,7 @@ mod tests {
         // Test for nm = 512
         let rng = &mut thread_rng();
         let n = 32;
-        let m = 16;
+        let m = 16u8;
         let nm = (usize::from(n)) * (usize::from(m));
         let mut G = Vec::with_capacity(nm);
         let mut H = Vec::with_capacity(nm);
@@ -1179,9 +1180,9 @@ mod tests {
                * ,7,4,15,15,2,15,5,4,4,5,6,8,12,13,10,8 */
         ];
 
-        for j in 0..usize::from(m) {
+        for &v in v_vec.iter().take(m.into()) {
             let r = Randomness::generate(rng);
-            let v_scalar = SomeCurve::scalar_from_u64(v_vec[j]);
+            let v_scalar = SomeCurve::scalar_from_u64(v);
             let v_value = Value::<SomeCurve>::new(v_scalar);
             let com = keys.hide(&v_value, &r);
             randomness.push(r);
@@ -1253,9 +1254,9 @@ mod tests {
                         * ,7,4,15,15,2,15,5,4,4,5,6,8,12,13,10,8 */
         ];
 
-        for j in 0..usize::from(m) {
+        for &v in v_vec.iter().take(m.into()) {
             let r = Randomness::generate(rng);
-            let v_scalar = SomeCurve::scalar_from_u64(v_vec[j]);
+            let v_scalar = SomeCurve::scalar_from_u64(v);
             let v_value = Value::<SomeCurve>::new(v_scalar);
             let com = keys.hide(&v_value, &r);
             randomness.push(r);

--- a/rust-src/crypto_common/src/serialize.rs
+++ b/rust-src/crypto_common/src/serialize.rs
@@ -284,10 +284,7 @@ pub fn serial_vector_no_length<B: Buffer, T: Serial>(xs: &[T], out: &mut B) {
 }
 
 /// Serialize an ordered map. Serialization is by increasing order of keys.
-pub fn serial_map_no_length<'a, B: Buffer, K: Serial + 'a, V: Serial + 'a>(
-    map: &BTreeMap<K, V>,
-    out: &mut B,
-) {
+pub fn serial_map_no_length<B: Buffer, K: Serial, V: Serial>(map: &BTreeMap<K, V>, out: &mut B) {
     for (k, v) in map.iter() {
         // iterator over ordered pairs.
         out.put(k);
@@ -324,7 +321,7 @@ pub fn deserial_map_no_length<R: ReadBytesExt, K: Deserial + Ord + Copy, V: Dese
 }
 
 /// Analogous to [serial_map_no_length], but for sets.
-pub fn serial_set_no_length<'a, B: Buffer, K: Serial + 'a>(map: &BTreeSet<K>, out: &mut B) {
+pub fn serial_set_no_length<B: Buffer, K: Serial>(map: &BTreeSet<K>, out: &mut B) {
     for k in map.iter() {
         out.put(k);
     }
@@ -601,7 +598,7 @@ impl<T: Deserial + Eq + Hash, S: BuildHasher + Default> Deserial for HashSet<T, 
     }
 }
 
-impl<'a, T: Serial> Serial for &'a T {
+impl<T: Serial> Serial for &T {
     fn serial<W: Buffer + WriteBytesExt>(&self, target: &mut W) { (*self).serial(target) }
 }
 

--- a/rust-src/crypto_common/src/types.rs
+++ b/rust-src/crypto_common/src/types.rs
@@ -597,7 +597,7 @@ mod tests {
             let js = serde_json::to_string(&signatures).expect("Serialization should succeed.");
             match serde_json::from_str::<TransactionSignature>(&js) {
                 Ok(s) => assert_eq!(s, signatures, "Deserialized incorrect value."),
-                Err(e) => assert!(false, "{}", e),
+                Err(e) => panic!("{}", e),
             }
 
             let binary_result = crate::serialize_deserialize(&signatures)

--- a/rust-src/curve_arithmetic/benches/hash_bench.rs
+++ b/rust-src/curve_arithmetic/benches/hash_bench.rs
@@ -20,10 +20,7 @@ macro_rules! rand_m_of_length {
 pub fn bench_hash_to_curve(c: &mut Criterion) {
     let mut csprng = thread_rng();
     let msg = rand_m_of_length!(1000, csprng);
-    let msg_clone = msg.clone();
-    c.bench_function("hash_to_g1", move |b| {
-        b.iter(|| G1::hash_to_group(&msg_clone))
-    });
+    c.bench_function("hash_to_g1", move |b| b.iter(|| G1::hash_to_group(&msg)));
 }
 
 // To run this benches do the following:

--- a/rust-src/curve_arithmetic/src/bls12_381_g1hash.rs
+++ b/rust-src/curve_arithmetic/src/bls12_381_g1hash.rs
@@ -1287,7 +1287,7 @@ mod tests {
     #[test]
     fn test_sswu_3mod4() {
         let msg = "".as_bytes();
-        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(&msg);
+        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(msg);
         assert_eq!(q0xiso.into_repr().0, [
             15322189115692639998,
             15797359889106953011,
@@ -1321,7 +1321,7 @@ mod tests {
             976070356284526495
         ]);
         let msg = "abc".as_bytes();
-        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(&msg);
+        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(msg);
         assert_eq!(q0xiso.into_repr().0, [
             12430049376656784768,
             16784989396329743852,
@@ -1355,7 +1355,7 @@ mod tests {
             2192215483010290
         ]);
         let msg = "abcdef0123456789".as_bytes();
-        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(&msg);
+        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(msg);
         assert_eq!(q0xiso.into_repr().0, [
             9041900009822400511,
             18050568042394074917,
@@ -1389,7 +1389,7 @@ mod tests {
             1763448765852971514
         ]);
         let msg = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq".as_bytes();
-        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(&msg);
+        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(msg);
         assert_eq!(q0xiso.into_repr().0, [
             10708545032665212688,
             17591047437115732803,
@@ -1423,7 +1423,7 @@ mod tests {
             209856280269423280
         ]);
         let msg = "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(&msg);
+        let (q0xiso, q0yiso, q1xiso, q1yiso) = test_sswu_3mod4_helper(msg);
         assert_eq!(q0xiso.into_repr().0, [
             8748476113528902904,
             7472129550841271360,
@@ -1466,7 +1466,7 @@ mod tests {
     fn test_hash_to_curve() {
         let msg = "".as_bytes();
         let dst = b"QUUX-V01-CS02-with-BLS12381G1_XMD:SHA-256_SSWU_RO_";
-        let p = hash_to_curve(&msg, &dst[..]);
+        let p = hash_to_curve(msg, &dst[..]);
         assert_eq!(to_bytes(&p), vec![
             133, 41, 38, 173, 210, 32, 123, 118, 202, 79, 165, 122, 135, 52, 65, 108, 141, 201, 94,
             36, 80, 23, 114, 200, 20, 39, 135, 0, 238, 214, 209, 228, 232, 207, 98, 217, 192, 157,
@@ -1482,7 +1482,7 @@ mod tests {
             Fq::from_str("1343412193624222137939591894701031123123641958980729764240763391191550653712890272928110356903136085217047453540965").unwrap(), 
             Fq::one()));
         let msg = "abc".as_bytes();
-        let p = hash_to_curve(&msg, &dst[..]);
+        let p = hash_to_curve(msg, &dst[..]);
         assert_eq!(to_bytes(&p), vec![
             131, 86, 123, 197, 239, 156, 105, 12, 42, 178, 236, 223, 106, 150, 239, 28, 19, 156,
             192, 178, 242, 132, 220, 160, 169, 167, 148, 51, 136, 164, 154, 58, 238, 102, 75, 165,
@@ -1498,7 +1498,7 @@ mod tests {
             Fq::from_str("1786897908129645780825838873875416513994655004408749907941296449131605892957529391590865627492442562626458913769565").unwrap(), 
             Fq::one()));
         let msg = "abcdef0123456789".as_bytes();
-        let p = hash_to_curve(&msg, &dst[..]);
+        let p = hash_to_curve(msg, &dst[..]);
         assert_eq!(to_bytes(&p), vec![
             145, 224, 176, 121, 222, 162, 154, 104, 240, 56, 62, 233, 79, 237, 27, 148, 9, 149, 39,
             36, 7, 227, 187, 145, 107, 191, 38, 140, 38, 61, 221, 87, 166, 162, 114, 0, 167, 132,
@@ -1514,7 +1514,7 @@ mod tests {
             Fq::from_str("563036982304416203921640398061260377444881693369806087719971277317609936727208012968659302318886963927918562170633").unwrap(), 
             Fq::one()));
         let msg = "q128_qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq".as_bytes();
-        let p = hash_to_curve(&msg, &dst[..]);
+        let p = hash_to_curve(msg, &dst[..]);
         assert_eq!(to_bytes(&p), vec![
             181, 246, 142, 170, 105, 59, 149, 204, 184, 82, 21, 220, 101, 250, 129, 3, 141, 105,
             98, 159, 112, 174, 238, 13, 15, 103, 124, 242, 34, 133, 231, 191, 88, 215, 203, 134,
@@ -1530,7 +1530,7 @@ mod tests {
             Fq::from_str("3698526739072864408749571082270628561764415577445404115596990919801523793138348254443092179877354467167123794222392").unwrap(), 
             Fq::one()));
         let msg = "a512_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".as_bytes();
-        let p = hash_to_curve(&msg, &dst[..]);
+        let p = hash_to_curve(msg, &dst[..]);
         assert_eq!(to_bytes(&p), vec![
             136, 42, 171, 174, 139, 125, 237, 176, 231, 138, 235, 97, 154, 211, 191, 217, 39, 122,
             47, 119, 186, 127, 173, 32, 239, 106, 171, 220, 108, 49, 209, 155, 165, 166, 209, 34,

--- a/rust-src/curve_arithmetic/src/secret_value.rs
+++ b/rust-src/curve_arithmetic/src/secret_value.rs
@@ -53,7 +53,6 @@ impl<F: Field + Serialize> Drop for Secret<F> {
 /// A secret value. The idea of this datatype is to mark
 /// some scalars as secret, so that their use is harder and there is
 /// no implicit copy.
-#[repr(transparent)]
 #[derive(Debug, PartialEq, Eq, Serialize, Clone, SerdeBase16Serialize)]
 pub struct Value<C: Curve> {
     pub value: Rc<Secret<C::Scalar>>,

--- a/rust-src/ecvrf/src/public.rs
+++ b/rust-src/ecvrf/src/public.rs
@@ -58,7 +58,7 @@ impl AsRef<[u8]> for PublicKey {
     fn as_ref(&self) -> &[u8] { self.as_bytes() }
 }
 
-impl<'a> From<&'a SecretKey> for PublicKey {
+impl From<&SecretKey> for PublicKey {
     /// Derive this public key from its corresponding `SecretKey`.
     /// Implements <https://tools.ietf.org/html/rfc8032#section-5.1.5>
     fn from(secret_key: &SecretKey) -> PublicKey {
@@ -75,7 +75,7 @@ impl<'a> From<&'a SecretKey> for PublicKey {
     }
 }
 
-impl<'a> From<&'a ExpandedSecretKey> for PublicKey {
+impl From<&ExpandedSecretKey> for PublicKey {
     /// Derive this public key from its corresponding `ExpandedSecretKey`.
     fn from(expanded_secret_key: &ExpandedSecretKey) -> PublicKey {
         let mut bits: [u8; 32] = expanded_secret_key.key.to_bytes();

--- a/rust-src/ecvrf/src/secret.rs
+++ b/rust-src/ecvrf/src/secret.rs
@@ -108,10 +108,10 @@ impl Drop for ExpandedSecretKey {
     }
 }
 
-impl<'a> From<&'a SecretKey> for ExpandedSecretKey {
+impl From<&SecretKey> for ExpandedSecretKey {
     /// Construct an `ExpandedSecretKey` from a `SecretKey`.
     /// Implements <https://tools.ietf.org/html/rfc8032#section-5.1.5>
-    fn from(secret_key: &'a SecretKey) -> ExpandedSecretKey {
+    fn from(secret_key: &SecretKey) -> ExpandedSecretKey {
         let mut h: Sha512 = Sha512::new();
         let mut hash: [u8; 64] = [0u8; 64];
         let mut lower: [u8; 32] = [0u8; 32];

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -236,7 +236,7 @@ mod tests {
     pub fn test_valid_path() {
         let valid_path = "m/44'/919'/0'/1'/0'";
         assert!(
-            parse_path(&valid_path).is_ok(),
+            parse_path(valid_path).is_ok(),
             "Path {} should be valid.",
             valid_path
         );

--- a/rust-src/eddsa_ed25519/benches/eddsa_benchmarks.rs
+++ b/rust-src/eddsa_ed25519/benches/eddsa_benchmarks.rs
@@ -16,16 +16,10 @@ pub fn bench_from_bytes(c: &mut Criterion) {
     }
     let ca = a.clone();
     c.bench_function("PublicKey::from_bytes {}", move |b| {
-        b.iter(|| match PublicKey::from_bytes(&a) {
-            Ok(_) => true,
-            Err(_) => false,
-        });
+        b.iter(|| PublicKey::from_bytes(&a).is_ok())
     });
     c.bench_function("SecretKey::from_bytes {}", move |b| {
-        b.iter(|| match SecretKey::from_bytes(&ca) {
-            Ok(_) => true,
-            Err(_) => false,
-        });
+        b.iter(|| SecretKey::from_bytes(&ca).is_ok())
     });
 }
 

--- a/rust-src/elgamal/src/public.rs
+++ b/rust-src/elgamal/src/public.rs
@@ -22,7 +22,7 @@ impl<C: Curve> Debug for PublicKey<C> {
     }
 }
 
-impl<'a, C: Curve> From<&'a SecretKey<C>> for PublicKey<C> {
+impl<C: Curve> From<&SecretKey<C>> for PublicKey<C> {
     /// Derive this public key from its corresponding `SecretKey`.
     fn from(secret_key: &SecretKey<C>) -> PublicKey<C> {
         let generator: C = secret_key.generator;
@@ -138,7 +138,7 @@ impl<C: Curve> PublicKey<C> {
     where
         T: Rng,
         I: IntoIterator<Item = &'a Value<C>>, {
-        let f = move |x: &'a Value<C>| -> (Cipher<C>, Randomness<C>) {
+        let f = move |x: &Value<C>| -> (Cipher<C>, Randomness<C>) {
             self.encrypt_exponent_rand_given_generator(x, h, csprng)
         };
         es.into_iter().map(f).collect()

--- a/rust-src/elgamal/src/secret.rs
+++ b/rust-src/elgamal/src/secret.rs
@@ -171,7 +171,6 @@ mod tests {
     macro_rules! macro_test_secret_key_to_byte_conversion {
         ($function_name:ident, $curve_type:path) => {
             #[test]
-            #[test]
             pub fn $function_name() {
                 let mut csprng = thread_rng();
                 for _i in 1..100 {

--- a/rust-src/id/src/id_verifier.rs
+++ b/rust-src/id/src/id_verifier.rs
@@ -162,15 +162,15 @@ mod tests {
         let value = Value::<G1>::new(attribute.to_field_element());
         let (commitment, randomness) = keys.commit(&value, &mut csprng);
         let maybe_proof =
-            prove_attribute_in_range(&gens, &keys, &attribute, &lower, &upper, &randomness);
+            prove_attribute_in_range(gens, &keys, &attribute, &lower, &upper, &randomness);
         if let Some(proof) = maybe_proof {
             assert_eq!(
-                verify_attribute_range(&keys, &gens, &lower, &upper, &commitment, &proof),
+                verify_attribute_range(&keys, gens, &lower, &upper, &commitment, &proof),
                 Ok(()),
                 "Incorrect range proof."
             );
         } else {
-            assert!(false, "Failed to produce proof.");
+            panic!("Failed to produce proof.");
         };
     }
 }

--- a/rust-src/id/src/identity_provider.rs
+++ b/rust-src/id/src/identity_provider.rs
@@ -968,7 +968,7 @@ mod tests {
         let timestamp = 1000;
         let id_cred_sec = &aci.cred_holder_info.id_cred.id_cred_sec;
         let request =
-            generate_id_recovery_request(&ip_info, &global_ctx, &id_cred_sec, timestamp).unwrap();
+            generate_id_recovery_request(&ip_info, &global_ctx, id_cred_sec, timestamp).unwrap();
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
         assert!(result);
@@ -1000,8 +1000,8 @@ mod tests {
         request.id_cred_pub = id_cred_pub;
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
-        assert_eq!(
-            result, false,
+        assert!(
+            !result,
             "Verifying pok of idCredSec did not fail with wrong idCredSec"
         );
     }
@@ -1021,12 +1021,12 @@ mod tests {
         let timestamp = 1000;
         let id_cred_sec = &aci.cred_holder_info.id_cred.id_cred_sec;
         let mut request =
-            generate_id_recovery_request(&ip_info, &global_ctx, &id_cred_sec, timestamp).unwrap();
+            generate_id_recovery_request(&ip_info, &global_ctx, id_cred_sec, timestamp).unwrap();
         request.timestamp += 1;
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
-        assert_eq!(
-            result, false,
+        assert!(
+            !result,
             "Verifying pok of idCredSec did not fail with wrong timestamp"
         );
     }
@@ -1046,13 +1046,13 @@ mod tests {
         let timestamp = 1000;
         let id_cred_sec = &aci.cred_holder_info.id_cred.id_cred_sec;
         let request =
-            generate_id_recovery_request(&ip_info, &global_ctx, &id_cred_sec, timestamp).unwrap();
+            generate_id_recovery_request(&ip_info, &global_ctx, id_cred_sec, timestamp).unwrap();
 
         ip_info.ip_identity = IpIdentity(1);
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
-        assert_eq!(
-            result, false,
+        assert!(
+            !result,
             "Verifying pok of idCredSec did not fail with wrong IDP ID"
         );
     }
@@ -1072,14 +1072,14 @@ mod tests {
         let timestamp = 1000;
         let id_cred_sec = &aci.cred_holder_info.id_cred.id_cred_sec;
         let request =
-            generate_id_recovery_request(&ip_info, &global_ctx, &id_cred_sec, timestamp).unwrap();
+            generate_id_recovery_request(&ip_info, &global_ctx, id_cred_sec, timestamp).unwrap();
 
         ip_info.ip_verify_key =
             ps_sig::PublicKey::arbitrary((5 + num_ars + max_attrs) as usize, &mut csprng);
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
-        assert_eq!(
-            result, false,
+        assert!(
+            !result,
             "Verifying pok of idCredSec did not fail with wrong IDP verify keys"
         );
     }
@@ -1099,13 +1099,13 @@ mod tests {
         let timestamp = 1000;
         let id_cred_sec = &aci.cred_holder_info.id_cred.id_cred_sec;
         let request =
-            generate_id_recovery_request(&ip_info, &global_ctx, &id_cred_sec, timestamp).unwrap();
+            generate_id_recovery_request(&ip_info, &global_ctx, id_cred_sec, timestamp).unwrap();
 
         global_ctx.genesis_string = String::from("another_string");
 
         let result = validate_id_recovery_request(&ip_info, &global_ctx, &request);
-        assert_eq!(
-            result, false,
+        assert!(
+            !result,
             "Verifying pok of idCredSec did not fail with wrong global context"
         );
     }

--- a/rust-src/id/src/secret_sharing.rs
+++ b/rust-src/id/src/secret_sharing.rs
@@ -212,9 +212,7 @@ mod test {
         let r = lagrange::<u32, G1>(&kxs, p);
         assert_eq!(r, G1::scalar_from_u64(1));
 
-        let mut kxs = Vec::new();
-        kxs.push(1);
-        kxs.push(2);
+        let kxs = vec![1, 2];
         let p = 1;
         let r = lagrange::<u32, G1>(&kxs, p);
         assert_eq!(r, G1::scalar_from_u64(2));
@@ -277,9 +275,9 @@ mod test {
             let sufficient_sample = &shares[0..(threshold as usize)];
             let sufficient_sample_points = sufficient_sample
                 .iter()
-                .map(|(n, s)| (*n, generator.mul_by_scalar(&s)))
+                .map(|(n, s)| (*n, generator.mul_by_scalar(s)))
                 .collect::<Vec<(u8, G1)>>();
-            let revealed_data: Fr = reveal::<_, G1>(&sufficient_sample);
+            let revealed_data: Fr = reveal::<_, G1>(sufficient_sample);
             assert_eq!(revealed_data, secret);
             let revealed_data_point: G1 = reveal_in_group::<_, G1>(&sufficient_sample_points);
             assert_eq!(revealed_data_point, secret_point);
@@ -305,7 +303,7 @@ mod test {
             assert_ne!(revealed_data, secret);
             let sufficient_points_err = shares
                 .iter()
-                .map(|(n, s)| (*n, generator.mul_by_scalar(&s)))
+                .map(|(n, s)| (*n, generator.mul_by_scalar(s)))
                 .collect::<Vec<(u8, G1)>>();
             let revealed_data_point: G1 = reveal_in_group::<_, G1>(&sufficient_points_err);
             assert_ne!(revealed_data_point, secret_point);
@@ -326,9 +324,9 @@ mod test {
             let insufficient_sample = &insufficient_shares[0..((threshold - 1) as usize)];
             let insufficient_sample_points = insufficient_sample
                 .iter()
-                .map(|(n, s)| (*n, generator.mul_by_scalar(&s)))
+                .map(|(n, s)| (*n, generator.mul_by_scalar(s)))
                 .collect::<Vec<(u8, G1)>>();
-            let revealed_data: Fr = reveal::<_, G1>(&insufficient_sample);
+            let revealed_data: Fr = reveal::<_, G1>(insufficient_sample);
             assert_ne!(revealed_data, secret);
             let revealed_data_point: G1 = reveal_in_group::<_, G1>(&insufficient_sample_points);
             assert_ne!(revealed_data_point, secret_point);

--- a/rust-src/id/src/sigma_protocols/aggregate_dlog.rs
+++ b/rust-src/id/src/sigma_protocols/aggregate_dlog.rs
@@ -97,7 +97,7 @@ impl<C: Curve> SigmaProtocol for AggregateDlog<C> {
     fn with_valid_data<R: rand::Rng>(
         data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         let mut secret = Vec::with_capacity(data_size);
         let mut coeff = Vec::with_capacity(data_size);

--- a/rust-src/id/src/sigma_protocols/com_enc_eq.rs
+++ b/rust-src/id/src/sigma_protocols/com_enc_eq.rs
@@ -165,7 +165,7 @@ impl<C: Curve> SigmaProtocol for ComEncEq<C> {
     fn with_valid_data<R: Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         use elgamal::SecretKey;
         let sk = SecretKey::generate_all(csprng);

--- a/rust-src/id/src/sigma_protocols/com_eq.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq.rs
@@ -127,7 +127,7 @@ impl<C: Curve, D: Curve<Scalar = C::Scalar>> SigmaProtocol for ComEq<C, D> {
     fn with_valid_data<R: rand::Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         let comm_key = CommitmentKey::generate(csprng);
         let a = Value::<D>::generate_non_zero(csprng);

--- a/rust-src/id/src/sigma_protocols/com_eq_different_groups.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq_different_groups.rs
@@ -135,7 +135,7 @@ impl<C1: Curve, C2: Curve<Scalar = C1::Scalar>> SigmaProtocol for ComEqDiffGroup
     fn with_valid_data<R: Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         let a_1: Value<C2> = Value::generate_non_zero(csprng);
         let cmm_key_1: CommitmentKey<C1> = CommitmentKey::generate(csprng);

--- a/rust-src/id/src/sigma_protocols/com_eq_sig.rs
+++ b/rust-src/id/src/sigma_protocols/com_eq_sig.rs
@@ -49,7 +49,7 @@ pub struct ComEqSigState<P: Pairing, C: Curve<Scalar = P::ScalarField>> {
 }
 
 #[allow(non_snake_case)]
-impl<'a, P: Pairing, C: Curve<Scalar = P::ScalarField>> SigmaProtocol for ComEqSig<P, C> {
+impl<P: Pairing, C: Curve<Scalar = P::ScalarField>> SigmaProtocol for ComEqSig<P, C> {
     type CommitMessage = (P::TargetField, Vec<Commitment<C>>);
     type ProtocolChallenge = C::Scalar;
     // Triple (rho', [mu_i], [R_i])
@@ -245,7 +245,7 @@ impl<'a, P: Pairing, C: Curve<Scalar = P::ScalarField>> SigmaProtocol for ComEqS
     fn with_valid_data<R: Rng>(
         data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         use ps_sig::{SecretKey as PsSigSecretKey, SigRetrievalRandomness, UnknownMessage};
         let ps_sk: PsSigSecretKey<P> = PsSigSecretKey::generate(data_size, csprng);
@@ -337,7 +337,7 @@ mod tests {
                 }
 
                 {
-                    if wrong_ces.commitments.len() > 0 {
+                    if !wrong_ces.commitments.is_empty() {
                         let idx = csprng.gen_range(0, wrong_ces.commitments.len());
                         let tmp = wrong_ces.commitments[idx];
                         wrong_ces.commitments[idx] = wrong_ces

--- a/rust-src/id/src/sigma_protocols/com_lin.rs
+++ b/rust-src/id/src/sigma_protocols/com_lin.rs
@@ -177,7 +177,7 @@ impl<C: Curve> SigmaProtocol for ComLin<C> {
     fn with_valid_data<R: rand::Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         let n = _data_size;
         let cmm_key = CommitmentKey::generate(csprng);
@@ -375,11 +375,11 @@ mod tests {
         let mut rs = Vec::with_capacity(usize::from(m));
         let mut cmms = Vec::with_capacity(usize::from(m));
         let cmm = cmm_key.hide(&sum, &r);
-        for i in 0..usize::from(m) {
+        for x_value in xs_values.iter().take(m.into()) {
             us.push(ui);
             ui.mul_assign(&two_32);
             let ri = Randomness::<G1>::generate(rng);
-            cmms.push(cmm_key.hide(&xs_values[i], &ri));
+            cmms.push(cmm_key.hide(x_value, &ri));
             rs.push(ri);
         }
         let rs_copy = rs.clone();

--- a/rust-src/id/src/sigma_protocols/com_mult.rs
+++ b/rust-src/id/src/sigma_protocols/com_mult.rs
@@ -33,7 +33,7 @@ pub struct Witness<C: Curve> {
 }
 
 #[allow(non_snake_case)]
-impl<'a, C: Curve> SigmaProtocol for ComMult<C> {
+impl<C: Curve> SigmaProtocol for ComMult<C> {
     type CommitMessage = ([Commitment<C>; 2], Commitment<C>);
     type ProtocolChallenge = C::Scalar;
     // alpha's, R_i's, R's
@@ -86,13 +86,11 @@ impl<'a, C: Curve> SigmaProtocol for ComMult<C> {
         let cR = state.2;
         for i in 0..2 {
             ss[i].mul_assign(&secret.values[i]); // c * x_i
-            ss[i].negate(); // 
-                            // - c * x_i
+            ss[i].negate(); // - c * x_i
             ss[i].add_assign(&alphas[i]); // alpha - c * x_i
 
             ts[i].mul_assign(&secret.rands[i]); // c * r_i
-            ts[i].negate(); // 
-                            // - c * r_i
+            ts[i].negate(); // - c * r_i
             ts[i].add_assign(&rands[i]); // rTilde_i - c * r_i
         }
 
@@ -142,7 +140,7 @@ impl<'a, C: Curve> SigmaProtocol for ComMult<C> {
     fn with_valid_data<R: rand::Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         let cmm_key = CommitmentKey::generate(csprng);
         let a_1 = Value::<C>::generate_non_zero(csprng);

--- a/rust-src/id/src/sigma_protocols/common.rs
+++ b/rust-src/id/src/sigma_protocols/common.rs
@@ -67,7 +67,7 @@ pub trait SigmaProtocol: Sized {
     fn with_valid_data<R: rand::Rng>(
         data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     );
 }
 
@@ -152,7 +152,7 @@ impl<P1: SigmaProtocol, P2: SigmaProtocol> SigmaProtocol for AndAdapter<P1, P2> 
     fn with_valid_data<R: rand::Rng>(
         data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         P1::with_valid_data(data_size, csprng, |first, s1, csprng| {
             P2::with_valid_data(data_size, csprng, |second, s2, csprng| {
@@ -273,7 +273,7 @@ impl<P: SigmaProtocol> SigmaProtocol for ReplicateAdapter<P> {
     fn with_valid_data<R: rand::Rng>(
         _data_size: usize,
         _csprng: &mut R,
-        _f: impl FnOnce(Self, Self::SecretData, &mut R) -> (),
+        _f: impl FnOnce(Self, Self::SecretData, &mut R),
     ) {
         todo!()
     }

--- a/rust-src/id/src/sigma_protocols/dlog.rs
+++ b/rust-src/id/src/sigma_protocols/dlog.rs
@@ -84,7 +84,7 @@ impl<C: Curve> SigmaProtocol for Dlog<C> {
     fn with_valid_data<R: rand::Rng>(
         _data_size: usize,
         csprng: &mut R,
-        f: impl FnOnce(Dlog<C>, Self::SecretData, &mut R) -> (),
+        f: impl FnOnce(Dlog<C>, Self::SecretData, &mut R),
     ) {
         let secret = Value::generate(csprng);
         let base = C::generate(csprng);

--- a/rust-src/id/src/test.rs
+++ b/rust-src/id/src/test.rs
@@ -128,7 +128,7 @@ pub fn test_create_pio<'a>(
     let threshold = Threshold::try_from(num_ars - 1).unwrap_or(Threshold(1));
 
     // Create and return PIO
-    let (pio, randomness) = generate_pio(&context, threshold, &id_use_data, initial_account_data)
+    let (pio, randomness) = generate_pio(&context, threshold, id_use_data, initial_account_data)
         .expect("Generating the pre-identity object should succeed.");
     (context, pio, randomness)
 }
@@ -151,7 +151,7 @@ pub fn test_create_pio_v1<'a>(
     let threshold = Threshold::try_from(num_ars - 1).unwrap_or(Threshold(1));
 
     // Create and return PIO
-    let (pio, randomness) = generate_pio_v1(&context, threshold, &id_use_data)
+    let (pio, randomness) = generate_pio_v1(&context, threshold, id_use_data)
         .expect("Generating the pre-identity object should succeed.");
     (context, pio, randomness)
 }
@@ -318,7 +318,7 @@ pub fn test_pipeline() {
             .values
             .ar_data
             .get(ar_id)
-            .expect(&format!("Anonymity revoker {} is not present.", ar_id));
+            .unwrap_or_else(|| panic!("Anonymity revoker {} is not present.", ar_id));
         let decrypted_share = (*ar_id, key.decrypt(&ar.enc_id_cred_pub_share));
         shares.push(decrypted_share);
     }
@@ -482,7 +482,7 @@ pub fn test_pipeline_v1() {
             .values
             .ar_data
             .get(ar_id)
-            .expect(&format!("Anonymity revoker {} is not present.", ar_id));
+            .unwrap_or_else(|| panic!("Anonymity revoker {} is not present.", ar_id));
         let decrypted_share = (*ar_id, key.decrypt(&ar.enc_id_cred_pub_share));
         shares.push(decrypted_share);
     }

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -429,14 +429,14 @@ pub const ATTRIBUTE_TAG_LEI: AttributeTag = AttributeTag(13);
 /// are internal tags, values at those indices are string tags).
 pub struct AttributeStringTag(String);
 
-impl<'a> fmt::Display for AttributeStringTag {
+impl fmt::Display for AttributeStringTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result { write!(f, "{}", self.0) }
 }
 
 // NB: This requires that the length of ATTRIBUTE_NAMES is no more than 256.
 // FIXME: This method's complexity is linear in the size of the set of
 // attributes.
-impl<'a> TryFrom<AttributeStringTag> for AttributeTag {
+impl TryFrom<AttributeStringTag> for AttributeTag {
     type Error = anyhow::Error;
 
     fn try_from(v: AttributeStringTag) -> Result<Self, Self::Error> {
@@ -452,7 +452,7 @@ impl<'a> TryFrom<AttributeStringTag> for AttributeTag {
     }
 }
 
-impl<'a> std::convert::From<AttributeTag> for AttributeStringTag {
+impl std::convert::From<AttributeTag> for AttributeStringTag {
     fn from(v: AttributeTag) -> Self {
         let v_usize: usize = v.into();
         if v_usize < ATTRIBUTE_NAMES.len() {
@@ -2457,8 +2457,8 @@ mod tests {
     #[test]
     fn test_yearmonth_serialization() {
         // Test equality
-        let ym1 = YearMonth::new(2020, 02).unwrap();
-        let ym2 = YearMonth::new(2020, 02).unwrap();
+        let ym1 = YearMonth::new(2020, 2).unwrap();
+        let ym2 = YearMonth::new(2020, 2).unwrap();
         assert_eq!(ym1, ym2);
 
         // Test serialization

--- a/rust-src/keygen_bls/src/lib.rs
+++ b/rust-src/keygen_bls/src/lib.rs
@@ -185,10 +185,10 @@ mod tests {
                 if let Ok(sk) = keygen_bls(&seed, b"") {
                     assert_eq!(sk.into_repr(), FrRepr(expected_outputs[i]))
                 } else {
-                    assert!(false);
+                    panic!("Could not generate key from seed.")
                 }
             } else {
-                assert!(false);
+                panic!("Could not hex decode.")
             }
         }
     }

--- a/rust-src/ps_sig/src/public.rs
+++ b/rust-src/ps_sig/src/public.rs
@@ -88,7 +88,7 @@ impl<C: Pairing> PublicKey<C> {
     }
 }
 
-impl<'a, C: Pairing> From<&'a SecretKey<C>> for PublicKey<C> {
+impl<C: Pairing> From<&SecretKey<C>> for PublicKey<C> {
     /// Derive this public key from its corresponding `SecretKey`.
     fn from(sk: &SecretKey<C>) -> PublicKey<C> {
         let ys = sk.ys.iter().map(|r| sk.g.mul_by_scalar(r)).collect();

--- a/rust-src/random_oracle/src/lib.rs
+++ b/rust-src/random_oracle/src/lib.rs
@@ -130,8 +130,8 @@ mod tests {
         let mut v1 = vec![0u8; 50];
         let mut csprng = thread_rng();
         for _ in 0..1000 {
-            for i in 0..50 {
-                v1[i] = csprng.gen::<u8>();
+            for v in v1.iter_mut() {
+                *v = csprng.gen::<u8>();
             }
             let mut s1 = RandomOracle::empty();
             for x in v1.iter() {
@@ -155,9 +155,9 @@ mod tests {
             let mut s1 = RandomOracle::empty();
             s1.add(&v1);
             let mut s2 = s1.split();
-            for i in 0..50 {
-                v1[i] = csprng.gen::<u8>();
-                s1.add(&v1[i]);
+            for v in v1.iter_mut() {
+                *v = csprng.gen::<u8>();
+                s1.add(v);
             }
             let res1 = s1.result();
             let ref_res1: &[u8] = res1.as_ref();


### PR DESCRIPTION
The main thing to resolve was complaints about redundant lifetimes.

## Purpose

Upgrade rust to 1.62. This is necessary since we need to upgrade tonic in the node to version 0.8 (for the upcoming grpc changes) which needs rust at least 1.56.

## Changes

Address new clippy suggestions. They do not change semantics or performance of the code.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
