### PR TITLE
Fix windows build with Rust 1.62.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -149,6 +149,7 @@ library
     extra-libraries:
         userenv
         ws2_32
+        bcrypt
   default-language: Haskell2010
 
 executable generate-update-keys

--- a/package.yaml
+++ b/package.yaml
@@ -98,6 +98,7 @@ library:
       extra-libraries:
         - userenv
         - ws2_32
+        - bcrypt
 
 
 executables:


### PR DESCRIPTION
## Purpose

Fix the windows build by adding a system dependency. This seems to be needed with Rust 1.62 (and some older versions as well, although I have not pinpointed exactly which version is first that needs this).