### PR TITLE
Add RNG support to TestHost

### DIFF
--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -80,6 +80,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base58"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
+
+[[package]]
+name = "base58check"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee2fe4c9a0c84515f136aaae2466744a721af6d63339c18689d9e995d74d99b"
+dependencies = [
+ "base58",
+ "sha2 0.8.2",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,11 +103,23 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+dependencies = [
+ "block-padding",
+ "byte-tools",
+ "byteorder",
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -100,16 +128,16 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
-name = "bs58"
-version = "0.4.0"
+name = "block-padding"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
+checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
 dependencies = [
- "sha2 0.9.9",
+ "byte-tools",
 ]
 
 [[package]]
@@ -117,6 +145,12 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
+
+[[package]]
+name = "byte-tools"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -209,12 +243,11 @@ dependencies = [
 name = "concordium-contracts-common"
 version = "4.1.0"
 dependencies = [
- "bs58",
+ "base58check",
  "chrono",
  "concordium-contracts-common-derive",
  "fnv",
  "hashbrown 0.11.2",
- "hex",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.15",
@@ -357,7 +390,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
  "typenum",
 ]
 
@@ -400,11 +433,20 @@ dependencies = [
 
 [[package]]
 name = "digest"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+dependencies = [
+ "generic-array 0.12.4",
+]
+
+[[package]]
+name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array",
+ "generic-array 0.14.6",
 ]
 
 [[package]]
@@ -467,6 +509,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "fake-simd"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "ffi_helpers"
@@ -574,6 +622,15 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
+dependencies = [
+ "typenum",
 ]
 
 [[package]]
@@ -856,6 +913,12 @@ checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
 
 [[package]]
 name = "opaque-debug"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+
+[[package]]
+name = "opaque-debug"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
@@ -975,7 +1038,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -989,35 +1052,23 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha",
- "rand_core 0.5.1",
- "rand_hc",
- "rand_pcg",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
+ "rand_chacha",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.2.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1036,24 +1087,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1249,6 +1282,18 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
+dependencies = [
+ "block-buffer 0.7.3",
+ "digest 0.8.1",
+ "fake-simd",
+ "opaque-debug 0.2.3",
+]
+
+[[package]]
+name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
@@ -1257,7 +1302,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug",
+ "opaque-debug 0.3.0",
 ]
 
 [[package]]
@@ -1511,7 +1556,7 @@ dependencies = [
  "num_enum",
  "ptree",
  "quickcheck",
- "rand 0.7.3",
+ "rand",
  "secp256k1",
  "serde 1.0.145",
  "sha2 0.10.6",

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -242,7 +242,6 @@ dependencies = [
 [[package]]
 name = "concordium-contracts-common"
 version = "4.1.0"
-
 dependencies = [
  "base58check",
  "chrono",

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -242,6 +242,7 @@ dependencies = [
 [[package]]
 name = "concordium-contracts-common"
 version = "4.1.0"
+
 dependencies = [
  "base58check",
  "chrono",
@@ -989,6 +990,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,7 +1039,7 @@ checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
  "env_logger",
  "log",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -1046,11 +1053,35 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom 0.1.16",
+ "libc",
+ "rand_chacha",
+ "rand_core 0.5.1",
+ "rand_hc",
+ "rand_pcg",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1069,6 +1100,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.7",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
+dependencies = [
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -1538,6 +1587,7 @@ dependencies = [
  "num_enum",
  "ptree",
  "quickcheck",
+ "rand 0.7.3",
  "secp256k1",
  "serde 1.0.145",
  "sha2 0.10.6",

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -80,22 +80,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "base58"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5024ee8015f02155eee35c711107ddd9a9bf3cb689cf2a9089c97e79b6e1ae83"
-
-[[package]]
-name = "base58check"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee2fe4c9a0c84515f136aaae2466744a721af6d63339c18689d9e995d74d99b"
-dependencies = [
- "base58",
- "sha2 0.8.2",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,23 +87,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
-dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array",
 ]
 
 [[package]]
@@ -128,16 +100,16 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cce20737498f97b993470a6e536b8523f0af7892a4f928cceb1ac5e52ebe7e"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array",
 ]
 
 [[package]]
-name = "block-padding"
-version = "0.1.5"
+name = "bs58"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
+checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 dependencies = [
- "byte-tools",
+ "sha2 0.9.9",
 ]
 
 [[package]]
@@ -145,12 +117,6 @@ name = "bumpalo"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1ad822118d20d2c234f427000d5acc36eabe1e29a348c89b63dd60b13f28e5d"
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -243,11 +209,12 @@ dependencies = [
 name = "concordium-contracts-common"
 version = "4.1.0"
 dependencies = [
- "base58check",
+ "bs58",
  "chrono",
  "concordium-contracts-common-derive",
  "fnv",
  "hashbrown 0.11.2",
+ "hex",
  "num-bigint",
  "num-integer",
  "num-traits 0.2.15",
@@ -390,7 +357,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array",
  "typenum",
 ]
 
@@ -433,20 +400,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.6",
+ "generic-array",
 ]
 
 [[package]]
@@ -509,12 +467,6 @@ dependencies = [
  "log",
  "regex",
 ]
-
-[[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 
 [[package]]
 name = "ffi_helpers"
@@ -622,15 +574,6 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -910,12 +853,6 @@ name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
-
-[[package]]
-name = "opaque-debug"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
 
 [[package]]
 name = "opaque-debug"
@@ -1312,18 +1249,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a256f46ea78a0c0d9ff00077504903ac881a1dafdc20da66545699e7776b3e69"
-dependencies = [
- "block-buffer 0.7.3",
- "digest 0.8.1",
- "fake-simd",
- "opaque-debug 0.2.3",
-]
-
-[[package]]
-name = "sha2"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
@@ -1332,7 +1257,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest 0.9.0",
- "opaque-debug 0.3.0",
+ "opaque-debug",
 ]
 
 [[package]]

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -37,6 +37,7 @@ futures = {version = "0.3", optional = true }
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 wasm-smith = { git = "https://github.com/Concordium/wasm-tools.git", branch = "mra/fuzzing", optional = true }
 wasmprinter = { git = "https://github.com/Concordium/wasm-tools.git", branch = "main", optional = true }
+rand = { version = "=0.7", features = ["small_rng"] }
 
 [dependencies.wasm-transform]
 path = "../wasm-transform"

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -37,7 +37,7 @@ futures = {version = "0.3", optional = true }
 arbitrary = { version = "0.4.6", features = ["derive"], optional = true }
 wasm-smith = { git = "https://github.com/Concordium/wasm-tools.git", branch = "mra/fuzzing", optional = true }
 wasmprinter = { git = "https://github.com/Concordium/wasm-tools.git", branch = "main", optional = true }
-rand = { version = "=0.7", features = ["small_rng"] }
+rand = { version = "=0.8", features = ["small_rng"] }
 
 [dependencies.wasm-transform]
 path = "../wasm-transform"

--- a/smart-contracts/wasm-chain-integration/benches/wasm.rs
+++ b/smart-contracts/wasm-chain-integration/benches/wasm.rs
@@ -266,13 +266,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         group.measurement_time(Duration::from_secs(10));
 
         let skeleton = parse::parse_skeleton(black_box(CONTRACT_BYTES_INSTRUCTIONS)).unwrap();
-        let module = validate::validate_module(&TestHost, &skeleton).unwrap();
+        let module = validate::validate_module(&TestHost::uninitialized(), &skeleton).unwrap();
         let artifact = module.compile::<ArtifactNamedImport>().unwrap();
         for n in [0, 1, 10000, 100000, 200000].iter() {
             group.bench_with_input(format!("execute n = {}", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "foo_extern", &[Value::I64(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "foo_extern", &[Value::I64(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -281,13 +283,15 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let skeleton =
             parse::parse_skeleton(black_box(CONTRACT_BYTES_MEMORY_INSTRUCTIONS)).unwrap();
-        let module = validate::validate_module(&TestHost, &skeleton).unwrap();
+        let module = validate::validate_module(&TestHost::uninitialized(), &skeleton).unwrap();
         let artifact = module.compile::<ArtifactNamedImport>().unwrap();
         for n in [1, 10, 50, 100, 250, 500, 1000, 1024].iter() {
             group.bench_with_input(format!("allocate n = {} pages", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "foo_extern", &[Value::I32(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "foo_extern", &[Value::I32(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -300,7 +304,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u32 n = {} times", n / 4), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "write_u32", &[Value::I32(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "write_u32", &[Value::I32(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -313,7 +319,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u64 n = {} times", n / 8), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "write_u64", &[Value::I32(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "write_u64", &[Value::I32(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -326,7 +334,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u8 n  = {} times as u32", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "write_u32_u8", &[Value::I32(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "write_u32_u8", &[Value::I32(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -339,7 +349,9 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u8 n  = {} times as u64", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact.run(&mut TestHost, "write_u64_u8", &[Value::I32(*m)]).is_ok(),
+                        artifact
+                            .run(&mut TestHost::uninitialized(), "write_u64_u8", &[Value::I32(*m)])
+                            .is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -362,7 +374,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             .throughput(criterion::Throughput::Elements(nrg));
 
         let skeleton = parse::parse_skeleton(black_box(CONTRACT_BYTES_LOOP)).unwrap();
-        let mut module = validate::validate_module(&TestHost, &skeleton).unwrap();
+        let mut module = validate::validate_module(&TestHost::uninitialized(), &skeleton).unwrap();
         module.inject_metering().unwrap();
         let artifact = module.compile::<MeteringImport>().unwrap();
 

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -69,7 +69,7 @@ impl<I> machine::Host<I> for TrapHost {
 /// generator.
 pub struct TestHost<R> {
     /// A RNG for randomised testing.
-    rng: Option<R>,
+    rng:      Option<R>,
     /// A flag set to `true` if the RNG was used.
     rng_used: bool,
 }
@@ -202,7 +202,7 @@ pub fn run_module_tests(
     seed: u64,
 ) -> ExecResult<Vec<(String, Option<ReportError>)>> {
     let host = TestHost {
-        rng: Some(SmallRng::seed_from_u64(seed)),
+        rng:      Some(SmallRng::seed_from_u64(seed)),
         rng_used: false,
     };
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
@@ -211,7 +211,7 @@ pub fn run_module_tests(
         if let Some(test_name) = name.as_ref().strip_prefix("concordium_test ") {
             // create a `TestHost` instance for each test
             let mut test_host = TestHost {
-                rng: Some(SmallRng::seed_from_u64(seed)),
+                rng:      Some(SmallRng::seed_from_u64(seed)),
                 // initially, set the flag to `false`, so it can be flipped later, once it was used
                 rng_used: false,
             };
@@ -242,7 +242,7 @@ pub fn generate_contract_schema_v0(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
     let host: TestHost<SmallRng> = TestHost {
-        rng: None,
+        rng:      None,
         rng_used: false,
     }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
@@ -299,7 +299,7 @@ pub fn generate_contract_schema_v1(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
     let host: TestHost<SmallRng> = TestHost {
-        rng: None,
+        rng:      None,
         rng_used: false,
     }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
@@ -346,7 +346,7 @@ pub fn generate_contract_schema_v2(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
     let host: TestHost<SmallRng> = TestHost {
-        rng: None,
+        rng:      None,
         rng_used: false,
     }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
@@ -393,7 +393,7 @@ pub fn generate_contract_schema_v3(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
     let host: TestHost<SmallRng> = TestHost {
-        rng: None,
+        rng:      None,
         rng_used: false,
     }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -125,10 +125,10 @@ impl<R: RngCore> validate::ValidateImportExport for TestHost<R> {
 pub enum ReportError {
     /// An error reported by `report_error`
     Reported {
-        filename:   String,
-        line:       u32,
-        column:     u32,
-        msg:        String,
+        filename: String,
+        line:     u32,
+        column:   u32,
+        msg:      String,
     },
     /// Some other source of error. We only have the description, and no
     /// location.
@@ -212,9 +212,10 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
 /// the wasm-test feature.
 ///
 /// The return value is a list of pairs (test_name, result)
-/// The result is None if the test passed, or an error message
-/// if it failed. The error message is the one reported to by report_error, or
-/// some internal invariant violation.
+/// The result is None if the test passed, or an error message and a boolean
+/// flag if it failed. The error message is the one reported to by report_error,
+/// or some internal invariant violation. The flag shows whether randomness was
+/// used.
 pub fn run_module_tests(
     module_bytes: &[u8],
     seed: u64,
@@ -235,9 +236,12 @@ pub fn run_module_tests(
                     } else {
                         out.push((
                             test_name.to_owned(),
-                            Some((ReportError::Other {
-                                msg: msg.to_string(),
-                            }, test_host.rng_used)),
+                            Some((
+                                ReportError::Other {
+                                    msg: msg.to_string(),
+                                },
+                                test_host.rng_used,
+                            )),
                         ))
                     }
                 }

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -74,6 +74,27 @@ pub struct TestHost<R> {
     rng_used: bool,
 }
 
+impl TestHost<SmallRng> {
+    /// Create a new `TestHost` instance without a RNG instance
+    pub fn uninitialized() -> Self {
+        TestHost {
+            rng:      None,
+            rng_used: false,
+        }
+    }
+}
+
+impl<R: RngCore> TestHost<R> {
+    /// Create a new `TestHost` instance with the given RNG and set the flag to
+    /// unused.
+    pub fn new(rng: R) -> Self {
+        TestHost {
+            rng:      Some(rng),
+            rng_used: false,
+        }
+    }
+}
+
 impl<R: RngCore> validate::ValidateImportExport for TestHost<R> {
     /// Simply ensure that there are no duplicates.
     #[cfg_attr(not(feature = "fuzz-coverage"), inline(always))]
@@ -201,20 +222,13 @@ pub fn run_module_tests(
     module_bytes: &[u8],
     seed: u64,
 ) -> ExecResult<Vec<(String, Option<ReportError>)>> {
-    let host = TestHost {
-        rng:      Some(SmallRng::seed_from_u64(seed)),
-        rng_used: false,
-    };
+    let host = TestHost::new(SmallRng::seed_from_u64(seed));
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
     let mut out = Vec::with_capacity(artifact.export.len());
     for name in artifact.export.keys() {
         if let Some(test_name) = name.as_ref().strip_prefix("concordium_test ") {
-            // create a `TestHost` instance for each test
-            let mut test_host = TestHost {
-                rng:      Some(SmallRng::seed_from_u64(seed)),
-                // initially, set the flag to `false`, so it can be flipped later, once it was used
-                rng_used: false,
-            };
+            // create a `TestHost` instance for each test with the usage flag set to `false`
+            let mut test_host = TestHost::new(SmallRng::seed_from_u64(seed));
             let res = artifact.run(&mut test_host, name, &[]);
             match res {
                 Ok(_) => out.push((test_name.to_owned(), None)),
@@ -241,10 +255,7 @@ pub fn run_module_tests(
 pub fn generate_contract_schema_v0(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost {
-        rng:      None,
-        rng_used: false,
-    }; // The RNG is not relevant for schema generation
+    let host = TestHost::uninitialized(); // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -298,10 +309,7 @@ pub fn generate_contract_schema_v0(
 pub fn generate_contract_schema_v1(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost {
-        rng:      None,
-        rng_used: false,
-    }; // The RNG is not relevant for schema generation
+    let host = TestHost::uninitialized(); // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -345,10 +353,7 @@ pub fn generate_contract_schema_v1(
 pub fn generate_contract_schema_v2(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost {
-        rng:      None,
-        rng_used: false,
-    }; // The RNG is not relevant for schema generation
+    let host = TestHost::uninitialized(); // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -392,10 +397,7 @@ pub fn generate_contract_schema_v2(
 pub fn generate_contract_schema_v3(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost {
-        rng:      None,
-        rng_used: false,
-    }; // The RNG is not relevant for schema generation
+    let host = TestHost::uninitialized(); // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -194,7 +194,7 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
 
 /// Instantiates the module with an external function to report back errors and
 /// a seed that is used to instantiate a RNG for randomized testing. Then tries
-/// to run exported test-functions, which are present if compile with
+/// to run exported test-functions, which are present if compiled with
 /// the wasm-test feature.
 ///
 /// The return value is a list of pairs (test_name, result)

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -206,20 +206,20 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
     }
 }
 
+/// The type of results returned after running a test.
+/// The value is a pair (test_name, result). The result is None if the test
+/// passed, or an error message and a boolean flag if it failed. The error
+/// message is the one reported to by report_error, or some internal invariant
+/// violation. The flag shows whether randomness was used.
+type TestResult = (String, Option<(ReportError, bool)>);
+
 /// Instantiates the module with an external function to report back errors and
 /// a seed that is used to instantiate a RNG for randomized testing. Then tries
 /// to run exported test-functions, which are present if compiled with
 /// the wasm-test feature.
 ///
-/// The return value is a list of pairs (test_name, result)
-/// The result is None if the test passed, or an error message and a boolean
-/// flag if it failed. The error message is the one reported to by report_error,
-/// or some internal invariant violation. The flag shows whether randomness was
-/// used.
-pub fn run_module_tests(
-    module_bytes: &[u8],
-    seed: u64,
-) -> ExecResult<Vec<(String, Option<(ReportError, bool)>)>> {
+/// The return value is a list of test results.
+pub fn run_module_tests(module_bytes: &[u8], seed: u64) -> ExecResult<Vec<TestResult>> {
     let host = TestHost::new(SmallRng::seed_from_u64(seed));
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
     let mut out = Vec::with_capacity(artifact.export.len());

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -75,7 +75,7 @@ pub struct TestHost<R> {
 }
 
 impl TestHost<SmallRng> {
-    /// Create a new `TestHost` instance without a RNG instance
+    /// Create a new `TestHost` instance without a RNG instance.
     pub const fn uninitialized() -> Self {
         TestHost {
             rng:      None,

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -102,10 +102,10 @@ pub enum ReportError {
     /// An error reported by `report_error`
     Reported {
         quickcheck: bool,
-        filename: String,
-        line:     u32,
-        column:   u32,
-        msg:      String,
+        filename:   String,
+        line:       u32,
+        column:     u32,
+        msg:        String,
     },
     /// Some other source of error. We only have the description, and no
     /// location.
@@ -159,7 +159,11 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
                 std::str::from_utf8(&memory[filename_start..filename_start + filename_length])?
                     .to_owned();
             let quickcheck_u32 = unsafe { stack.pop_u32() };
-            ensure!(quickcheck_u32 == 0 || quickcheck_u32 == 1, "Cannot convert {} to a boolean, must be 0 or 1", quickcheck_u32);
+            ensure!(
+                quickcheck_u32 == 0 || quickcheck_u32 == 1,
+                "Cannot convert {} to a boolean, must be 0 or 1",
+                quickcheck_u32
+            );
             let quickcheck = quickcheck_u32 != 0;
             bail!(ReportError::Reported {
                 quickcheck,
@@ -172,12 +176,13 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
             let size = unsafe { stack.pop_u32() } as usize;
             let dest = unsafe { stack.pop_u32() } as usize;
             ensure!(dest + size <= memory.len(), "Illegal memory access.");
-            // if the `rng` field of `TestHost` contains some value, use it, otherwise instantiate a new RNG
+            // if the `rng` field of `TestHost` contains some value, use it, otherwise
+            // instantiate a new RNG
             match self.rng.as_mut() {
                 Some(r) => {
                     r.try_fill_bytes(&mut memory[dest..dest + size])?;
                     Ok(None)
-                },
+                }
                 None => {
                     bail!("Expected initialised RNG.");
                 }
@@ -199,9 +204,14 @@ impl<R: RngCore> machine::Host<ArtifactNamedImport> for TestHost<R> {
 /// The result is None if the test passed, or an error message
 /// if it failed. The error message is the one reported to by report_error, or
 /// some internal invariant violation.
-pub fn run_module_tests(module_bytes: &[u8], seed: u64) -> ExecResult<Vec<(String, Option<ReportError>)>> {
+pub fn run_module_tests(
+    module_bytes: &[u8],
+    seed: u64,
+) -> ExecResult<Vec<(String, Option<ReportError>)>> {
     let rng = SmallRng::seed_from_u64(seed);
-    let mut host = TestHost { rng: Some(rng) };
+    let mut host = TestHost {
+        rng: Some(rng),
+    };
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
     let mut out = Vec::with_capacity(artifact.export.len());
     for name in artifact.export.keys() {
@@ -232,7 +242,9 @@ pub fn run_module_tests(module_bytes: &[u8], seed: u64) -> ExecResult<Vec<(Strin
 pub fn generate_contract_schema_v0(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost { rng: None}; // The RNG is not relevant for schema generation
+    let host: TestHost<SmallRng> = TestHost {
+        rng: None,
+    }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -286,7 +298,9 @@ pub fn generate_contract_schema_v0(
 pub fn generate_contract_schema_v1(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost { rng: None}; // The RNG is not relevant for schema generation
+    let host: TestHost<SmallRng> = TestHost {
+        rng: None,
+    }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -330,7 +344,9 @@ pub fn generate_contract_schema_v1(
 pub fn generate_contract_schema_v2(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost { rng: None}; // The RNG is not relevant for schema generation
+    let host: TestHost<SmallRng> = TestHost {
+        rng: None,
+    }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();
@@ -374,7 +390,9 @@ pub fn generate_contract_schema_v2(
 pub fn generate_contract_schema_v3(
     module_bytes: &[u8],
 ) -> ExecResult<schema::VersionedModuleSchema> {
-    let host: TestHost<SmallRng> = TestHost { rng: None}; // The RNG is not relevant for schema generation
+    let host: TestHost<SmallRng> = TestHost {
+        rng: None,
+    }; // The RNG is not relevant for schema generation
     let artifact = utils::instantiate::<ArtifactNamedImport, _>(&host, module_bytes)?;
 
     let mut contract_schemas = BTreeMap::new();


### PR DESCRIPTION
## Purpose

Extend `TestHost` with new host function that calls a RNG. The purpose of this is to run QuickCheck test for Wasm code that runs on-chain and doesn't support random number generation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.