### PR TITLE
uncache v1 state.

### DIFF
--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -668,14 +668,6 @@ extern "C" fn get_new_state_size_v1(mut loader: LoadCallback, tree: *mut Mutable
 }
 
 #[no_mangle]
-/// Load the entire tree into memory. If any data is in the backing store it is
-/// loaded using the provided callback.
-extern "C" fn cache_persistent_state_v1(mut loader: LoadCallback, tree: *mut PersistentState) {
-    let tree = unsafe { &mut *tree };
-    tree.cache(&mut loader)
-}
-
-#[no_mangle]
 /// Compute the hash of the persistent state and write it to the provided
 /// buffer which is assumed to be able to hold 32 bytes.
 /// The hash of the tree is cached, so this is generally a cheap function.

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -450,10 +450,9 @@ impl<V> CachedRef<V> {
         }
     }
 
-    /// If the value is in memory, set it to cached with the given key.
+    /// If the value is in memory, uncache it with the given key.
     /// Otherwise do nothing. This of course has the precondition that the key
     /// stores the value in the relevant backing store. Internal use only.
-    /// TOOD: doc
     fn uncache(&mut self, reference: Reference) {
         if let CachedRef::Memory {
             ..
@@ -465,9 +464,9 @@ impl<V> CachedRef<V> {
         }
     }
 
-    /// If the value is purely in memory then store it the backing store.
-    /// Store the reference (in the backing store) into the provided buffer.
-    /// TOOD: doc
+    /// If the value is purely in memory then store it the backing store and
+    /// uncache it. Store the reference (in the backing store) into the
+    /// provided buffer.
     pub(crate) fn store_and_uncache<S: BackingStoreStore, W: std::io::Write>(
         &mut self,
         backing_store: &mut S,

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -454,13 +454,8 @@ impl<V> CachedRef<V> {
     /// Otherwise do nothing. This of course has the precondition that the key
     /// stores the value in the relevant backing store. Internal use only.
     fn uncache(&mut self, reference: Reference) {
-        if let CachedRef::Memory {
-            ..
-        } = self
-        {
-            *self = CachedRef::Disk {
-                reference,
-            };
+        *self = CachedRef::Disk {
+            reference,
         }
     }
 
@@ -3252,13 +3247,7 @@ impl Node {
     pub fn is_cached(&self) -> bool {
         if let Some(value) = &self.value {
             if let InlineOrHashed::Indirect(value) = &*value.borrow() {
-                match &value.data {
-                    CachedRef::Disk {
-                        reference: _,
-                    } => return false,
-                    // [Cached] or [Memory]
-                    _ => return true,
-                };
+                return !matches!(&value.data, CachedRef::Disk { .. });
             } else {
                 // [InlineOrHashed::Inline] are not [CachedRef]'s
                 return false;

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -3253,14 +3253,19 @@ impl Node {
     pub fn is_cached(&self) -> bool {
         if let Some(value) = &self.value {
             if let InlineOrHashed::Indirect(value) = &*value.borrow() {
-                if let CachedRef::Disk {
-                    ..
-                } = value.data
-                {
-                    return false;
-                }
+                match &value.data {
+                    CachedRef::Disk {
+                        reference: _,
+                    } => return false,
+                    // [Cached] or [Memory]
+                    _ => return true,
+                };
+            } else {
+                // [InlineOrHashed::Inline] are not [CachedRef]'s
+                return false;
             }
         }
+
         for child in self.children.iter() {
             match &*child.1.borrow() {
                 CachedRef::Disk {

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -453,33 +453,22 @@ impl<V> CachedRef<V> {
     /// If the value is in memory, set it to cached with the given key.
     /// Otherwise do nothing. This of course has the precondition that the key
     /// stores the value in the relevant backing store. Internal use only.
-    fn cache_with(&mut self, reference: Reference) {
+    /// TOOD: doc
+    fn uncache(&mut self, reference: Reference) {
         if let CachedRef::Memory {
             ..
         } = self
         {
-            let value = std::mem::replace(self, CachedRef::Disk {
+            *self = CachedRef::Disk {
                 reference,
-            });
-            if let CachedRef::Memory {
-                value,
-            } = value
-            {
-                *self = CachedRef::Cached {
-                    value,
-                    reference,
-                };
-            } else {
-                // this is unreachable since we hold a mutable reference to the cached value
-                // and we know the value was a purely in-memory one
-                unsafe { std::hint::unreachable_unchecked() }
-            }
+            };
         }
     }
 
     /// If the value is purely in memory then store it the backing store.
     /// Store the reference (in the backing store) into the provided buffer.
-    pub(crate) fn store_and_cache<S: BackingStoreStore, W: std::io::Write>(
+    /// TOOD: doc
+    pub(crate) fn store_and_uncache<S: BackingStoreStore, W: std::io::Write>(
         &mut self,
         backing_store: &mut S,
         buf: &mut W,
@@ -496,29 +485,22 @@ impl<V> CachedRef<V> {
                 let reference = backing_store.store_raw(value.as_ref())?;
                 // Take the value out of the cachedref and temporarily replace it with
                 // a dummy value.
-                let value = std::mem::replace(self, CachedRef::Disk {
+                // and now write the cached value back in.
+                *self = CachedRef::Disk {
                     reference,
-                });
-                if let CachedRef::Memory {
-                    value,
-                } = value
-                {
-                    // and now write the cached value back in.
-                    *self = CachedRef::Cached {
-                        value,
-                        reference,
-                    };
-                } else {
-                    // this is unreachable since we hold a mutable reference to the cached value
-                    // and we know the value was a purely in-memory one
-                    unsafe { std::hint::unreachable_unchecked() }
-                }
+                };
                 reference.store(buf)
             }
             CachedRef::Cached {
-                reference,
-                ..
-            } => reference.store(buf),
+                reference: _,
+                value,
+            } => {
+                let reference = backing_store.store_raw(value.as_ref())?;
+                *self = CachedRef::Disk {
+                    reference,
+                };
+                reference.store(buf)
+            }
         }
     }
 
@@ -1571,7 +1553,7 @@ impl Node {
                         // variant.
                         buf.write_u8(0b1111_1111u8)?;
                         buf.write_all(indirect.hash.as_ref())?;
-                        indirect.data.store_and_cache(backing_store, buf)?;
+                        indirect.data.store_and_uncache(backing_store, buf)?;
                     }
                 }
             }
@@ -1609,7 +1591,7 @@ impl Node {
                         )?;
                         let key = backing_store.store_raw(&tmp_buf)?;
                         ref_stack.push(key);
-                        node_ref_mut.cache_with(key);
+                        node_ref_mut.uncache(key);
                     } else {
                         // the node's children have not yet been processed. Push the node back onto
                         // the stack recording that now the children have

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/low_level.rs
@@ -486,14 +486,15 @@ impl<V> CachedRef<V> {
                 reference.store(buf)
             }
             CachedRef::Cached {
-                reference: _,
-                value,
+                reference,
+                value: _,
             } => {
-                let reference = backing_store.store_raw(value.as_ref())?;
                 *self = CachedRef::Disk {
-                    reference,
+                    reference: *reference,
                 };
-                reference.store(buf)
+                // The value was already stored
+                // since it's a [CachedRef::Cached].
+                Ok(())
             }
         }
     }

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/tests.rs
@@ -144,25 +144,29 @@ fn prop_insert_freeze_lookup() {
     QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(_, _) -> anyhow::Result<()>);
 }
 
-///#[test]
-/// Check that storing also caches the data.
-///fn prop_storing_caches() {
-///    let prop = |inputs: Vec<(Vec<u8>, Value)>| -> anyhow::Result<()> {
-///        let reference = inputs.iter().cloned().collect::<BTreeMap<_, _>>();
-///        let (trie, mut loader) = make_mut_trie(inputs);
-///        let mut frozen = if let Some(t) = trie.freeze(&mut loader, &mut
-/// EmptyCollector) {            t
-///        } else {
-///            ensure!(reference.is_empty(), "Reference map is empty, but trie
-/// is not.");            return Ok(());
-///        };
-///        let mut ser = Vec::new();
-///        let _ = frozen.store_update(&mut ser);
-///        ensure!(frozen.get(&mut loader).data.is_cached(), "Not all data is
-/// stored.");        Ok(())
-///    };
-///    QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(Vec<_>) ->
-/// anyhow::Result<()>); }
+#[test]
+/// Check that storing also uncaches the data.
+fn prop_storing_uncaches() {
+    let prop = |inputs: Vec<(Vec<u8>, Value)>| -> anyhow::Result<()> {
+        let reference = inputs.iter().cloned().collect::<BTreeMap<_, _>>();
+        let (trie, mut loader) = make_mut_trie(inputs);
+        let mut frozen = if let Some(t) = trie.freeze(&mut loader, &mut EmptyCollector) {
+            t
+        } else {
+            ensure!(
+                reference.is_empty(),
+                "Reference map is empty, but trie
+ is not."
+            );
+            return Ok(());
+        };
+        let mut ser = Vec::new();
+        let _ = frozen.store_update(&mut ser);
+        ensure!(!frozen.get(&mut loader).data.is_cached(), "Data should not be cached.");
+        Ok(())
+    };
+    QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(Vec<_>) -> anyhow::Result<()>);
+}
 
 #[test]
 /// Check that storing computes the correct size, and that it can be

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/tests.rs
@@ -144,25 +144,25 @@ fn prop_insert_freeze_lookup() {
     QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(_, _) -> anyhow::Result<()>);
 }
 
-#[test]
+///#[test]
 /// Check that storing also caches the data.
-fn prop_storing_caches() {
-    let prop = |inputs: Vec<(Vec<u8>, Value)>| -> anyhow::Result<()> {
-        let reference = inputs.iter().cloned().collect::<BTreeMap<_, _>>();
-        let (trie, mut loader) = make_mut_trie(inputs);
-        let mut frozen = if let Some(t) = trie.freeze(&mut loader, &mut EmptyCollector) {
-            t
-        } else {
-            ensure!(reference.is_empty(), "Reference map is empty, but trie is not.");
-            return Ok(());
-        };
-        let mut ser = Vec::new();
-        let _ = frozen.store_update(&mut ser);
-        ensure!(frozen.get(&mut loader).data.is_cached(), "Not all data is stored.");
-        Ok(())
-    };
-    QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(Vec<_>) -> anyhow::Result<()>);
-}
+///fn prop_storing_caches() {
+///    let prop = |inputs: Vec<(Vec<u8>, Value)>| -> anyhow::Result<()> {
+///        let reference = inputs.iter().cloned().collect::<BTreeMap<_, _>>();
+///        let (trie, mut loader) = make_mut_trie(inputs);
+///        let mut frozen = if let Some(t) = trie.freeze(&mut loader, &mut
+/// EmptyCollector) {            t
+///        } else {
+///            ensure!(reference.is_empty(), "Reference map is empty, but trie
+/// is not.");            return Ok(());
+///        };
+///        let mut ser = Vec::new();
+///        let _ = frozen.store_update(&mut ser);
+///        ensure!(frozen.get(&mut loader).data.is_cached(), "Not all data is
+/// stored.");        Ok(())
+///    };
+///    QuickCheck::new().tests(NUM_TESTS).quickcheck(prop as fn(Vec<_>) ->
+/// anyhow::Result<()>); }
 
 #[test]
 /// Check that storing computes the correct size, and that it can be


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-node/issues/462

This PR evicts smart contract state from memory by simply not caching the state. 
 
## Changes

- Evicting state references by converting them to 'Disk' as opposed to 'Cached' references.
- Removed `cache_persistent_state_v1` as sc state should no longer be cached on startup.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
