### PR TITLE
Add documentation to `resume_receive`, and fix a bug.

### DIFF
--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -464,7 +464,6 @@ instance Serialize Parameter where
 
 -- |State of a smart contract. In general we don't know anything other than
 -- it is a sequence of bytes.
--- FIXME: In the future this should be more structured allowing for more sharing.
 newtype ContractState = ContractState {contractState :: BS.ByteString }
     deriving(Eq)
 

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contracts/wasm-chain-integration/benches/v1-host-functions.rs
+++ b/smart-contracts/wasm-chain-integration/benches/v1-host-functions.rs
@@ -122,7 +122,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         inner: Vec::new(),
                     };
                     let inner = mutable_state.get_inner(&mut backing_store);
-                    let state = InstanceState::new(0, backing_store, inner);
+                    let state = InstanceState::new(backing_store, inner);
                     let mut host = ReceiveHost::<_, Vec<u8>, _> {
                         energy: start_energy,
                         stateless: StateLessReceiveHost {
@@ -267,7 +267,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         inner: Vec::new(),
                     };
                     let inner = mutable_state.get_inner(&mut backing_store);
-                    let state = InstanceState::new(0, backing_store, inner);
+                    let state = InstanceState::new(backing_store, inner);
                     let mut host = ReceiveHost::<_, Vec<u8>, _> {
                         energy: start_energy,
                         stateless: StateLessReceiveHost {
@@ -368,7 +368,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                         inner: Vec::new(),
                     };
                     let inner = mutable_state.get_inner(&mut backing_store);
-                    let state = InstanceState::new(0, backing_store, inner);
+                    let state = InstanceState::new(backing_store, inner);
                     let mut host = ReceiveHost::<_, Vec<u8>, _> {
                         energy: start_energy,
                         stateless: StateLessReceiveHost {

--- a/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
@@ -104,7 +104,7 @@ fn test_crypto_prims() -> anyhow::Result<()> {
             inner: Vec::new(),
         };
         let inner = mutable_state.get_inner(&mut backing_store);
-        let state = InstanceState::new(0, backing_store, inner);
+        let state = InstanceState::new(backing_store, inner);
         let mut host = ReceiveHost::<_, Vec<u8>, _> {
             energy: start_energy,
             stateless: StateLessReceiveHost {

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -233,7 +233,7 @@ unsafe extern "C" fn call_receive_v1(
         let state_ptr = std::mem::replace(&mut *state_ptr_ptr, std::ptr::null_mut());
         let mut loader = loader;
         let mut state = (&mut *state_ptr).make_fresh_generation(&mut loader);
-        let instance_state = InstanceState::new(0, loader, state.get_inner(&mut loader));
+        let instance_state = InstanceState::new(loader, state.get_inner(&mut loader));
         match std::str::from_utf8(receive_name)
             .ok()
             .and_then(|s| OwnedReceiveName::new(s.into()).ok())

--- a/smart-contracts/wasm-chain-integration/src/v1/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/mod.rs
@@ -1071,7 +1071,7 @@ pub fn invoke_init<BackingStore: BackingStoreLoad, R: RunnableCode>(
 ) -> ExecResult<InitResult> {
     let mut initial_state = trie::MutableState::initial_state();
     let inner = initial_state.get_inner(&mut loader);
-    let state_ref = InstanceState::new(0, loader, inner);
+    let state_ref = InstanceState::new(loader, inner);
     let mut host = InitHost {
         energy,
         activation_frames: constants::MAX_ACTIVATION_FRAMES,

--- a/smart-contracts/wasm-chain-integration/src/v1/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/mod.rs
@@ -1316,6 +1316,21 @@ pub fn invoke_receive<
     process_receive_result(artifact, host, result)
 }
 
+/// Resume execution of the receive method after handling the interrupt.
+/// The arguments
+///
+/// - `interrupted_state` is the state of execution that is captured when we
+///   started handling the interrupt
+/// - `response` is the response from the operation that was invoked
+/// - `energy` is the remaning energy left for execution
+/// - `state_trie` is the current state of the contract instance, **after**
+///   handling the interrupt
+/// - `state_updated` indicates whether the state of the instance has changed
+///   during handling of the operation This can currently only happen if there
+///   is re-entrancy, i.e., if during handling of the interrupt the instance
+///   that invoked it is itself again invoked.
+/// - `backing_store` gives access to any on-disk storage for the instance
+///   state.
 pub fn resume_receive<BackingStore: BackingStoreLoad>(
     interrupted_state: Box<ReceiveInterruptedState<CompiledFunction>>,
     response: InvokeResponse,  // response from the call
@@ -1340,9 +1355,9 @@ pub fn resume_receive<BackingStore: BackingStoreLoad>(
     };
     let response = match response {
         InvokeResponse::Success {
-            state_updated,
             new_balance,
             data,
+            ..
         } => {
             host.stateless.receive_ctx.common.self_balance = new_balance;
             // the response value is constructed by setting the last 5 bytes to 0

--- a/smart-contracts/wasm-chain-integration/src/v1/tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/tests.rs
@@ -25,7 +25,7 @@ fn prop_create_write_read_delete() {
         };
         let mut m_state = MutableState::initial_state();
         let inner = m_state.get_inner(&mut loader);
-        let mut state = InstanceState::new(0, loader, inner);
+        let mut state = InstanceState::new(loader, inner);
         let mut energy = crate::InterpreterEnergy::from(u64::MAX);
         for (k, v) in &inputs {
             let entry = state
@@ -105,7 +105,7 @@ fn test_overflowing_write_resize() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
     let mut energy = crate::InterpreterEnergy::from(u64::MAX);
     let k = &[42];
     let entry = state
@@ -201,7 +201,7 @@ fn test_size_of_invalid_entry() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
     let entry = state
         .create_entry(&[0])
         .context("Entry should be created.")?
@@ -246,7 +246,7 @@ fn prop_entry_write_resizing() {
         };
         let mut m_state = MutableState::initial_state();
         let inner = m_state.get_inner(&mut loader);
-        let mut state = InstanceState::new(0, loader, inner);
+        let mut state = InstanceState::new(loader, inner);
         let mut energy = crate::InterpreterEnergy::from(u64::MAX);
         for (k, v) in &inputs {
             let entry = state
@@ -289,7 +289,7 @@ fn test_prefix_removal_fails_if_out_of_energy() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
     let key = vec![1];
     for k in &key {
         let entry = state
@@ -326,7 +326,7 @@ fn prop_iterators() {
         };
         let mut m_state = MutableState::initial_state();
         let inner = m_state.get_inner(&mut loader);
-        let mut state = InstanceState::new(0, loader, inner);
+        let mut state = InstanceState::new(loader, inner);
         let mut energy = crate::InterpreterEnergy::from(u64::MAX);
         // create the state with some locked parts.
         for (k, v) in &inputs {
@@ -458,7 +458,7 @@ fn prop_iterator_traversing() {
         };
         let mut m_state = MutableState::initial_state();
         let inner = m_state.get_inner(&mut loader);
-        let mut state = InstanceState::new(0, loader, inner);
+        let mut state = InstanceState::new(loader, inner);
         let mut energy = crate::InterpreterEnergy::from(u64::MAX);
         let mut prefixes = trie::low_level::PrefixesMap::new();
         for (k, v) in &inputs {
@@ -520,7 +520,7 @@ fn test_iterator_errors() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
 
     ensure!(state.create_entry(&[0, 1]).is_ok(), "Entry should have been created");
     ensure!(state.create_entry(&[0, 2]).is_ok(), "Entry should have been created");
@@ -569,7 +569,7 @@ fn test_iterator_deletion_and_consuming() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
     let mut energy = crate::InterpreterEnergy::from(u64::MAX);
     let key = &[0];
     ensure!(state.create_entry(key).is_ok(), "Entry should have been created.");
@@ -647,7 +647,7 @@ fn test_invalid_generation_operations() -> anyhow::Result<()> {
     };
     let mut m_state = MutableState::initial_state();
     let inner = m_state.get_inner(&mut loader);
-    let mut state = InstanceState::new(0, loader, inner);
+    let mut state = InstanceState::new(loader, inner);
     let mut energy = crate::InterpreterEnergy::from(u64::MAX);
     let entry = state
         .create_entry(&[0])

--- a/smart-contracts/wasm-chain-integration/src/v1/types.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/types.rs
@@ -857,13 +857,14 @@ impl trie::AllocCounter<trie::Value> for InterpreterEnergy {
 }
 
 impl<'a, BackingStore: trie::BackingStoreLoad> InstanceState<'a, BackingStore> {
+    /// Create a new [`InstanceState`] using the given backing store to load
+    /// data from disk.
     pub fn new(
-        current_generation: u32,
         backing_store: BackingStore,
         state: &'a trie::MutableStateInner,
     ) -> InstanceState<'a, BackingStore> {
         Self {
-            current_generation,
+            current_generation: 0,
             backing_store,
             changed: false,
             state_trie: state.lock(),
@@ -872,6 +873,7 @@ impl<'a, BackingStore: trie::BackingStoreLoad> InstanceState<'a, BackingStore> {
         }
     }
 
+    /// Migrate the [`InstanceState`] to a new generation.
     pub fn migrate(
         state_updated: bool,
         current_generation: InstanceCounter,


### PR DESCRIPTION
## Purpose

Fix bug in `resume_receive`, and clarify the usage.
This bug is not an issue on the node since the value that is supplied is the same for both state_changed flags. But if this function is used independently then it is not correct, and in any case it does not conform to the intent.

## Changes

- Add documentation
- Use correct `state_changed` flag when informing the instance.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.