### PR TITLE
Simplify range proof verifier

### DIFF
--- a/rust-src/bulletproofs/benches/benches.rs
+++ b/rust-src/bulletproofs/benches/benches.rs
@@ -97,33 +97,12 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     );
     let proof = proof.unwrap();
 
-    let commitments_p = commitments.clone();
-    let proof_p = proof.clone();
-    let gens_p = gens.clone();
     group.bench_function("Verify Efficient", move |b| {
         b.iter(|| {
             let mut transcript = RandomOracle::empty();
             assert!(
-                verify_efficient(&mut transcript, n, &commitments_p, &proof_p, &gens_p, &keys)
-                    .is_ok()
+                verify_efficient(&mut transcript, n, &commitments, &proof, &gens, &keys).is_ok()
             );
-        })
-    });
-
-    let commitments_p = commitments.clone();
-    let proof_p = proof.clone();
-    let gens_p = gens.clone();
-    group.bench_function("Verify More Efficient", move |b| {
-        b.iter(|| {
-            let mut transcript = RandomOracle::empty();
-            assert!(verify_more_efficient(
-                &mut transcript,
-                n,
-                &commitments_p,
-                &proof_p,
-                &gens_p,
-                &keys
-            ));
         })
     });
 }

--- a/rust-src/bulletproofs/src/inner_product_proof.rs
+++ b/rust-src/bulletproofs/src/inner_product_proof.rs
@@ -1,6 +1,5 @@
 //! Logarithmic sized inner product proof used as base for the other proofs in
 //! this crate
-use crate::utils::*;
 use crypto_common::*;
 use crypto_common_derive::*;
 use curve_arithmetic::{multiexp, Curve};
@@ -29,7 +28,7 @@ pub struct InnerProductProof<C: Curve> {
 /// - Q - the elliptic curve point Q
 /// - a_slice - a slice to the vector a of scalars
 /// - b_slice - a slice to the vector b of scalars
-/// Precondictions:
+/// Preconditions:
 /// G_slice, H_slice, a_slice and b_slice should all be of the same length, and
 /// this length must be a power of 2.
 #[allow(non_snake_case)]
@@ -276,15 +275,18 @@ pub fn verify_scalars<C: Curve>(
 }
 
 /// This function verifies an inner product proof,
-/// i.e. a proof of knowledge of vectors a and b such that
-/// P'=<a,G>+<b,H>+<a,b>Q. The arguments are
-/// - G_vec - the vector G of elliptic curve points
-/// - H_vec - the vector H of elliptic curve points
-/// - P_prime - the elliptic curve point P'
-/// - Q - the elliptic curve point Q
-/// - proof - the inner product proof
-/// Precondictions:
-/// G_vec, H_vec should all be of the same length, and this length must a power
+/// i.e., a proof of knowledge of vectors `a` and `b` such that
+/// `P'=<a,G>+<b,H>+<a,b>Q`.
+///
+/// Arguments:
+/// - `G_vec` - slice `G` of elliptic curve points
+/// - `H_vec` - slice `H` of elliptic curve points
+/// - `P_prime` - the elliptic curve point `P'`
+/// - `Q` - the elliptic curve point `Q`
+/// - `proof` - the inner product proof
+///
+/// Preconditions:
+/// `G_vec` and `H_vec` must be of the same length, and this length must a power
 /// of 2.
 #[allow(non_snake_case)]
 pub fn verify_inner_product<C: Curve>(
@@ -295,44 +297,29 @@ pub fn verify_inner_product<C: Curve>(
     Q: &C,
     proof: &InnerProductProof<C>,
 ) -> bool {
+    // call verify_inner_product_with_scalars
+    // Since H is directly given, set all exponents for H to 1
     let n = G_vec.len();
-    let L_R = &proof.lr_vec;
-    let a = proof.a;
-    let b = proof.b;
-    let mut ab = a;
-    ab.mul_assign(&b);
+    let H_exponents = vec![C::Scalar::one(); n];
+    // P_prime is also given directly, so set P_prime_bases to P_prime with exponent
+    // 1. Since it is assumed that P_prime_bases starts with contains G, H and Q,
+    // set the first 2n+1 exponents to 0.
+    let mut P_prime_bases = Vec::with_capacity(2 * n + 2);
+    P_prime_bases.extend(G_vec);
+    P_prime_bases.extend(H_vec);
+    P_prime_bases.push(*Q);
+    P_prime_bases.push(*P_prime);
+    let mut P_prime_exponents = Vec::with_capacity(2 * n + 2);
+    P_prime_exponents.extend(vec![C::Scalar::zero(); 2 * n + 1]);
+    P_prime_exponents.push(C::Scalar::one());
 
-    let verification_scalars = match verify_scalars(transcript, n, proof) {
-        None => return false,
-        Some(scalars) => scalars,
-    };
-    let (u_sq, u_inv_sq, s) = (
-        verification_scalars.u_sq,
-        verification_scalars.u_inv_sq,
-        verification_scalars.s,
-    );
-
-    let G = multiexp(G_vec, &s);
-    let mut s_inv = s;
-    s_inv.reverse();
-    let H = multiexp(H_vec, &s_inv);
-
-    let mut sum = C::zero_point();
-    for j in 0..L_R.len() {
-        sum = sum.plus_point(
-            &(L_R[j]
-                .0
-                .mul_by_scalar(&u_sq[j])
-                .plus_point(&(L_R[j].1.mul_by_scalar(&u_inv_sq[j])))),
-        );
-    }
-
-    let RHS = G
-        .mul_by_scalar(&a)
-        .plus_point(&H.mul_by_scalar(&b))
-        .plus_point(&Q.mul_by_scalar(&ab))
-        .minus_point(&sum);
-    P_prime.minus_point(&RHS).is_zero_point()
+    verify_inner_product_with_scalars(
+        transcript,
+        &H_exponents,
+        &P_prime_bases,
+        &P_prime_exponents,
+        proof,
+    )
 }
 
 /// This function is an optimized variant of the above.
@@ -342,34 +329,35 @@ pub fn verify_inner_product<C: Curve>(
 ///
 /// Arguments:
 /// - `transcript` - the proof transcript
-/// - `gens` - generators containing vectors `G` and `H` both of length at least
-///   `n`
+/// - `G_slice` - slice `G` of `n` elliptic curve points
+/// - `H_slice` - slice `H` of `n` elliptic curve points
 /// - `H_exponents` - slice of scalars to whose powers the `H_i` are raised
 /// - `P_prime_bases` - slice of points for computing curve point `P'`. It is
-///   assumed that the first base points are `G | H, Q`, which are implicit and
-///   omitted from `P_prime_bases`
+///   assumed that the first base points are `G | H, Q`
 /// - `P_prime_exponents` - slice of scalars to whose powers the elements
 ///   `P_prime_bases` are raised
-/// - `Q` - the elliptic curve point `Q`
 /// - `proof` - the inner product proof
 ///
 /// Preconditions:
 /// - `H_exponents` must have length `n`, which is a power of 2.
-/// - `gens` contain at least `n` pairs of generators.
+/// - `G_slice` and `H_slice` each contain `n` generators.
+/// - `P_prime_bases` contains `G` and `H`, each consisting of `n` curve points,
+///   followed by a curve point `Q` and may contain additional curve points.
 /// - The length of `P_prime_exponents` is equal to the length of
-///   `P_prime_bases` plus of `2n + 1` (since `G`, `H`, and `Q` are
-/// omitted from `P_prime_bases`).
+///   `P_prime_bases`
 #[allow(non_snake_case)]
 pub(crate) fn verify_inner_product_with_scalars<C: Curve>(
     transcript: &mut RandomOracle,
-    gens: &Generators<C>,
     H_exponents: &[C::Scalar],
     P_prime_bases: &[C],
     P_prime_exponents: &[C::Scalar],
-    Q: &C,
     proof: &InnerProductProof<C>,
 ) -> bool {
-    let n = gens.G_H.len();
+    let n = H_exponents.len();
+    let G_slice = &P_prime_bases[0..n];
+    let H_slice = &P_prime_bases[n..2 * n];
+    let Q = P_prime_bases[2 * n];
+
     let L_R = &proof.lr_vec;
     let a = proof.a;
     let b = proof.b;
@@ -408,19 +396,15 @@ pub(crate) fn verify_inner_product_with_scalars<C: Curve>(
         ge.mul_assign(&a);
     }
 
-    let mut rhs_bases = Vec::with_capacity(2 * n + 1 + nsum_bases.len() + P_prime_bases.len());
-    // Add G and H from gens to rhs_bases
-    for i in 0..n {
-        rhs_bases.push(gens.G_H[i].0);
-    }
-    for i in 0..n {
-        rhs_bases.push(gens.G_H[i].1);
-    }
+    let mut rhs_bases = Vec::with_capacity(nsum_bases.len() + P_prime_bases.len());
+    // Add G and H to rhs_bases
+    rhs_bases.extend(G_slice);
+    rhs_bases.extend(H_slice);
 
     // add further elements to rhs_bases
-    rhs_bases.push(*Q);
+    rhs_bases.push(Q);
     rhs_bases.append(&mut nsum_bases);
-    rhs_bases.extend(P_prime_bases);
+    rhs_bases.extend(&P_prime_bases[2 * n + 1..]);
 
     let mut rhs_exps = Vec::with_capacity(rhs_bases.len());
     rhs_exps.append(&mut G_exps);

--- a/rust-src/bulletproofs/src/inner_product_proof.rs
+++ b/rust-src/bulletproofs/src/inner_product_proof.rs
@@ -305,8 +305,8 @@ pub fn verify_inner_product<C: Curve>(
     // 1. Since it is assumed that P_prime_bases starts with G, H and Q, add those
     // first and set the first 2n+1 exponents to 0.
     let mut P_prime_bases = Vec::with_capacity(2 * n + 2);
-    P_prime_bases.extend(G_vec);
-    P_prime_bases.extend(H_vec);
+    P_prime_bases.extend_from_slice(G_vec);
+    P_prime_bases.extend_from_slice(H_vec);
     P_prime_bases.push(*Q);
     P_prime_bases.push(*P_prime);
     let mut P_prime_exponents = Vec::with_capacity(2 * n + 2);

--- a/rust-src/bulletproofs/src/inner_product_proof.rs
+++ b/rust-src/bulletproofs/src/inner_product_proof.rs
@@ -322,10 +322,10 @@ pub fn verify_inner_product<C: Curve>(
     )
 }
 
-/// This function is an optimized variant of the above.
-/// It is verified whether `P'=<a,G>+<b,H'>+<a,b>Q` for `P' =
-/// multiexp(P_prime_bases, P_prime_exponents)` and `H'_i =
-/// H_i^H_exponents_i`.
+/// This function is the actual verification function used at the core of the
+/// function `verify_inner_product`. It is verified whether
+/// `P'=<a,G>+<b,H'>+<a,b>Q` for `P' = multiexp(P_prime_bases,
+/// P_prime_exponents)` and `H'_i = H_i^H_exponents_i`.
 ///
 /// Arguments:
 /// - `transcript` - the proof transcript
@@ -338,7 +338,6 @@ pub fn verify_inner_product<C: Curve>(
 ///
 /// Preconditions:
 /// - `H_exponents` must have length `n`, which is a power of 2.
-/// - `G_slice` and `H_slice` each contain `n` generators.
 /// - `P_prime_bases` contains `G` and `H`, each consisting of `n` curve points,
 ///   followed by a curve point `Q`, and may contain additional curve points.
 /// - The length of `P_prime_exponents` is equal to the length of

--- a/rust-src/bulletproofs/src/range_proof.rs
+++ b/rust-src/bulletproofs/src/range_proof.rs
@@ -598,8 +598,8 @@ pub fn verify_efficient<C: Curve>(
     };
     let y_inv_nm = z_vec(y_inv, 0, H.len());
 
-    // P_prime = g_hat^t_x * h^-e_tilde * A * S^x * multiexp(G, -z1) * multiexp(H,
-    // PH_scalars), where H_scalars[j] = z + y^-j * z^(2+j//n) * 2^(j%n)
+    // P' = multiexp(G, -z1) multiexp(H, PH_scalars) g_hat^t_x * h^-e_tilde * A S^x,
+    // where H_scalars[j] = z + y^-j * z^(2+j//n) * 2^(j%n)
     let mut P_prime_exps = Vec::with_capacity(2 * nm + 4);
     let mut minus_z = z;
     minus_z.negate();
@@ -618,12 +618,12 @@ pub fn verify_efficient<C: Curve>(
     }
 
     // add remaining exponents
-    P_prime_exps.push(tx);
+    P_prime_exps.push(tx); // exponent for g_hat
     let mut minus_e_tilde = e_tilde;
     minus_e_tilde.negate();
-    P_prime_exps.push(minus_e_tilde);
-    P_prime_exps.push(C::Scalar::one());
-    P_prime_exps.push(x);
+    P_prime_exps.push(minus_e_tilde); // exponent for h = B_tilde
+    P_prime_exps.push(C::Scalar::one()); // exponent for A
+    P_prime_exps.push(x); // exponent for S
 
     // P_prime_bases starts with G, H, and Q = g_hat
     let mut P_prime_bases = Vec::with_capacity(2 * nm + 4);

--- a/rust-src/bulletproofs/src/set_membership_proof.rs
+++ b/rust-src/bulletproofs/src/set_membership_proof.rs
@@ -714,4 +714,27 @@ mod tests {
             Err(VerificationError::IPVerificationError)
         ));
     }
+
+    #[test]
+    /// Test honest proof supplying more generators than needed
+    fn test_smp_prove_many_generators() {
+        let rng = &mut thread_rng();
+
+        let the_set = get_set_vector::<SomeCurve>(&[1, 7, 3, 5]);
+        let v = SomeCurve::scalar_from_u64(3);
+        let num_gens = 2112;
+        let (gens, v_keys, v_rand) = generate_helper_values(num_gens);
+
+        // prove
+        let mut transcript = RandomOracle::empty();
+        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        assert!(proof.is_ok());
+        let proof = proof.unwrap();
+
+        // verify
+        let v_com = get_v_com(v, v_keys, v_rand);
+        let mut transcript = RandomOracle::empty();
+        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
+        assert!(result.is_ok());
+    }
 }


### PR DESCRIPTION
## Purpose

There have been three different verification methods for range proofs: A naive one, an efficient one (which is actually used), and a more efficient one. This pull request changes the efficient verification to use the same inner-product verification as the set-membership proofs. This makes that method essentially as simple and modular as the naive one and almost as efficient as the more efficient one (the performance benefits of the more efficient one appear negligible, < 1% on a desktop PC).

## Changes

- Use inner-product verification from set-membership proof for range-proof verification.
- Remove naive verification.
- Remove more efficient verification.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.