### PR TITLE
Bump parameter size limit.

### DIFF
--- a/rust-src/concordium_base/src/constants.rs
+++ b/rust-src/concordium_base/src/constants.rs
@@ -12,8 +12,7 @@ pub const MAX_REGISTERED_DATA_SIZE: usize = 256;
 pub const MAX_MEMO_SIZE: usize = 256;
 
 /// Maximum allowed length of a smart contract parameter.
-/// This must be kept in sync with maxParameterLen.
-pub const MAX_PARAMETER_LEN: usize = 1024;
+pub const MAX_PARAMETER_LEN: usize = 65535;
 
 /// Maximum allowed size of the Wasm module to deploy on the chain.
 pub const MAX_WASM_MODULE_SIZE: u32 = 8 * 65536;


### PR DESCRIPTION
## Purpose

Fix parameter size limit for P5 in concordium-base.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.