### PR TITLE
Base changes supporting a new hashing scheme for transaction outcomes.

### DIFF
--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -116,8 +116,6 @@ module Concordium.Types (
   BlockNonce,
   BlockSignature,
   BlockProof,
-  TransactionOutcomesHashV0(..),
-  TransactionOutcomesHash,
   StateHashV0(..),
   StateHash,
   BlockHash(..),
@@ -1028,14 +1026,10 @@ type TransactionHash = TransactionHashV0
 newtype BlockHash = BlockHash {blockHash :: Hash.Hash}
   deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, FromJSONKey, ToJSONKey, Read, Hashable)
 
-newtype TransactionOutcomesHashV0 = TransactionOutcomesHashV0 {v0TransactionOutcomesHash :: Hash.Hash}
-  deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, FromJSONKey, ToJSONKey, Read, Hashable)
-
 newtype StateHashV0 = StateHashV0 {v0StateHash :: Hash.Hash}
   deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, FromJSONKey, ToJSONKey, Read, Hashable)
 
 type StateHash = StateHashV0
-type TransactionOutcomesHash = TransactionOutcomesHashV0
 
 type BlockProof = VRF.Proof
 type BlockSignature = Sig.Signature

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -43,8 +43,6 @@ import Concordium.Crypto.EncryptedTransfers
 import qualified Concordium.Crypto.VRF as VRF
 import qualified Concordium.Crypto.BlockSignature as Sig
 import qualified Concordium.Crypto.BlsSignature as Bls
-import qualified Concordium.Crypto.SHA256 as H
-import Concordium.Types.HashableTo
 
 -- |We assume that the list is non-empty and at most 255 elements long.
 newtype AccountOwnershipProof = AccountOwnershipProof [(KeyIndex, Dlog25519Proof)]

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1860,6 +1860,7 @@ type TransactionSummary = TransactionSummary' ValidResult
 -- derive another 'HashableTo' instance which omits
 -- the exact 'RejectReason' in the resulting hash.
 newtype TransactionSummaryV1 = TransactionSummaryV1 (TransactionSummary' ValidResult)
+    deriving(Eq, Show, Generic)
 
 -- |TODO implement and doc.
 instance HashableTo H.Hash TransactionSummaryV1 where

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1853,7 +1853,8 @@ data TransactionSummary' a = TransactionSummary {
   tsIndex :: !TransactionIndex
   } deriving(Eq, Show, Generic)
 
--- |TODO DOC and suffix with v0?
+-- |A transaction summary parameterized with the an outcome
+-- of a valid transaction containing either a 'TxSuccess' or 'TxReject'.
 type TransactionSummary = TransactionSummary' ValidResult
 
 -- |We create a wrapper here so we can
@@ -1862,7 +1863,9 @@ type TransactionSummary = TransactionSummary' ValidResult
 newtype TransactionSummaryV1 = TransactionSummaryV1 {_transactionSummaryV1 :: TransactionSummary' ValidResult}
     deriving(Eq, Show, Generic)
 
--- |TODO implement and doc.
+-- |A 'HashableTo' instance for a 'TransactionSummary'' which
+-- omits the exact reject reason.
+-- Failures are simply tagged with a '0x1' byte.
 instance HashableTo H.Hash TransactionSummaryV1 where
   getHash (TransactionSummaryV1 summary) = H.hash $! S.runPut $!
       putMaybe S.put (tsSender summary) <>

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1817,7 +1817,7 @@ instance AE.FromJSON Event where
 
 -- |Index of the transaction in a block, starting from 0.
 newtype TransactionIndex = TransactionIndex Word64
-    deriving(Eq, Ord, Enum, Num, Show, Read, Real, Integral, S.Serialize, AE.ToJSON, AE.FromJSON) via Word64
+    deriving(Eq, Ord, Enum, Bits, Num, Show, Read, Real, Integral, S.Serialize, AE.ToJSON, AE.FromJSON) via Word64
 
 -- |The 'Maybe TransactionType' is to cover the case of a transaction payload
 -- that cannot be deserialized. A transaction is still included in a block, but
@@ -1859,7 +1859,7 @@ type TransactionSummary = TransactionSummary' ValidResult
 -- |We create a wrapper here so we can
 -- derive another 'HashableTo' instance which omits
 -- the exact 'RejectReason' in the resulting hash.
-newtype TransactionSummaryV1 = TransactionSummaryV1 (TransactionSummary' ValidResult)
+newtype TransactionSummaryV1 = TransactionSummaryV1 {_transactionSummaryV1 :: TransactionSummary' ValidResult}
     deriving(Eq, Show, Generic)
 
 -- |TODO implement and doc.

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1851,8 +1851,8 @@ data TransactionSummary' a = TransactionSummary {
   tsIndex :: !TransactionIndex
   } deriving(Eq, Show, Generic)
 
--- |A transaction summary parameterized with the an outcome
--- of a valid transaction containing either a 'TxSuccess' or 'TxReject'.
+-- |A transaction summary parameterized with an outcome of a valid transaction
+-- containing either a 'TxSuccess' or 'TxReject'.
 type TransactionSummary = TransactionSummary' ValidResult
 
 -- |Outcomes of a valid transaction. Either a reject with a reason or a

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1857,26 +1857,6 @@ data TransactionSummary' a = TransactionSummary {
 -- of a valid transaction containing either a 'TxSuccess' or 'TxReject'.
 type TransactionSummary = TransactionSummary' ValidResult
 
--- |We create a wrapper here so we can
--- derive another 'HashableTo' instance which omits
--- the exact 'RejectReason' in the resulting hash.
-newtype TransactionSummaryV1 = TransactionSummaryV1 {_transactionSummaryV1 :: TransactionSummary' ValidResult}
-    deriving(Eq, Show, Generic)
-
--- |A 'HashableTo' instance for a 'TransactionSummary'' which
--- omits the exact reject reason.
--- Failures are simply tagged with a '0x1' byte.
-instance HashableTo H.Hash TransactionSummaryV1 where
-  getHash (TransactionSummaryV1 summary) = H.hash $! S.runPut $!
-      putMaybe S.put (tsSender summary) <>
-      S.put (tsHash summary) <>
-      S.put (tsCost summary) <>
-      S.put (tsEnergyCost summary) <>
-      S.put (tsType summary) <>
-      -- |We simply put a '1' indicating a failure.
-      S.putWord8 1 <>
-      S.put (tsIndex summary)
-
 -- |Outcomes of a valid transaction. Either a reject with a reason or a
 -- successful transaction with a list of events which occurred during execution.
 -- We also record the cost of the transaction.

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -81,7 +81,8 @@ instance FromJSON ProtocolVersion where
 -- term level 'SProtocolVersion's.
 class
     ( IsChainParametersVersion (ChainParametersVersionFor pv),
-      IsAccountVersion (AccountVersionFor pv)
+      IsAccountVersion (AccountVersionFor pv),
+      IsTransactionOutcomesVersion (TransactionOutcomesVersionFor pv)
     ) =>
     IsProtocolVersion (pv :: ProtocolVersion)
     where
@@ -215,6 +216,42 @@ instance IsAccountVersion 'AccountV1 where
 
 instance IsAccountVersion 'AccountV2 where
     accountVersion = SAccountV2
+
+
+-- |Transaction outcomes versions.
+-- The difference between the two versions are only related
+-- to the hashing scheme.
+-- * 'TOVO' is used in P1 to P4. The hash is computed as a simple hash list.
+-- All the contents of the transaction summaries are used for computing the hash.
+-- * 'TOV1' is used in PV5 and onwards. The hash is computed via a merkle tree and the
+-- exact reject reasons for failed transactions are omitted from the hash. 
+data TransactionOutcomesVersion
+     = TOV0
+     | TOV1
+
+-- |Projection of 'ProtocolVersion' to 'TransactionOutcomesVersion'.
+type family TransactionOutcomesVersionFor (pv :: ProtocolVersion) :: TransactionOutcomesVersion where
+    TransactionOutcomesVersionFor 'P1 = 'TOV0
+    TransactionOutcomesVersionFor 'P2 = 'TOV0
+    TransactionOutcomesVersionFor 'P3 = 'TOV0
+    TransactionOutcomesVersionFor 'P4 = 'TOV0
+    TransactionOutcomesVersionFor 'P5 = 'TOV1
+
+-- |Supporting type for bringing the 'TransactionOutcomesVersion' to the term level.
+data STransactionOutcomesVersion (tov :: TransactionOutcomesVersion) where
+    STOV0 :: STransactionOutcomesVersion 'TOV0
+    STOV1 :: STransactionOutcomesVersion 'TOV1
+
+class IsTransactionOutcomesVersion (tov :: TransactionOutcomesVersion)
+    where
+    -- |The singleton associated with the outcomes version.
+    transactionOutcomesVersion :: STransactionOutcomesVersion tov
+
+instance IsTransactionOutcomesVersion 'TOV0 where
+  transactionOutcomesVersion = STOV0
+
+instance IsTransactionOutcomesVersion 'TOV1 where
+  transactionOutcomesVersion = STOV1
 
 -- |A type used at the kind level to denote that delegation is or is not expected to be supported
 -- at an account version. This is intended to give more descriptive type errors in cases where the

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -827,6 +827,17 @@ type family TransactionOutcomesVersionFor (pv :: ProtocolVersion) :: Transaction
     TransactionOutcomesVersionFor 'P4 = 'TOV0
     TransactionOutcomesVersionFor 'P5 = 'TOV1
 
+-- |todo doc
+data STransactionOutcomesVersion (tov :: TransactionOutcomesVersion) where
+    STOV0 :: STransactionOutcomesVersion 'TOV0
+    STOV1 :: STransactionOutcomesVersion 'TOV1
+
+-- |todo DOC
+class IsTransactionOutcomesVersion (tov :: TransactionOutcomesVersion)
+    where
+    -- |The singleton associated with the protocol version.
+    transactionOutcomesVersion :: STransactionOutcomesVersion tov
+
 -- |TODO doc
 -- TODO: suffix with V0?
 data TransactionOutcomes = TransactionOutcomes {

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -17,6 +17,7 @@ import qualified Data.Sequence as Seq
 import Data.Aeson(FromJSON(..), ToJSON(..))
 import qualified Data.Aeson as AE
 import qualified Data.ByteString as BS
+import Data.Hashable
 import qualified Data.Serialize as S
 import qualified Data.Map.Strict as Map
 import Lens.Micro.Platform
@@ -855,6 +856,7 @@ instance HashableTo TransactionOutcomesHash TransactionOutcomes where
 -- No matter the strategy for deriving the TrasactionOutcomeHash we will
 -- always end up with a value of this type.
 newtype TransactionOutcomesHash = TransactionOutcomesHash { tohGet :: H.Hash}
+ deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, AE.FromJSONKey, AE.ToJSONKey, Read, Hashable)
 
 emptyTransactionOutcomesV0 :: TransactionOutcomes
 emptyTransactionOutcomesV0 = TransactionOutcomes Vec.empty Seq.empty

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -17,7 +17,6 @@ import qualified Data.Sequence as Seq
 import Data.Aeson(FromJSON(..), ToJSON(..))
 import qualified Data.Aeson as AE
 import qualified Data.ByteString as BS
-import Data.Hashable (Hashable (..))
 import qualified Data.Serialize as S
 import qualified Data.Map.Strict as Map
 import Lens.Micro.Platform
@@ -820,121 +819,58 @@ data TransactionOutcomesVersion
      | TOV1
 
 -- |Projection of 'ProtocolVersion' to 'TransactionOutcomesVersion'.
-type family TransactionOutcomesHashVersionFor (pv :: ProtocolVersion) :: TransactionOutcomesVersion where
-    TransactionOutcomesHashVersionFor 'P1 = 'TOV0
-    TransactionOutcomesHashVersionFor 'P2 = 'TOV0
-    TransactionOutcomesHashVersionFor 'P3 = 'TOV0
-    TransactionOutcomesHashVersionFor 'P4 = 'TOV0
-    TransactionOutcomesHashVersionFor 'P5 = 'TOV1
+type family TransactionOutcomesVersionFor (pv :: ProtocolVersion) :: TransactionOutcomesVersion where
+    TransactionOutcomesVersionFor 'P1 = 'TOV0
+    TransactionOutcomesVersionFor 'P2 = 'TOV0
+    TransactionOutcomesVersionFor 'P3 = 'TOV0
+    TransactionOutcomesVersionFor 'P4 = 'TOV0
+    TransactionOutcomesVersionFor 'P5 = 'TOV1
 
 -- |TODO doc
-data TransactionOutcomesV0 (tov :: TransactionOutcomesVersion)  = TransactionOutcomesV0 {
+-- TODO: suffix with V0?
+data TransactionOutcomes = TransactionOutcomes {
     outcomeValues :: !(Vec.Vector TransactionSummary),
     _outcomeSpecial :: !(Seq.Seq SpecialTransactionOutcome)
-    }
+}
+makeLenses ''TransactionOutcomes
 
-makeLenses ''TransactionOutcomesV0
-
-instance Show (TransactionOutcomesV0 'TOV0) where
-    show (TransactionOutcomesV0 v s) = "Normal transactions: " ++ show (Vec.toList v) ++ ", special transactions: " ++ show s
-
--- |Transaction outcome types.
-data TransactionOutcomeT
-    = TransactionSummary
-    -- ^Outcome of normal transactions.
-    | SpecialTransactionOutcome
-    -- ^Outcome of a special transaction.    
-
--- |Transaction outcomes from P5 and onwards.
--- The transaction outcomes are hashed as a binary merkle tree.
-newtype TransactionOutcomesV1 (tov :: TransactionOutcomesVersion) =  TransactionOutcomesV1 { tosGetTree:: MerkleTree TransactionOutcomeT }
+instance Show TransactionOutcomes where
+    show (TransactionOutcomes v s) = "Normal transactions: " ++ show (Vec.toList v) ++ ", special transactions: " ++ show s
 
 -- |Serialization of the V0 transaction outcomes used in P1-P4.
-putTransactionOutcomesV0 :: S.Putter (TransactionOutcomesV0 'TOV0)
-putTransactionOutcomesV0 TransactionOutcomesV0{..} = do
+-- TODO: RENAME?
+putTransactionOutcomes :: S.Putter TransactionOutcomes
+putTransactionOutcomes TransactionOutcomes{..} = do
     putListOf putTransactionSummary (Vec.toList outcomeValues)
     S.put _outcomeSpecial
 
--- |Serialization of the V1 transaction outcomes used in P5 and onwards.
-putTransactionOutcomesV1 :: S.Putter (TransactionOutcomesV1 'TOV1)
-putTransactionOutcomesV1 TransactionOutcomesV1{..} = do
-    putMerkleTree tosGetTree
+-- |TODO DOC and move to node? (Same with 'TransactionOutcomes') 
+getTransactionOutcomes :: SProtocolVersion pv -> S.Get TransactionOutcomes
+getTransactionOutcomes spv = TransactionOutcomes <$> (Vec.fromList <$> getListOf (getTransactionSummary spv)) <*> S.get
 
-putMerkleTree :: S.Putter (MerkleTree a)
-putMerkleTree = undefined
-
-getTransactionOutcomes :: SProtocolVersion pv -> S.Get (TransactionOutcomesV0 'TOV0)
-getTransactionOutcomes spv = TransactionOutcomesV0 <$> (Vec.fromList <$> getListOf (getTransactionSummary spv)) <*> S.get
-
--- TODO: fix this to use an lfmb tree. Potentially change storage type to the tree in blockstate too.
--- Does this need to be domain seperated? (Would require serialisation changes?)
---instance HashableTo TransactionOutcomesHashV0 TransactionOutcomes where
---    getHash transactionoutcomes = TransactionOutcomesHashV0 $ H.hash $ S.runPut $ putTransactionOutcomes transactionoutcomes
+instance HashableTo TransactionOutcomesHash TransactionOutcomes where
+    getHash transactionoutcomes = TransactionOutcomesHash $ H.hash $ S.runPut $ putTransactionOutcomes transactionoutcomes
 
 -- |A simple wrapper around a `Hash`.
 -- No matter the strategy for deriving the TrasactionOutcomeHash we will
 -- always end up with a value of this type.
 newtype TransactionOutcomesHash = TransactionOutcomesHash { tohGet :: H.Hash}
 
-instance HashableTo TransactionOutcomesHash (TransactionOutcomes tov) where
-  getHash :: TransactionOutcomes tov -> TransactionOutcomesHash
-  getHash = \case                     
-    TOHV0 tos -> TransactionOutcomesHash $ H.hash $ S.runPut $ putTransactionOutcomesV0 tos
-    TOHV1 tos -> TransactionOutcomesHash $ H.hash $ S.runPut $ putTransactionOutcomesV1 tos
+emptyTransactionOutcomesV0 :: TransactionOutcomes
+emptyTransactionOutcomesV0 = TransactionOutcomes Vec.empty Seq.empty
 
-
--- |A binary merkle tree
--- It can either be empty or not empty.
--- See `BMT`` for the non empty case.
-data MerkleTree v
-    = Empty
-    | NonEmpty (BMT v)
-
--- |A simple non-empty binary merkle tree
-data BMT' h v
-    = Leaf h v
-    | Node h (BMT' h v) (BMT' h v)
-
-newtype BMT v = BMT' H.Hash
-
-merkleTreeFromAscList :: [a] -> MerkleTree a
-merkleTreeFromAscList = undefined
-
--- |Compute and get the transaction outcomes hash based on the supplied protocol version @pv@. 
--- For PV 1-4 the hash will be a hash list based on the the full transaction outcome per transaction i.e. including the exact
--- `RejectReason` for failed transactions.
--- For PV5 and onwards the hash is computed as a merkle tree and omitting the exact `RejectReason`.
---getTransactionOutcomesHash :: ProtocolVersion -> TransactionOutcomes -> TransactionOutcomesHash
---getTransactionOutcomesHash pv outcomes =
---    if pv < P5 then
---      getHash outcomes
---    else
---      getNewHash outcomes
---  where
---    getNewHash :: TransactionOutcomes -> H.Hash
---    getNewHash outcomes = undefined
-    
-
-emptyTransactionOutcomesV0 :: (TransactionOutcomesV0 'TOV0)
-emptyTransactionOutcomesV0 = TransactionOutcomesV0 Vec.empty Seq.empty
-
-transactionOutcomesV0FromList :: [TransactionSummary] -> TransactionOutcomesV0 'TOV0
+transactionOutcomesV0FromList :: [TransactionSummary] -> TransactionOutcomes
 transactionOutcomesV0FromList l =
   let outcomeValues = Vec.fromList l
       _outcomeSpecial = Seq.empty
-  in TransactionOutcomesV0{..}
+  in TransactionOutcomes{..}
 
-type instance Index (TransactionOutcomesV0 'TOV0) = TransactionIndex
-type instance IxValue (TransactionOutcomesV0 'TOV0) = TransactionSummary
+type instance Index TransactionOutcomes = TransactionIndex
+type instance IxValue TransactionOutcomes = TransactionSummary
 
-instance Ixed (TransactionOutcomesV0 'TOV0) where
-  ix idx f outcomes@TransactionOutcomesV0{..} =
+instance Ixed TransactionOutcomes where
+  ix idx f outcomes@TransactionOutcomes{..} =
     let x = fromIntegral idx
     in if x >= length outcomeValues then pure outcomes
-       else ix x f outcomeValues <&> (\ov -> TransactionOutcomesV0{outcomeValues=ov,..})
+       else ix x f outcomeValues <&> (\ov -> TransactionOutcomes{outcomeValues=ov,..})
 
-
-data TransactionOutcomes (tov :: TransactionOutcomesVersion) where
-    TOHV0 :: TransactionOutcomesV0 'TOV0 -> TransactionOutcomes 'TOV0
-    TOHV1 :: TransactionOutcomesV1 'TOV1 -> TransactionOutcomes 'TOV1
---  deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, AE.FromJSONKey, AE.ToJSONKey, Read, Hashable)

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -712,6 +712,9 @@ data SpecialTransactionOutcome =
 
 $(deriveJSON defaultOptions{fieldLabelModifier = firstLower . drop 3} ''SpecialTransactionOutcome)
 
+instance HashableTo H.Hash SpecialTransactionOutcome where
+  getHash = H.hash . S.encode
+
 instance S.Serialize SpecialTransactionOutcome where
     put BakingRewards{..} = do
       S.putWord8 0

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -715,6 +715,9 @@ $(deriveJSON defaultOptions{fieldLabelModifier = firstLower . drop 3} ''SpecialT
 instance HashableTo H.Hash SpecialTransactionOutcome where
   getHash = H.hash . S.encode
 
+-- Generic instance based on the HashableTo instance
+instance Monad m => MHashableTo m H.Hash SpecialTransactionOutcome
+
 instance S.Serialize SpecialTransactionOutcome where
     put BakingRewards{..} = do
       S.putWord8 0
@@ -815,36 +818,6 @@ instance S.Serialize SpecialTransactionOutcome where
         stoFinalizationReward <- S.get
         return PaydayPoolReward{..}
       _ -> fail "Invalid SpecialTransactionOutcome type"
-
-
--- |Transaction outcomes versions.
--- The difference between the two versions are only related
--- to the hashing scheme.
--- * 'TOVO' is used in P1 to P4. The hash is computed as a simple hash list.
--- All the contents of the transaction summaries are used for computing the hash.
--- * 'TOV1' is used in PV5 and onwards. The hash is computed via a merkle tree and the
--- exact reject reasons for failed transactions are omitted from the hash. 
-data TransactionOutcomesVersion
-     = TOV0
-     | TOV1
-
--- |Projection of 'ProtocolVersion' to 'TransactionOutcomesVersion'.
-type family TransactionOutcomesVersionFor (pv :: ProtocolVersion) :: TransactionOutcomesVersion where
-    TransactionOutcomesVersionFor 'P1 = 'TOV0
-    TransactionOutcomesVersionFor 'P2 = 'TOV0
-    TransactionOutcomesVersionFor 'P3 = 'TOV0
-    TransactionOutcomesVersionFor 'P4 = 'TOV0
-    TransactionOutcomesVersionFor 'P5 = 'TOV1
-
--- |Supporting type for bringing the 'TransactionOutcomesVersion' to the term level.
-data STransactionOutcomesVersion (tov :: TransactionOutcomesVersion) where
-    STOV0 :: STransactionOutcomesVersion 'TOV0
-    STOV1 :: STransactionOutcomesVersion 'TOV1
-
-class IsTransactionOutcomesVersion (tov :: TransactionOutcomesVersion)
-    where
-    -- |The singleton associated with the outcomes version.
-    transactionOutcomesVersion :: STransactionOutcomesVersion tov
 
 -- |TODO doc
 -- TODO: suffix with V0?

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -850,6 +850,20 @@ newtype TransactionOutcomesHash = TransactionOutcomesHash { tohGet :: H.Hash}
 emptyTransactionOutcomesV0 :: TransactionOutcomes
 emptyTransactionOutcomesV0 = TransactionOutcomes Vec.empty Seq.empty
 
+{-# NOINLINE emptyTransactionOutcomesHashV1 #-}
+-- |Hash of the empty V1 transaction outcomes structure. This transaction outcomes
+-- structure is used starting in protocol version 5.
+--
+-- This is not the ideal location here, since the merkle structures that define
+-- it are defined in the global state modules, however any other place leads to
+-- problematic module dependencies. We should ideally restructure those so that
+-- we do not have this duplication here.
+emptyTransactionOutcomesHashV1 :: TransactionOutcomesHash
+emptyTransactionOutcomesHashV1 = TransactionOutcomesHash $ H.hashShort
+    ("TransactionOutcomesV1" <>
+     H.hashToShortByteString (H.hash "EmptyLFMBTree") <>
+     H.hashToShortByteString (H.hash "EmptyLFMBTree"))
+
 transactionOutcomesV0FromList :: [TransactionSummary] -> TransactionOutcomes
 transactionOutcomesV0FromList l =
   let outcomeValues = Vec.fromList l

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -817,7 +817,13 @@ instance S.Serialize SpecialTransactionOutcome where
       _ -> fail "Invalid SpecialTransactionOutcome type"
 
 
--- |TODO DOC
+-- |Transaction outcomes versions.
+-- The difference between the two versions are only related
+-- to the hashing scheme.
+-- * 'TOVO' is used in P1 to P4. The hash is computed as a simple hash list.
+-- All the contents of the transaction summaries are used for computing the hash.
+-- * 'TOV1' is used in PV5 and onwards. The hash is computed via a merkle tree and the
+-- exact reject reasons for failed transactions are omitted from the hash. 
 data TransactionOutcomesVersion
      = TOV0
      | TOV1
@@ -830,15 +836,14 @@ type family TransactionOutcomesVersionFor (pv :: ProtocolVersion) :: Transaction
     TransactionOutcomesVersionFor 'P4 = 'TOV0
     TransactionOutcomesVersionFor 'P5 = 'TOV1
 
--- |todo doc
+-- |Supporting type for bringing the 'TransactionOutcomesVersion' to the term level.
 data STransactionOutcomesVersion (tov :: TransactionOutcomesVersion) where
     STOV0 :: STransactionOutcomesVersion 'TOV0
     STOV1 :: STransactionOutcomesVersion 'TOV1
 
--- |todo DOC
 class IsTransactionOutcomesVersion (tov :: TransactionOutcomesVersion)
     where
-    -- |The singleton associated with the protocol version.
+    -- |The singleton associated with the outcomes version.
     transactionOutcomesVersion :: STransactionOutcomesVersion tov
 
 -- |TODO doc
@@ -867,7 +872,7 @@ instance HashableTo TransactionOutcomesHash TransactionOutcomes where
     getHash transactionoutcomes = TransactionOutcomesHash $ H.hash $ S.runPut $ putTransactionOutcomes transactionoutcomes
 
 -- |A simple wrapper around a `Hash`.
--- No matter the strategy for deriving the TrasactionOutcomeHash we will
+-- No matter the strategy for deriving the 'TrasactionOutcomeHash' we will
 -- always end up with a value of this type.
 newtype TransactionOutcomesHash = TransactionOutcomesHash { tohGet :: H.Hash}
  deriving newtype (Eq, Ord, Show, S.Serialize, ToJSON, FromJSON, AE.FromJSONKey, AE.ToJSONKey, Read, Hashable)

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -819,8 +819,8 @@ instance S.Serialize SpecialTransactionOutcome where
         return PaydayPoolReward{..}
       _ -> fail "Invalid SpecialTransactionOutcome type"
 
--- |TODO doc
--- TODO: suffix with V0?
+-- |Outcomes of transactions. The vector of outcomes must have the same size as the
+-- number of transactions in the block, and ordered in the same way.
 data TransactionOutcomes = TransactionOutcomes {
     outcomeValues :: !(Vec.Vector TransactionSummary),
     _outcomeSpecial :: !(Seq.Seq SpecialTransactionOutcome)
@@ -830,14 +830,11 @@ makeLenses ''TransactionOutcomes
 instance Show TransactionOutcomes where
     show (TransactionOutcomes v s) = "Normal transactions: " ++ show (Vec.toList v) ++ ", special transactions: " ++ show s
 
--- |Serialization of the V0 transaction outcomes used in P1-P4.
--- TODO: RENAME?
 putTransactionOutcomes :: S.Putter TransactionOutcomes
 putTransactionOutcomes TransactionOutcomes{..} = do
     putListOf putTransactionSummary (Vec.toList outcomeValues)
     S.put _outcomeSpecial
 
--- |TODO DOC and move to node? (Same with 'TransactionOutcomes') 
 getTransactionOutcomes :: SProtocolVersion pv -> S.Get TransactionOutcomes
 getTransactionOutcomes spv = TransactionOutcomes <$> (Vec.fromList <$> getListOf (getTransactionSummary spv)) <*> S.get
 


### PR DESCRIPTION
## Purpose

Introduce  multiple versions of `TransactionOutcomes` which can be used for supporting different kinds of hashing schemes.
In particular from P5 and onwards we do not want to hash the exact `RejectReason` anymore. (See https://github.com/Concordium/concordium-node/issues/566)

There are two versions of `TransactionOutcomes` and these are determined by the `ProtocolVersion`. 
PV1 to PV4 makes use of `TransactionOutcomesVersion 0` (`TOV0`) while P5 uses `TOV1`. 

Further there is introduced a `TransactionSummaryV1` type which is just a `newtype` wrapper around the existing `TransactionSummary` type. The purpose of this is to allow for a different `HashableTo` instance which omits the exact reject reason in the computed hash.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
