### PR TITLE
Update lock files to record the correct contracts-common version.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -323,7 +323,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -339,7 +339,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contracts/wasm-test/Cargo.lock
+++ b/smart-contracts/wasm-test/Cargo.lock
@@ -128,7 +128,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "3.1.0"
+version = "4.0.0"
 dependencies = [
  "base58check",
  "chrono",
@@ -144,7 +144,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
## Purpose

Fix out of sync lock files. The contracts-common dependency was updated in https://github.com/Concordium/concordium-base/pull/214 but the lock files were not regenerated .

## Changes

Reflect the real version of the contracts-common dependency.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.