### PR TITLE
Changed sets to contain scalars instead of u64s.

### DIFF
--- a/rust-src/bulletproofs/benches/smp_bench.rs
+++ b/rust-src/bulletproofs/benches/smp_bench.rs
@@ -18,10 +18,10 @@ pub fn bench_set_membership_proof(c: &mut Criterion) {
         let rng = &mut thread_rng();
         // Instance
         let n = 2_usize.pow(i);
-        let mut the_set = Vec::<u64>::with_capacity(n);
+        let mut the_set = Vec::<<G1 as Curve>::Scalar>::with_capacity(n);
         // Technically generates a multi-set, but this is fine
         for _ in 0..n {
-            the_set.push(rng.next_u64())
+            the_set.push(G1::generate_scalar(rng));
         }
         let v_index = rng.gen_range(0, n);
         let v = the_set[v_index];
@@ -31,8 +31,7 @@ pub fn bench_set_membership_proof(c: &mut Criterion) {
         let B_tilde = G1::generate(rng);
         let v_keys = CommitmentKey { g: B, h: B_tilde };
         let v_rand = Randomness::generate(rng);
-        let v_scalar = G1::scalar_from_u64(v);
-        let v_value = Value::<G1>::new(v_scalar);
+        let v_value = Value::<G1>::new(v);
         let v_com = v_keys.hide(&v_value, &v_rand);
 
         // Get some generators

--- a/rust-src/bulletproofs/src/lib.rs
+++ b/rust-src/bulletproofs/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! In particular this means
 //!  * range proofs for 64-bit unsigned integers.
-//!  * set membership proofs for 64-bit unsigned integers.
+//!  * set membership proofs for scalars of curve `C`.
 pub mod inner_product_proof;
 pub mod range_proof;
 pub mod set_membership_proof;

--- a/rust-src/bulletproofs/src/set_membership_proof.rs
+++ b/rust-src/bulletproofs/src/set_membership_proof.rs
@@ -539,13 +539,7 @@ mod tests {
 
     /// Converts the u64 set vector into a vector over the field
     fn get_set_vector<C: Curve>(the_set: &[u64]) -> Vec<C::Scalar> {
-        let n = the_set.len();
-        let mut s_vec = Vec::with_capacity(n);
-        for elem_i in the_set {
-            let s_i = C::scalar_from_u64(*elem_i);
-            s_vec.push(s_i);
-        }
-        s_vec
+        the_set.iter().copied().map(C::scalar_from_u64).collect()
     }
 
     /// generates several values used in tests

--- a/rust-src/bulletproofs/src/set_membership_proof.rs
+++ b/rust-src/bulletproofs/src/set_membership_proof.rs
@@ -79,8 +79,8 @@ fn a_L_a_R<F: Field>(v: &F, set_slice: &[F]) -> Option<(Vec<F>, Vec<F>)> {
 /// the commitment `V` to `v`. The arguments are
 /// - `transcript` - the random oracle for Fiat Shamir
 /// - `csprng` - cryptographic safe randomness generator
-/// - `the_set` - the set as a vector
-/// - `v` the value
+/// - `the_set` - the set as a vector of scalars
+/// - `v` the value, a scalar 
 /// - `gens` - generators containing vectors `G` and `H` both of at least length
 ///   `k` where k is the smallest power of two >= `n`
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in the bluepaper)
@@ -348,7 +348,7 @@ pub enum VerificationError {
 /// of value v that is in a set S and that is consistent
 /// with a commitment V to v. The arguments are
 /// - `transcript` - the random oracle for Fiat Shamir
-/// - `the_set` - the set as a vector
+/// - `the_set` - the set as a vector of scalars
 /// - `V` - commitment to `v`
 /// - `proof` - the set membership proof to verify
 /// - `gens` - generators containing vectors `G` and `H` both of length at least

--- a/rust-src/bulletproofs/src/set_membership_proof.rs
+++ b/rust-src/bulletproofs/src/set_membership_proof.rs
@@ -80,7 +80,7 @@ fn a_L_a_R<F: Field>(v: &F, set_slice: &[F]) -> Option<(Vec<F>, Vec<F>)> {
 /// - `transcript` - the random oracle for Fiat Shamir
 /// - `csprng` - cryptographic safe randomness generator
 /// - `the_set` - the set as a vector of scalars
-/// - `v` the value, a scalar 
+/// - `v` the value, a scalar
 /// - `gens` - generators containing vectors `G` and `H` both of at least length
 ///   `k` where k is the smallest power of two >= `n`
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in the bluepaper)

--- a/rust-src/bulletproofs/src/utils.rs
+++ b/rust-src/bulletproofs/src/utils.rs
@@ -45,31 +45,15 @@ impl<C: Curve> Generators<C> {
 /// - z - the field element z
 /// - first_power - the first power j
 /// - n - the integer n.
-pub fn z_vec<F: Field>(z: F, first_power: usize, n: usize) -> Vec<F> {
+pub fn z_vec<F: Field>(z: F, first_power: u64, n: usize) -> Vec<F> {
     let mut z_n = Vec::with_capacity(n);
-    // let mut z_i = F::one();
-    // FIXME: This should would be better to do with `pow`.
-    // for _ in 0..first_power {
-    //    z_i.mul_assign(&z);
-    //}
-    let exp: [u64; 1] = [first_power as u64];
+    let exp: [u64; 1] = [first_power];
     let mut z_i = z.pow(exp);
     for _ in 0..n {
         z_n.push(z_i);
         z_i.mul_assign(&z);
     }
     z_n
-}
-
-/// Converts the u64 set vector into a vector over the field
-pub fn get_set_vector<C: Curve>(the_set: &[u64]) -> Vec<C::Scalar> {
-    let n = the_set.len();
-    let mut s_vec = Vec::with_capacity(n);
-    for elem_i in the_set {
-        let s_i = C::scalar_from_u64(*elem_i);
-        s_vec.push(s_i);
-    }
-    s_vec
 }
 
 /// Pads a non-empty field vector to a power of two length by repeating the last


### PR DESCRIPTION
## Purpose

Sets for set membership proofs contained u64s. This is not enough, e.g., for names.

## Changes

Use curve scalars directly instead of converting from u64.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.