### PR TITLE
ffi api changes related to init and recv fun(s)

### DIFF
--- a/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
@@ -146,9 +146,9 @@ unsafe extern "C" fn call_receive_v0(
 /// `*artifact_len` bytes for the artifact, followed by a list of export item
 /// names. The length of the list is encoded as u16, big endian, and each name
 /// is encoded as u16, big endian.
-/// 
-/// If validation succeeds, the serialized artifact is at `*output_artifact_bytes`
-/// and should be freed with `rs_free_array_len`.
+///
+/// If validation succeeds, the serialized artifact is at
+/// `*output_artifact_bytes` and should be freed with `rs_free_array_len`.
 ///
 /// # Safety
 /// This function is safe provided all the supplied pointers are not null and
@@ -190,65 +190,5 @@ unsafe extern "C" fn validate_and_process_v0(
             ptr
         }
         Err(_) => std::ptr::null_mut(),
-    }
-}
-
-// # Administrative functions.
-
-#[no_mangle]
-/// # Safety
-/// This function is safe provided the supplied pointer is
-/// constructed with [Arc::into_raw] and for each [Arc::into_raw] this function
-/// is called only once.
-unsafe extern "C" fn artifact_v0_free(artifact_ptr: *const ArtifactV0) {
-    if !artifact_ptr.is_null() {
-        // decrease the reference count
-        Arc::from_raw(artifact_ptr);
-    }
-}
-
-#[no_mangle]
-/// Convert an artifact to a byte array and return a pointer to it, storing its
-/// length in `output_len`. To avoid leaking memory the return value should be
-/// freed with `rs_free_array_len`.
-///
-/// # Safety
-/// This function is safe provided the `artifact_ptr` was obtained with
-/// `Arc::into_raw` and `output_len` points to a valid memory location.
-unsafe extern "C" fn artifact_v0_to_bytes(
-    artifact_ptr: *const ArtifactV0,
-    output_len: *mut size_t,
-) -> *mut u8 {
-    let artifact = Arc::from_raw(artifact_ptr);
-    let mut bytes = Vec::new();
-    artifact.output(&mut bytes).expect("Artifact serialization does not fail.");
-    bytes.shrink_to_fit();
-    *output_len = bytes.len() as size_t;
-    let ptr = bytes.as_mut_ptr();
-    std::mem::forget(bytes);
-    let _ = Arc::into_raw(artifact);
-    ptr
-}
-
-#[no_mangle]
-/// Deserialize an artifact from bytes and return a pointer to it.
-/// If deserialization fails this returns [None](https://doc.rust-lang.org/std/option/enum.Option.html#variant.None)
-/// and otherwise it returns a valid pointer to the artifact. To avoid leaking
-/// memory the memory must be freed using [artifact_v0_free].
-///
-/// # Safety
-/// This function is safe provided
-/// - either the `input_len` is greater than 0 and the `bytes_ptr` points to
-///   data of the given size
-/// - or `input_len` = 0
-unsafe extern "C" fn artifact_v0_from_bytes(
-    bytes_ptr: *const u8,
-    input_len: size_t,
-) -> *const ArtifactV0 {
-    let bytes = slice_from_c_bytes!(bytes_ptr, input_len as usize);
-    if let Ok(borrowed_artifact) = parse_artifact(bytes) {
-        Arc::into_raw(Arc::new(borrowed_artifact.into()))
-    } else {
-        std::ptr::null()
     }
 }

--- a/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
@@ -134,16 +134,21 @@ unsafe extern "C" fn call_receive_v0(
 /// - `wasm_bytes_ptr` a pointer to the Wasm module in Wasm binary format,
 ///   version 1.
 /// - `wasm_bytes_len` the length of the data pointed to by `wasm_bytes_ptr`
-/// - `artifact_out` a pointer where the pointer to the artifact will be
-///   written.
 /// - `output_len` a pointer where the total length of the output will be
 ///   written.
+/// - `output_artifact_len` a pointer where the length of the serialized
+///   artifact will be written.
+/// - `output_artifact_bytes` a pointer where the pointer to the serialized
+///   artifact will be written.
 ///
 /// The return value is either a null pointer if validation fails, or a pointer
 /// to a byte array of length `*output_len`. The byte array starts with
 /// `*artifact_len` bytes for the artifact, followed by a list of export item
 /// names. The length of the list is encoded as u16, big endian, and each name
 /// is encoded as u16, big endian.
+/// 
+/// If validation succeeds, the serialized artifact is at `*output_artifact_bytes`
+/// and should be freed with `rs_free_array_len`.
 ///
 /// # Safety
 /// This function is safe provided all the supplied pointers are not null and
@@ -152,7 +157,8 @@ unsafe extern "C" fn validate_and_process_v0(
     wasm_bytes_ptr: *const u8,
     wasm_bytes_len: size_t,
     output_len: *mut size_t, // this is the total length of the output byte array
-    output_artifact: *mut *const ArtifactV0, /* location where the pointer to the artifact will
+    output_artifact_len: *mut size_t, // the length of the artifact byte array
+    output_artifact_bytes: *mut *const u8, /* location where the pointer to the artifact will
                               * be written. */
 ) -> *mut u8 {
     let wasm_bytes = slice_from_c_bytes!(wasm_bytes_ptr, wasm_bytes_len as usize);
@@ -173,10 +179,14 @@ unsafe extern "C" fn validate_and_process_v0(
             *output_len = out_buf.len() as size_t;
             let ptr = out_buf.as_mut_ptr();
             std::mem::forget(out_buf);
-            // move the artifact to the arc.
-            let arc = Arc::new(artifact);
-            // and forget it.
-            *output_artifact = Arc::into_raw(arc);
+
+            let mut artifact_bytes = Vec::new();
+            artifact.output(&mut artifact_bytes).expect("Artifact serialization does not fail.");
+            artifact_bytes.shrink_to_fit();
+            *output_artifact_len = artifact_bytes.len() as size_t;
+            *output_artifact_bytes = artifact_bytes.as_mut_ptr();
+            std::mem::forget(artifact_bytes);
+
             ptr
         }
         Err(_) => std::ptr::null_mut(),

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -260,11 +260,8 @@ unsafe extern "C" fn call_receive_v1(
                     entrypoint,
                 };
 
-                // We're interrupted. We convert the 'BorrowedArtifactV1' to a (owned)
-                // 'ArtifactV1' and put it in the config.
-                let owned_artifact: Arc<ArtifactV1> = Arc::new(artifact.into());
                 let res = invoke_receive(
-                    owned_artifact.clone(),
+                    artifact,
                     amount,
                     receive_ctx,
                     actual_name.as_receive_name(),

--- a/smart-contracts/wasm-transform/src/artifact.rs
+++ b/smart-contracts/wasm-transform/src/artifact.rs
@@ -15,7 +15,8 @@ use derive_more::{Display, From, Into};
 use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
-    io::Write, sync::Arc,
+    io::Write,
+    sync::Arc,
 };
 
 #[derive(Copy, Clone)]
@@ -419,12 +420,10 @@ impl<'a, ImportFunc> From<BorrowedArtifact<'a, ImportFunc>> for OwnedArtifact<Im
     }
 }
 
-/// Convert a borrowed artifact to an owned one inside an `Arc`. This allocates memory for all
-/// the code of the artifact so it should be used sparingly.
+/// Convert a borrowed artifact to an owned one inside an `Arc`. This allocates
+/// memory for all the code of the artifact so it should be used sparingly.
 impl<'a, ImportFunc> From<BorrowedArtifact<'a, ImportFunc>> for Arc<OwnedArtifact<ImportFunc>> {
-    fn from(a : BorrowedArtifact<'a, ImportFunc>) -> Self {
-        Arc::new(a.into())
-    }
+    fn from(a: BorrowedArtifact<'a, ImportFunc>) -> Self { Arc::new(a.into()) }
 }
 
 /// Internal opcode. This is mostly the same as OpCode, but with control

--- a/smart-contracts/wasm-transform/src/artifact.rs
+++ b/smart-contracts/wasm-transform/src/artifact.rs
@@ -15,7 +15,7 @@ use derive_more::{Display, From, Into};
 use std::{
     collections::BTreeMap,
     convert::{TryFrom, TryInto},
-    io::Write,
+    io::Write, sync::Arc,
 };
 
 #[derive(Copy, Clone)]
@@ -416,6 +416,14 @@ impl<'a, ImportFunc> From<BorrowedArtifact<'a, ImportFunc>> for OwnedArtifact<Im
             export,
             code: code.into_iter().map(CompiledFunction::from).collect::<Vec<_>>(),
         }
+    }
+}
+
+/// Convert a borrowed artifact to an owned one inside an `Arc`. This allocates memory for all
+/// the code of the artifact so it should be used sparingly.
+impl<'a, ImportFunc> From<BorrowedArtifact<'a, ImportFunc>> for Arc<OwnedArtifact<ImportFunc>> {
+    fn from(a : BorrowedArtifact<'a, ImportFunc>) -> Self {
+        Arc::new(a.into())
     }
 }
 


### PR DESCRIPTION
## Purpose

Revise the FFI interface for processing and invoking smart contracts.

## Changes

- Processing smart contracts returns the artifact bytes, rather than a pointer to an artifact. (These bytes can then be stored without further FFI calls for serialization.)
- Invoking contract initialisation and receive functions takes in the artifact bytes, rather than an artifact pointer. The artifact bytes are only copied when the execution is suspended.
- FFI calls for managing artifact pointers are removed as they are now unneeded.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.