### PR TITLE
Use hex encoding to display contract events and parameters.

### DIFF
--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -491,8 +491,8 @@ instance Serialize ReceiveName where
 -- The parameter is limited to 1kB in size. This is ensured
 -- by deserialization methods.
 newtype Parameter = Parameter {parameter :: ShortByteString}
-    deriving (Eq, Show)
-    deriving (AE.ToJSON, AE.FromJSON) via ByteStringHex
+    deriving (Eq)
+    deriving (AE.ToJSON, AE.FromJSON, Show) via ByteStringHex
 
 -- |Parameter of size 0.
 emptyParameter :: Parameter
@@ -757,8 +757,8 @@ getActionsTree' size = go HM.empty 0
 
 -- |Event as reported by contract execution.
 newtype ContractEvent = ContractEvent BSS.ShortByteString
-    deriving (Eq, Show)
-    deriving (AE.ToJSON, AE.FromJSON) via ByteStringHex
+    deriving (Eq)
+    deriving (AE.ToJSON, AE.FromJSON, Show) via ByteStringHex
 
 instance Serialize ContractEvent where
     put (ContractEvent ev) = putShortByteStringWord32 ev


### PR DESCRIPTION
## Purpose

Part of https://github.com/Concordium/concordium-wallet-proxy/issues/73

## Changes

Use hex to display parameters and contract events using the Show instance. There is no advantage in the ugly `Parameter { ... }` display and this fixes a number of places in the client which have an ugly output.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
