### PR TITLE
Add ability to construct contract state from iterators and streams.

### DIFF
--- a/.github/workflows/build-test-smart-contracts.yaml
+++ b/.github/workflows/build-test-smart-contracts.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           cargo fmt -- --color=always --check
 
-  "lint_clippy":
+  "lint_clippy_wasm_transform":
     name: smart-contracts/${{ matrix.build-dir }} lint:clippy
     # Don't run on draft pull requests
     if: ${{ !github.event.pull_request.draft }}
@@ -84,7 +84,6 @@ jobs:
       matrix:
         build-dir:
           - 'wasm-transform'
-          - 'wasm-chain-integration'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -102,7 +101,39 @@ jobs:
         working-directory: smart-contracts/${{ matrix.build-dir }}
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          cargo clippy --features async --color=always --tests --benches -- -Dclippy::all
+          cargo clippy --color=always --tests --benches -- -Dclippy::all
+
+  "lint_clippy_wasm_chain_integration":
+    name: smart-contracts/${{ matrix.build-dir }} lint:clippy
+    # Don't run on draft pull requests
+    if: ${{ !github.event.pull_request.draft }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        build-dir:
+          - 'wasm-chain-integration'
+        features:
+          - 'enable-ffi'
+          - 'display-state'
+          - 'async'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: recursive
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_CLIPPY }}
+          override: true
+          target: ${{ env.TARGET }}
+          components: clippy
+      - name: Clippy
+        working-directory: smart-contracts/${{ matrix.build-dir }}
+        run: |
+          git config --global url."https://github.com/".insteadOf "git@github.com:"
+          cargo clippy --features ${{ matrix.features }} --no-default-features --color=always --tests --benches -- -Dclippy::all
 
   "lint_clippy_example_contracts":
     name: smart-contracts/${{ matrix.example-contract }} lint:clippy

--- a/.github/workflows/build-test-smart-contracts.yaml
+++ b/.github/workflows/build-test-smart-contracts.yaml
@@ -102,7 +102,7 @@ jobs:
         working-directory: smart-contracts/${{ matrix.build-dir }}
         run: |
           git config --global url."https://github.com/".insteadOf "git@github.com:"
-          cargo clippy --color=always --tests --benches -- -Dclippy::all
+          cargo clippy --features async --color=always --tests --benches -- -Dclippy::all
 
   "lint_clippy_example_contracts":
     name: smart-contracts/${{ matrix.example-contract }} lint:clippy
@@ -209,4 +209,3 @@ jobs:
         run: |
           cargo build
           ./target/debug/wasm-test --dir ../testdata/wasm-spec-test-suite/core/
-

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -504,6 +504,95 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "futures"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
+
+[[package]]
+name = "futures-task"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
+
+[[package]]
+name = "futures-util"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -801,6 +890,18 @@ dependencies = [
  "fixedbitset",
  "indexmap",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "plotters"
@@ -1379,6 +1480,7 @@ dependencies = [
  "derive_more",
  "ed25519-zebra",
  "ffi_helpers",
+ "futures",
  "libc",
  "num_enum",
  "ptree",

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -13,6 +13,8 @@ default=["enable-ffi"]
 fuzz = ["arbitrary", "wasm-smith", "wasmprinter"]
 fuzz-coverage = ["wasm-transform/fuzz-coverage"]
 display-state = ["ptree"]
+# enable construction of the state from streams.
+async = ["futures"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
@@ -30,6 +32,7 @@ byteorder = "1.4"
 tinyvec = {version = "1.5", features = ["alloc"]}
 slab = "0.4.5"
 ptree = { version = "0.4.0", optional = true }
+futures = {version = "0.3", optional = true }
 
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 wasm-smith = { git = "https://github.com/Concordium/wasm-tools.git", branch = "mra/fuzzing", optional = true }

--- a/smart-contracts/wasm-chain-integration/src/v1/trie/api.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/trie/api.rs
@@ -250,6 +250,9 @@ impl PersistentState {
     /// If the stream yields duplicate keys then values at later keys
     /// override earlier ones. The resulting state lies entirely in memory
     /// and so can be used with any [`Loader`].
+    ///
+    /// This function should be preferred over
+    /// [`try_from_stream`](Self::try_from_stream) when it is applicable.
     pub async fn from_stream<S>(s: S) -> Self
     where
         S: futures::stream::Stream<Item = (Vec<u8>, Vec<u8>)> + Unpin, {


### PR DESCRIPTION
## Purpose

Make it easier to use the contract state in the rust sdk.

## Changes

Expose contract state construction methods, from iterators, and from streams.
The latter is useful in combination with the grpc API since the return value there is naturally a stream. This allows us to not construct an intermediate representation in memory.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.