### PR TITLE
WIP: Towards an update of BLS and pairing deps.

### DIFF
--- a/rust-src/bulletproofs/src/inner_product_proof.rs
+++ b/rust-src/bulletproofs/src/inner_product_proof.rs
@@ -3,6 +3,8 @@ use crypto_common_derive::*;
 use curve_arithmetic::{multiexp, Curve};
 use ff::Field;
 use random_oracle::RandomOracle;
+use std::ops::{Neg, AddAssign, SubAssign, MulAssign, Mul};
+
 
 #[derive(Clone, Serialize, Debug)]
 pub struct InnerProductProof<C: Curve> {
@@ -133,7 +135,7 @@ pub fn prove_inner_product_with_scalars<C: Curve>(
         L_R.push((Lj, Rj));
         let u_j: C::Scalar = transcript.challenge_scalar::<C, _>(b"uj");
         // println!("Prover's u_{:?} = {:?}", j, u_j);
-        let u_j_inv = match u_j.inverse() {
+        let u_j_inv = match u_j.invert().into() {
             Some(inv) => inv,
             _ => return None,
         };
@@ -237,7 +239,7 @@ pub fn verify_scalars<C: Curve>(
         transcript.append_message(b"Lj", Lj);
         transcript.append_message(b"Rj", Rj);
         let u_j: C::Scalar = transcript.challenge_scalar::<C, _>(b"uj");
-        let u_j_inv = match u_j.inverse() {
+        let u_j_inv = match u_j.invert().into() {
             Some(inv) => inv,
             _ => return None,
         };

--- a/rust-src/curve_arithmetic/src/lib.rs
+++ b/rust-src/curve_arithmetic/src/lib.rs
@@ -1,7 +1,7 @@
 //! Basic definitions of the curve and pairing abstractions, and implementations
 //! of these abstractions for the curves used on Concordium.
-mod bls12_381_g1hash;
-mod bls12_381_g2hash;
+// mod bls12_381_g1hash;
+// mod bls12_381_g2hash;
 mod bls12_381_instance;
 mod curve_arithmetic;
 pub use crate::curve_arithmetic::*;

--- a/rust-src/curve_arithmetic/src/secret_value.rs
+++ b/rust-src/curve_arithmetic/src/secret_value.rs
@@ -98,7 +98,7 @@ impl<C: Curve> Value<C> {
         }
     }
 }
-
+/*
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -123,3 +123,4 @@ mod tests {
 
     macro_test_value_to_byte_conversion!(value_to_byte_conversion_bls12_381_g2_affine, G2Affine);
 }
+*/

--- a/rust-src/dodis_yampolskiy_prf/src/secret.rs
+++ b/rust-src/dodis_yampolskiy_prf/src/secret.rs
@@ -6,6 +6,7 @@ use curve_arithmetic::{Curve, Secret, Value};
 use ff::Field;
 use rand::*;
 use std::rc::Rc;
+use std::ops::AddAssign;
 
 /// A PRF key.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, SerdeBase16Serialize)]
@@ -51,8 +52,8 @@ impl<C: Curve> SecretKey<C> {
     /// return Ok, and vice-versa.
     pub fn prf_exponent(&self, n: u8) -> Result<C::Scalar, PrfError> {
         let mut x = C::scalar_from_u64(u64::from(n));
-        x.add_assign(self);
-        match x.inverse() {
+        x.add_assign(self.as_ref());
+        match Option::from(x.invert()) {
             None => Err(PrfError(DivisionByZero)),
             Some(y) => Ok(y),
         }

--- a/rust-src/elgamal/src/secret.rs
+++ b/rust-src/elgamal/src/secret.rs
@@ -8,6 +8,8 @@ use curve_arithmetic::{Curve, Value};
 use ff::Field;
 use rand::*;
 use std::collections::HashMap;
+use std::ops::{Neg, AddAssign, SubAssign, MulAssign, Mul};
+
 
 /// Elgamal secret key packed together with a chosen generator.
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SerdeBase16Serialize)]

--- a/rust-src/id/src/constants.rs
+++ b/rust-src/id/src/constants.rs
@@ -6,7 +6,7 @@ use crypto_common::{
     Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, SerdeDeserialize, SerdeSerialize, Serial,
 };
 use curve_arithmetic::{Curve, Pairing};
-use pairing::bls12_381::G1;
+use bls12_381::G1Projective as G1;
 use serde::{
     de::{self, Visitor},
     Deserializer, Serializer,
@@ -15,12 +15,12 @@ use std::{fmt, io::Cursor, str::FromStr};
 use thiserror::Error;
 
 /// Curve used by the anonymity revoker.
-pub type ArCurve = pairing::bls12_381::G1;
+pub type ArCurve = bls12_381::G1Projective;
 /// Pairing used by the identity provider.
-pub type IpPairing = pairing::bls12_381::Bls12;
+pub type IpPairing = bls12_381::Bls12;
 /// Field used by the identity provider and anonymity revoker.
 /// This isthe base field of both the ArCurve and the IpPairing.
-pub type BaseField = <pairing::bls12_381::Bls12 as Pairing>::ScalarField;
+pub type BaseField = <bls12_381::Bls12 as Pairing>::ScalarField;
 
 /// Index used to create the RegId of the initial credential.
 pub const INITIAL_CREDENTIAL_INDEX: u8 = 0;

--- a/rust-src/id/src/ffi.rs
+++ b/rust-src/id/src/ffi.rs
@@ -8,7 +8,7 @@ use crate::{
 use crypto_common::{size_t, types::TransactionTime, *};
 use either::Either::{Left, Right};
 use ffi_helpers::*;
-use pairing::bls12_381::{Bls12, G1};
+use bls12_381::{Bls12, G1Projective as G1};
 use pedersen_scheme::CommitmentKey as PedersenKey;
 use rand::thread_rng;
 use std::{collections::BTreeMap, convert::TryInto, io::Cursor};

--- a/rust-src/keygen_bls/src/lib.rs
+++ b/rust-src/keygen_bls/src/lib.rs
@@ -3,8 +3,10 @@
 use curve_arithmetic::Curve;
 use ff::{Field, PrimeField};
 use hkdf::Hkdf;
-use pairing::bls12_381::{Fr, FrRepr, G1};
+use bls12_381::{Scalar as Fr, G1Projective as  G1};
 use sha2::{Digest, Sha256};
+
+use std::ops::{Neg, AddAssign, SubAssign, MulAssign, Mul};
 
 /// This function is an implementation of the procedure described in <https://tools.ietf.org/html/draft-irtf-cfrg-bls-signature-04#section-2.3>
 /// It computes a random scalar in Fr given a seed (the argument `ikm`).
@@ -24,9 +26,9 @@ pub fn keygen_bls(ikm: &[u8], key_info: &[u8]) -> Result<Fr, hkdf::InvalidLength
     // shift with
     // 452312848583266388373324160190187140051835877600158453279131187530910662656 =
     // 2^248 = 2^(31*8)
-    let shift = Fr::from_repr(FrRepr([0, 0, 0, 72057594037927936])).unwrap();
+    let shift = Fr::from_raw([0, 0, 0, 72057594037927936]);
     let mut salt = Sha256::digest(&salt[..]);
-    while sk.is_zero() {
+    while sk.is_zero().into() {
         let (_, h) = Hkdf::<Sha256>::extract(Some(&salt), &ikm);
         let mut okm = vec![0u8; l as usize];
         h.expand(&l_bytes, &mut okm)?;
@@ -74,9 +76,9 @@ pub fn keygen_bls_deprecated(ikm: &[u8], key_info: &[u8]) -> Result<Fr, hkdf::In
     // shift with
     // 452312848583266388373324160190187140051835877600158453279131187530910662656 =
     // 2^248
-    let shift = Fr::from_repr(FrRepr([0, 0, 0, 72057594037927936])).unwrap();
+    let shift = Fr::from_raw([0, 0, 0, 72057594037927936]);
     let mut salt = Sha256::digest(&salt[..]);
-    while sk.is_zero() {
+    while sk.is_zero().into() {
         let (_, h) = Hkdf::<Sha256>::extract(Some(&salt), &ikm);
         let mut okm = vec![0u8; l as usize];
         h.expand(&l_bytes, &mut okm)?;

--- a/rust-src/ps_sig/src/secret.rs
+++ b/rust-src/ps_sig/src/secret.rs
@@ -14,6 +14,8 @@ use curve_arithmetic::*;
 use ff::Field;
 
 use rand::*;
+use std::ops::{Neg, AddAssign, SubAssign, MulAssign, Mul};
+
 
 /// A secret key
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
## Purpose

To update to the newest versions of the https://crates.io/crates/pairing and https://crates.io/crates/bls12_381 crates. 
Our current version (0.15.0) of the pairing crate has the bls12_381 module inside, but in newer versions it is in the separate crate https://crates.io/crates/bls12_381. 

STATUS: We need to be able to serialize `Curve::TargetField` elements, but the `Fp12` inside the target group `Gt` has been made private in https://crates.io/crates/bls12_381, so we are currently not able to serialize `Gt` elements. 
Concretely, this is needed for the Sigma protocol `ComEqSig` in order to produce a proof knowledge of a Pointcheval-Sanders Signature. The `id` crate does therefore not compile.  

## Changes

The crates
- bulletproofs/
- crypto_common
- curve_arithmetic
- dodis_yampolskiy_prf
- elgamal
- id
- keygen_bls
- pedersen_scheme
- ps_sig

have so far been touched in order to use the https://crates.io/crates/bls12_381 (the `id` crate does not compile).

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
