### PR TITLE
Relax smart contract restrictions

### DIFF
--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -25,8 +25,22 @@ maxPayloadSize SP5 = maxPayloadSize SP4
 -- * Web assembly related constants
 
 -- |Maximum length of the parameter to init and receive methods.
-maxParameterLen :: Word16
-maxParameterLen = 1024
+-- The limit was changed from `1024` to `65535` in P5.
+maxParameterLen :: SProtocolVersion pv -> Word16
+maxParameterLen SP1 = 1024
+maxParameterLen SP2 = 1024
+maxParameterLen SP3 = 1024
+maxParameterLen SP4 = 1024
+maxParameterLen _ = 65535
+
+-- |Whether the number of logs and size of return values should be limited.
+-- The limits have been removed in P5 and onward.
+limitLogsAndReturnValues :: SProtocolVersion pv -> Bool
+limitLogsAndReturnValues SP1 = True
+limitLogsAndReturnValues SP2 = True
+limitLogsAndReturnValues SP3 = True
+limitLogsAndReturnValues SP4 = True
+limitLogsAndReturnValues _ = False
 
 -- |Maximum module size of a V0 module.
 maxWasmModuleSizeV0 :: Word32

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -31,7 +31,7 @@ maxParameterLen SP1 = 1024
 maxParameterLen SP2 = 1024
 maxParameterLen SP3 = 1024
 maxParameterLen SP4 = 1024
-maxParameterLen _ = 65535
+maxParameterLen SP5 = 65535
 
 -- |Whether the number of logs and size of return values should be limited.
 -- The limits have been removed in P5 and onward.
@@ -40,7 +40,7 @@ limitLogsAndReturnValues SP1 = True
 limitLogsAndReturnValues SP2 = True
 limitLogsAndReturnValues SP3 = True
 limitLogsAndReturnValues SP4 = True
-limitLogsAndReturnValues _ = False
+limitLogsAndReturnValues SP5 = False
 
 -- |Maximum module size of a V0 module.
 maxWasmModuleSizeV0 :: Word32

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -2088,8 +2088,9 @@ instance S.Serialize RejectReason where
       rejectReason <- S.getInt32be
       contractAddress <- S.get
       receiveName <- S.get
-      -- Get the parameter without validating its length. This is OK here, because the length has been checked before reaching this point.
-      -- Checking requires the protocol version as input, which is why it is skipped here.
+      -- We only ever deserialize valid transactions, which means that the parameter size is known to be valid.
+      -- This allows us to skip the size check, which is useful because checking requires the protocol version,
+      -- which we do not currently have access to here.
       parameter <- Wasm.getParameterUnchecked
       return RejectedReceive {..}
     14 -> return InvalidProof

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -410,13 +410,13 @@ putPayload InitContract{..} =
       S.put icAmount <>
       S.put icModRef <>
       S.put icInitName <>
-      S.put icParam
+      Wasm.putParameter icParam
 putPayload Update{..} =
     P.putWord8 2 <>
     S.put uAmount <>
     S.put uAddress <>
     S.put uReceiveName <>
-    S.put uMessage
+    Wasm.putParameter uMessage
 putPayload Transfer{..} =
     P.putWord8 3 <>
     S.put tToAddress <>
@@ -560,13 +560,13 @@ getPayload spv size = S.isolate (fromIntegral size) (S.bytesRead >>= go)
               icAmount <- S.get
               icModRef <- S.get
               icInitName <- S.get
-              icParam <- S.get
+              icParam <- Wasm.getParameter spv
               return InitContract{..}
             2 -> do
               uAmount <- S.get
               uAddress <- S.get
               uReceiveName <- S.get
-              uMessage <- S.get
+              uMessage <- Wasm.getParameter spv
               return Update{..}
             3 -> do
               tToAddress <- S.get
@@ -1062,7 +1062,7 @@ putEvent = \case ModuleDeployed mref ->
                    S.put euAddress <>
                    S.put euInstigator <>
                    S.put euAmount <>
-                   S.put euMessage <>
+                   Wasm.putParameter euMessage <>
                    S.put euReceiveName <>
                    S.put euContractVersion <>
                    S.putWord32be (fromIntegral (length euEvents)) <>
@@ -1245,7 +1245,7 @@ getEvent spv =
       euAddress <- S.get
       euInstigator <- S.get
       euAmount <- S.get
-      euMessage <- S.get
+      euMessage <- Wasm.getParameter spv
       euReceiveName <- S.get
       euContractVersion <- S.get
       euEventsLength <- fromIntegral <$> S.getWord32be
@@ -2026,7 +2026,7 @@ instance S.Serialize RejectReason where
       S.putInt32be rejectReason <>
       S.put contractAddress <>
       S.put receiveName <>
-      S.put parameter
+      Wasm.putParameter parameter
     InvalidProof -> S.putWord8 14
     AlreadyABaker bid -> S.putWord8 15 <> S.put bid
     NotABaker addr -> S.putWord8 16 <> S.put addr
@@ -2088,7 +2088,9 @@ instance S.Serialize RejectReason where
       rejectReason <- S.getInt32be
       contractAddress <- S.get
       receiveName <- S.get
-      parameter <- S.get
+      -- Get the parameter without validating its length. This is OK here, because the length has been checked before reaching this point.
+      -- Checking requires the protocol version as input, which is why it is skipped here.
+      parameter <- Wasm.getParameterUnchecked
       return RejectedReceive {..}
     14 -> return InvalidProof
     15 -> AlreadyABaker <$> S.get

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -37,6 +37,7 @@ module Concordium.Wasm (
   maxParameterLen,
   maxWasmModuleSizeV0,
   maxWasmModuleSizeV1,
+  limitLogsAndReturnValues,
 
   -- * Modules
   -- ** Binary module
@@ -77,6 +78,9 @@ module Concordium.Wasm (
   uncheckedMakeReceiveName,
   Parameter(..),
   emptyParameter,
+  getParameter,
+  getParameterUnchecked,
+  putParameter,
 
   -- *** Contract state
   ContractState(..),
@@ -453,11 +457,22 @@ newtype Parameter = Parameter { parameter :: ShortByteString }
 emptyParameter :: Parameter
 emptyParameter = Parameter BSS.empty
 
-instance Serialize Parameter where
-  put = putShortByteStringWord16 . parameter
-  get = do
+-- |Put (serialize) a @Parameter@.
+putParameter :: Putter Parameter
+putParameter = putShortByteStringWord16 . parameter
+
+-- |Get (deserialize) a @Parameter@ and ensure that its size is valid. The size limit depends on the protocol version.
+getParameter :: SProtocolVersion pv -> Get Parameter
+getParameter spv = do
     len <- getWord16be
-    unless (len <= maxParameterLen) $ fail "Parameter size exceeds limits."
+    unless (len <= maxParameterLen spv) $ fail "Parameter size exceeds limits."
+    Parameter <$> getShortByteString (fromIntegral len)
+
+-- |Get (deserialize) a @Parameter@ *without checking that its size is valid*. This should only be used when
+-- we know for a fact that the parameter size is within the valid bounds for the given protocol version.
+getParameterUnchecked :: Get Parameter
+getParameterUnchecked = do
+    len <- getWord16be
     Parameter <$> getShortByteString (fromIntegral len)
 
 --------------------------------------------------------------------------------
@@ -665,7 +680,7 @@ getActionsTree' size = go HM.empty 0
                            erAddr <- get
                            erName <- get
                            erAmount <- get
-                           erParameter <- get
+                           erParameter <- getParameterUnchecked -- TODO: Ensure interpreter checks the length.
                            let action = TSend{..}
                            go (HM.insert n action acc) (n+1)
                          1 -> do

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -465,7 +465,7 @@ putParameter = putShortByteStringWord16 . parameter
 getParameter :: SProtocolVersion pv -> Get Parameter
 getParameter spv = do
     len <- getWord16be
-    unless (len <= maxParameterLen spv) $ fail "Parameter size exceeds limits."
+    unless (len <= maxParameterLen spv) $ fail "Parameter size exceeds the limit."
     Parameter <$> getShortByteString (fromIntegral len)
 
 -- |Get (deserialize) a @Parameter@ *without checking that its size is valid*. This should only be used when
@@ -680,7 +680,7 @@ getActionsTree' size = go HM.empty 0
                            erAddr <- get
                            erName <- get
                            erAmount <- get
-                           erParameter <- getParameterUnchecked -- TODO: Ensure interpreter checks the length.
+                           erParameter <- getParameterUnchecked
                            let action = TSend{..}
                            go (HM.insert n action acc) (n+1)
                          1 -> do

--- a/smart-contracts/wasm-chain-integration/benches/v1-host-functions.rs
+++ b/smart-contracts/wasm-chain-integration/benches/v1-host-functions.rs
@@ -19,7 +19,7 @@ use wasm_chain_integration::{
             self, low_level::MutableTrie, EmptyCollector, Loader, MutableState, PersistentState,
         },
         ConcordiumAllowedImports, InstanceState, ProcessedImports, ReceiveContext, ReceiveHost,
-        StateLessReceiveHost,
+        ReceiveParams, StateLessReceiveHost,
     },
     InterpreterEnergy,
 };
@@ -137,7 +137,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             receive_ctx,
                             return_value: Vec::new(),
                             parameters,
-                            support_queries: true,
+                            params: ReceiveParams::new_p5(),
                         },
                         state,
                     };
@@ -283,7 +283,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             receive_ctx,
                             return_value: Vec::new(),
                             parameters,
-                            support_queries: true
+                            params: ReceiveParams::new_p5()
                         },
                         state,
                     };
@@ -385,7 +385,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                             receive_ctx,
                             return_value: Vec::new(),
                             parameters,
-                            support_queries: true,
+                            params: ReceiveParams::new_p5(),
                         },
                         state,
                     };

--- a/smart-contracts/wasm-chain-integration/benches/wasm.rs
+++ b/smart-contracts/wasm-chain-integration/benches/wasm.rs
@@ -533,14 +533,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let setup_init_host = || -> InitHost<Parameter<'_>, &InitContext<PolicyBytes<'_>>> {
             InitHost {
-                energy:            InterpreterEnergy {
+                energy: InterpreterEnergy {
                     energy: nrg * 1000,
                 },
                 activation_frames: MAX_ACTIVATION_FRAMES,
-                logs:              Logs::new(),
-                state:             State::new(None),
-                param:             Parameter::from(&[] as &[u8]),
-                init_ctx:          &init_ctx,
+                logs: Logs::new(),
+                state: State::new(None),
+                param: Parameter::from(&[] as &[u8]),
+                init_ctx: &init_ctx,
+                limit_logs_and_return_values: false,
             }
         };
 
@@ -556,6 +557,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     param,
                     outcomes: Outcome::new(),
                     receive_ctx: &receive_ctx,
+                    max_parameter_size: u16::MAX.into(),
+                    limit_logs_and_return_values: false,
                 }
             };
 

--- a/smart-contracts/wasm-chain-integration/src/constants.rs
+++ b/smart-contracts/wasm-chain-integration/src/constants.rs
@@ -7,9 +7,9 @@ pub const MAX_ACTIVATION_FRAMES: u32 = 1024;
 /// Maximum size of a log message.
 pub const MAX_LOG_SIZE: u32 = 512;
 
-/// Maximum number of log messages per execution *in protocol version < 5* (no
-/// limit from 5 and onward). This together with the previous constant limits
-/// the amount of data that can be logged to 16kB.
+/// Maximum number of log messages per execution in *protocol version 4 and
+/// lower*. This, together with the previous constant, limits the amount of data
+/// that can be logged to 16kB.
 pub const MAX_NUM_LOGS: usize = 64;
 
 /// Base cost of a log event call.

--- a/smart-contracts/wasm-chain-integration/src/constants.rs
+++ b/smart-contracts/wasm-chain-integration/src/constants.rs
@@ -4,15 +4,12 @@ pub const MAX_CONTRACT_STATE: u32 = 16384; // 16kB
 /// Maximum number of nested function calls.
 pub const MAX_ACTIVATION_FRAMES: u32 = 1024;
 
-/// Maximum size of the init/receive parameter.
-pub const MAX_PARAMETER_SIZE: usize = 1024;
-
 /// Maximum size of a log message.
 pub const MAX_LOG_SIZE: u32 = 512;
 
-/// Maximum number of log messages per execution.
-/// This together with the previous constant limits the amount of data that can
-/// be logged to 16kB.
+/// Maximum number of log messages per execution *in protocol version < 5* (no
+/// limit from 5 and onward). This together with the previous constant limits
+/// the amount of data that can be logged to 16kB.
 pub const MAX_NUM_LOGS: usize = 64;
 
 /// Base cost of a log event call.
@@ -36,16 +33,40 @@ pub const BASE_SIMPLE_TRANSFER_ACTION_COST: u64 = BASE_ACTION_COST + 40000;
 // TODO: These should in principle be const fn, but rust in 1.45.2 u64::from
 // are not marked as const fn, so they are not.
 
-/// Cost of copying the given amount of bytes from the host (e.g., parameter or
+/// Cost of copying the given amount of bytes from the host (e.g., policy or
 /// contract state) to the Wasm memory. The 10 is to account for copying empty
 /// buffers and is based on benchmarks.
 #[inline(always)]
 pub fn copy_from_host_cost(x: u32) -> u64 { 10 + u64::from(x) }
-/// Cost of copying the given amount of bytes to the host (e.g., parameter or
-/// contract state) from the Wasm to host memory. The 10 is to account for
+
+/// Cost of copying the given amount of bytes to the host (e.g., contract state)
+/// from the Wasm to host memory. The 10 is to account for
 /// copying empty buffers and is based on benchmarks.
 #[inline(always)]
 pub fn copy_to_host_cost(x: u32) -> u64 { 10 + u64::from(x) }
+
+/// Cost of copying a V1 parameter between the Wasm memory and the host in
+/// either direction.
+///
+/// - The cost for parameters <= 1kB is: base cost + 1NRG per *kilobyte*.
+/// - The cost for parameters > 1kB is: base cost + 1NRG per *byte*.
+///
+/// Prior to P5, the parameters were limited to 1kB, which is why the cost
+/// scheme is as it is.
+///
+/// Notes on the factors:
+/// - The `10` is to account for copying empty buffers and is based on
+///   benchmarks.
+/// - The `1000` factor makes it so that the cost is 1NRG per byte.
+#[inline(always)]
+pub fn copy_parameter_cost(len: u32) -> u64 {
+    let len = u64::from(len);
+    if len <= 1024 {
+        10 + len
+    } else {
+        10 + 1000 * len
+    }
+}
 
 /// Cost of allocating additional smart contract state. The argument is the
 /// number of additional bytes. The `/100` guarantees that with 3_000_000NRG

--- a/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
@@ -43,12 +43,14 @@ unsafe extern "C" fn call_init_v0(
             Ok(name) => {
                 let res = invoke_init(
                     &artifact,
-                    amount,
                     init_ctx,
-                    name,
-                    parameter.into(),
+                    InitInvocation {
+                        amount,
+                        init_name: name,
+                        parameter: parameter.into(),
+                        energy,
+                    },
                     limit_logs_and_return_values,
-                    energy,
                 );
                 match res {
                     Ok(result) => {
@@ -108,14 +110,16 @@ unsafe extern "C" fn call_receive_v0(
             Ok(name) => {
                 let res = invoke_receive(
                     &artifact,
-                    amount,
                     receive_ctx,
+                    ReceiveInvocation {
+                        amount,
+                        receive_name: name,
+                        parameter: parameter.into(),
+                        energy,
+                    },
                     state,
-                    name,
-                    parameter.into(),
                     max_parameter_size,
                     limit_logs_and_return_values,
-                    energy,
                 );
                 match res {
                     Ok(result) => {

--- a/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/ffi.rs
@@ -21,6 +21,7 @@ unsafe extern "C" fn call_init_v0(
     init_name_len: size_t,
     param_bytes: *const u8,
     param_bytes_len: size_t,
+    limit_logs_and_return_values: u8,
     energy: InterpreterEnergy,
     output_len: *mut size_t,
 ) -> *mut u8 {
@@ -34,12 +35,21 @@ unsafe extern "C" fn call_init_v0(
     let res = std::panic::catch_unwind(|| {
         let init_name = slice_from_c_bytes!(init_name, init_name_len as usize);
         let parameter = slice_from_c_bytes!(param_bytes, param_bytes_len as usize);
+        let limit_logs_and_return_values = limit_logs_and_return_values != 0;
         let init_ctx =
             deserial_init_context(slice_from_c_bytes!(init_ctx_bytes, init_ctx_bytes_len as usize))
                 .expect("Precondition violation: invalid init ctx given by host.");
         match std::str::from_utf8(init_name) {
             Ok(name) => {
-                let res = invoke_init(&artifact, amount, init_ctx, name, parameter.into(), energy);
+                let res = invoke_init(
+                    &artifact,
+                    amount,
+                    init_ctx,
+                    name,
+                    parameter.into(),
+                    limit_logs_and_return_values,
+                    energy,
+                );
                 match res {
                     Ok(result) => {
                         let mut out = result.to_bytes();
@@ -72,6 +82,8 @@ unsafe extern "C" fn call_receive_v0(
     state_bytes_len: size_t,
     param_bytes: *const u8,
     param_bytes_len: size_t,
+    max_parameter_size: size_t,
+    limit_logs_and_return_values: u8,
     energy: InterpreterEnergy,
     output_len: *mut size_t,
 ) -> *mut u8 {
@@ -91,6 +103,7 @@ unsafe extern "C" fn call_receive_v0(
         let receive_name = slice_from_c_bytes!(receive_name, receive_name_len as usize);
         let state = slice_from_c_bytes!(state_bytes, state_bytes_len as usize);
         let parameter = slice_from_c_bytes!(param_bytes, param_bytes_len as usize);
+        let limit_logs_and_return_values = limit_logs_and_return_values != 0;
         match std::str::from_utf8(receive_name) {
             Ok(name) => {
                 let res = invoke_receive(
@@ -100,6 +113,8 @@ unsafe extern "C" fn call_receive_v0(
                     state,
                     name,
                     parameter.into(),
+                    max_parameter_size,
+                    limit_logs_and_return_values,
                     energy,
                 );
                 match res {

--- a/smart-contracts/wasm-chain-integration/src/v0/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/mod.rs
@@ -190,46 +190,46 @@ impl State {
 
 pub struct InitHost<ParamType, Ctx> {
     /// Remaining energy for execution.
-    pub energy:                   InterpreterEnergy,
+    pub energy: InterpreterEnergy,
     /// Remaining amount of activation frames.
     /// In other words, how many more functions can we call in a nested way.
-    pub activation_frames:        u32,
+    pub activation_frames: u32,
     /// Logs produced during execution.
-    pub logs:                     Logs,
+    pub logs: Logs,
     /// The contract's state.
-    pub state:                    State,
+    pub state: State,
     /// The parameter to the init method.
-    pub param:                    ParamType,
+    pub param: ParamType,
     /// The init context for this invocation.
-    pub init_ctx:                 Ctx,
+    pub init_ctx: Ctx,
     /// Whether there is a limit on the number of logs and sizes of return
     /// values. Limit removed in P5.
-    limit_logs_and_return_values: bool,
+    pub limit_logs_and_return_values: bool,
 }
 
 pub struct ReceiveHost<ParamType, Ctx> {
     /// Remaining energy for execution.
-    pub energy:                   InterpreterEnergy,
+    pub energy: InterpreterEnergy,
     /// Remaining amount of activation frames.
     /// In other words, how many more functions can we call in a nested way.
-    pub activation_frames:        u32,
+    pub activation_frames: u32,
     /// Logs produced during execution.
-    pub logs:                     Logs,
+    pub logs: Logs,
     /// The contract's state.
-    pub state:                    State,
+    pub state: State,
     /// The parameter to the receive method.
-    pub param:                    ParamType,
+    pub param: ParamType,
     /// Outcomes of the execution, i.e., the actions tree.
-    pub outcomes:                 Outcome,
+    pub outcomes: Outcome,
     /// The receive context for this call.
-    pub receive_ctx:              Ctx,
+    pub receive_ctx: Ctx,
     /// The maximum parameter size.
     /// In P1-P4 it was 1024.
     /// In P5+ it is 65535.
-    max_parameter_size:           usize,
+    pub max_parameter_size: usize,
     /// Whether there is a limit on the number of logs and sizes of return
     /// values. Limit removed in P5.
-    limit_logs_and_return_values: bool,
+    pub limit_logs_and_return_values: bool,
 }
 
 /// Types which can act as init contexts.

--- a/smart-contracts/wasm-chain-integration/src/v0/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/mod.rs
@@ -28,7 +28,7 @@ impl Logs {
     /// - 1 if data was logged.
     pub fn log_event(&mut self, event: Vec<u8>, limit_num_logs: bool) -> i32 {
         let cur_len = self.logs.len();
-        if (!limit_num_logs && cur_len < u32::MAX as usize) || cur_len < constants::MAX_NUM_LOGS {
+        if (!limit_num_logs && cur_len <= u32::MAX as usize) || cur_len < constants::MAX_NUM_LOGS {
             self.logs.push_back(event);
             1
         } else {

--- a/smart-contracts/wasm-chain-integration/src/v0/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v0/mod.rs
@@ -28,7 +28,7 @@ impl Logs {
     /// - 1 if data was logged.
     pub fn log_event(&mut self, event: Vec<u8>, limit_num_logs: bool) -> i32 {
         let cur_len = self.logs.len();
-        if !limit_num_logs || cur_len < constants::MAX_NUM_LOGS {
+        if (!limit_num_logs && cur_len < u32::MAX as usize) || cur_len < constants::MAX_NUM_LOGS {
             self.logs.push_back(event);
             1
         } else {
@@ -223,7 +223,9 @@ pub struct ReceiveHost<ParamType, Ctx> {
     pub outcomes:                 Outcome,
     /// The receive context for this call.
     pub receive_ctx:              Ctx,
-    /// The maximum parameter size. Is constant for a given protocol version.
+    /// The maximum parameter size.
+    /// In P1-P4 it was 1024.
+    /// In P5+ it is 65535.
     max_parameter_size:           usize,
     /// Whether there is a limit on the number of logs and sizes of return
     /// values. Limit removed in P5.

--- a/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
@@ -119,9 +119,7 @@ fn test_crypto_prims() -> anyhow::Result<()> {
                 receive_ctx,
                 return_value: Vec::new(),
                 parameters,
-                support_queries: false,
-                max_parameter_size: usize::from(u16::MAX),
-                limit_logs_and_return_values: false,
+                params: super::ReceiveParams::new_p5(),
             },
             state,
         };

--- a/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/crypto_primitives_tests.rs
@@ -120,6 +120,8 @@ fn test_crypto_prims() -> anyhow::Result<()> {
                 return_value: Vec::new(),
                 parameters,
                 support_queries: false,
+                max_parameter_size: usize::from(u16::MAX),
+                limit_logs_and_return_values: false,
             },
             state,
         };

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -108,6 +108,7 @@ unsafe extern "C" fn call_init_v1(
     init_name_len: size_t,
     param_bytes: *const u8, // parameters to the init method
     param_bytes_len: size_t,
+    limit_logs_and_return_values: u8,
     energy: InterpreterEnergy,
     output_return_value: *mut *mut ReturnValue,
     output_len: *mut size_t,
@@ -124,6 +125,7 @@ unsafe extern "C" fn call_init_v1(
     let res = std::panic::catch_unwind(|| {
         let init_name = slice_from_c_bytes!(init_name, init_name_len as usize);
         let parameter = slice_from_c_bytes!(param_bytes, param_bytes_len as usize);
+        let limit_logs_and_return_values = limit_logs_and_return_values != 0;
         let init_ctx = v0::deserial_init_context(slice_from_c_bytes!(
             init_ctx_bytes,
             init_ctx_bytes_len as usize
@@ -137,6 +139,7 @@ unsafe extern "C" fn call_init_v1(
                     init_ctx,
                     name,
                     parameter,
+                    limit_logs_and_return_values,
                     energy,
                     loader,
                 );
@@ -217,6 +220,8 @@ unsafe extern "C" fn call_receive_v1(
     state_ptr_ptr: *mut *mut MutableState,
     param_bytes: *const u8, // parameters to the entrypoint
     param_bytes_len: size_t,
+    max_parameter_size: size_t,
+    limit_logs_and_return_values: u8,
     energy: InterpreterEnergy,
     output_return_value: *mut *mut ReturnValue,
     output_config: *mut *mut ReceiveInterruptedStateV1,
@@ -238,6 +243,7 @@ unsafe extern "C" fn call_receive_v1(
         .expect("Precondition violation: Should be given a valid receive context.");
         let receive_name = slice_from_c_bytes!(receive_name, receive_name_len as usize);
         let parameter = slice_from_c_bytes!(param_bytes, param_bytes_len as usize);
+        let limit_logs_and_return_values = limit_logs_and_return_values != 0;
         let state_ptr = std::mem::replace(&mut *state_ptr_ptr, std::ptr::null_mut());
         let mut loader = loader;
         let mut state = (&mut *state_ptr).make_fresh_generation(&mut loader);
@@ -269,6 +275,8 @@ unsafe extern "C" fn call_receive_v1(
                     receive_ctx,
                     actual_name.as_receive_name(),
                     parameter,
+                    max_parameter_size,
+                    limit_logs_and_return_values,
                     energy,
                     instance_state,
                 );

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -274,6 +274,12 @@ unsafe extern "C" fn call_receive_v1(
 
                 let support_queries = support_queries_tag != 0;
 
+                let params = ReceiveParams {
+                    max_parameter_size,
+                    limit_logs_and_return_values,
+                    support_queries,
+                };
+
                 let res = invoke_receive(
                     artifact,
                     receive_ctx,
@@ -284,9 +290,7 @@ unsafe extern "C" fn call_receive_v1(
                         parameter,
                     },
                     instance_state,
-                    support_queries,
-                    max_parameter_size,
-                    limit_logs_and_return_values,
+                    params,
                 );
                 match res {
                     Ok(result) => {

--- a/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/ffi.rs
@@ -135,12 +135,14 @@ unsafe extern "C" fn call_init_v1(
             Ok(name) => {
                 let res = invoke_init(
                     &artifact,
-                    Amount::from_micro_ccd(amount),
                     init_ctx,
-                    name,
-                    parameter,
+                    InitInvocation {
+                        amount: Amount::from_micro_ccd(amount),
+                        init_name: name,
+                        parameter,
+                        energy,
+                    },
                     limit_logs_and_return_values,
-                    energy,
                     loader,
                 );
                 match res {


### PR DESCRIPTION
## Purpose

Relax restrictions for parameter and return value size and number of logs. See https://github.com/Concordium/concordium-node/pull/573 for more details.

Solves part of https://github.com/Concordium/concordium-node/issues/563.

## Changes

- Add functions for getting the limits, which depend on the PV.
- Remove `Serialize` instance for `Parameter` as we now need the PV for determining the max size.
   - Added put/get functions for it instead.
- Pass in the limits from the scheduler and save it in the init/receive host, to be used when relevant.
- Change the cost function for parameters larger than 1kb.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.