### PR TITLE
Unify macros that were defined twice.

### DIFF
--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -485,6 +485,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
+name = "ffi_helpers"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,6 +1378,7 @@ dependencies = [
  "criterion",
  "derive_more",
  "ed25519-zebra",
+ "ffi_helpers",
  "libc",
  "num_enum",
  "ptree",

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -8,7 +8,7 @@ license-file = "../../LICENSE"
 [features]
 # If this feature is enabled  the ffi exports are going to be produced
 # for use from Haskell.
-enable-ffi = []
+enable-ffi = ["ffi_helpers"]
 default=["enable-ffi"]
 fuzz = ["arbitrary", "wasm-smith", "wasmprinter"]
 fuzz-coverage = ["wasm-transform/fuzz-coverage"]
@@ -43,6 +43,10 @@ version = "0"
 version = "3.0"
 path = "../../concordium-contracts-common/concordium-contracts-common"
 features = ["derive-serde"]
+
+[dependencies.ffi_helpers]
+path = "../../rust-src/ffi_helpers"
+optional = true
 
 [lib]
 crate-type = ["cdylib", "staticlib", "rlib"]

--- a/smart-contracts/wasm-chain-integration/src/lib.rs
+++ b/smart-contracts/wasm-chain-integration/src/lib.rs
@@ -45,20 +45,6 @@ macro_rules! type_matches {
 }
 pub(crate) use type_matches;
 
-// After refactoring to have a common dependency with crypto, replace this
-// with the version from crypto.
-macro_rules! slice_from_c_bytes {
-    ($cstr:expr, $length:expr) => {
-        if $length != 0 {
-            assert!(!$cstr.is_null(), "Null pointer in `slice_from_c_bytes`.");
-            std::slice::from_raw_parts($cstr, $length)
-        } else {
-            &[]
-        }
-    };
-}
-pub(crate) use slice_from_c_bytes;
-
 /// Result of contract execution. This is just a wrapper around
 /// [anyhow::Result].
 pub type ExecResult<A> = anyhow::Result<A>;

--- a/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
@@ -1,4 +1,5 @@
-use crate::{slice_from_c_bytes, v0::*};
+use crate::v0::*;
+use ffi_helpers::{slice_from_c_bytes, slice_from_c_bytes_worker};
 use libc::size_t;
 use std::sync::Arc;
 use wasm_transform::{artifact::CompiledFunction, output::Output, utils::parse_artifact};

--- a/smart-contracts/wasm-chain-integration/src/v0/types.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/types.rs
@@ -102,6 +102,7 @@ impl<Policies> ReceiveContext<Policies> {
     pub fn self_address(&self) -> &ContractAddress { &self.self_address }
 }
 
+#[cfg(feature = "enable-ffi")]
 pub(crate) fn deserial_receive_context(source: &[u8]) -> ParseResult<ReceiveContext<&[u8]>> {
     let mut cursor = Cursor::new(source);
     let metadata = cursor.get()?;
@@ -126,6 +127,7 @@ pub(crate) fn deserial_receive_context(source: &[u8]) -> ParseResult<ReceiveCont
     }
 }
 
+#[cfg(feature = "enable-ffi")]
 pub(crate) fn deserial_init_context(source: &[u8]) -> ParseResult<InitContext<&[u8]>> {
     let mut cursor = Cursor::new(source);
     let metadata = cursor.get()?;

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -18,8 +18,9 @@ use super::trie::{
     foreign::{LoadCallback, StoreCallback},
     EmptyCollector, Loadable, MutableState, PersistentState, Reference, SizeCollector,
 };
-use crate::{slice_from_c_bytes, v1::*};
+use crate::v1::*;
 use concordium_contracts_common::OwnedReceiveName;
+use ffi_helpers::{slice_from_c_bytes, slice_from_c_bytes_worker};
 use libc::size_t;
 use sha2::Digest;
 use std::sync::Arc;

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/mod.rs
@@ -7,7 +7,10 @@ mod tests;
 mod api;
 pub use api::*;
 pub use low_level::Iterator;
-pub(crate) mod foreign;
+// We need this in some integration with the node, but we don't want to
+// advertise it.
+#[doc(hidden)]
+pub mod foreign;
 // We need the low-level module for testing and benchmarks, but we do not wish
 // to expose it.
 #[doc(hidden)]


### PR DESCRIPTION
This also removes unused definition warnings when compiling with no default features.

## Purpose

Remove warnings when compiling with no default features.

## Changes

- wasm-chain-integration now depends on ffi_helpers
- doubly defined macros are unified.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
