### PR TITLE
Add a number of equality instances for types in rust-src.

### DIFF
--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -128,7 +128,7 @@ impl TryFrom<String> for UrlText {
 }
 
 /// The status of whether a baking pool allows delegators to join.
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, Copy)]
+#[derive(SerdeSerialize, SerdeDeserialize, PartialEq, Eq, Debug, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 #[repr(u8)]
 pub enum OpenStatus {
@@ -156,7 +156,7 @@ impl Deserial for OpenStatus {
     }
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
+#[derive(SerdeSerialize, SerdeDeserialize, PartialEq, Eq, Debug, Clone)]
 #[serde(rename_all = "camelCase", tag = "delegateType")]
 /// Target of delegation.
 pub enum DelegationTarget {
@@ -204,7 +204,7 @@ impl Deserial for DelegationTarget {
 /// Additional information about a baking pool.
 /// This information is added with the introduction of delegation in protocol
 /// version 4.
-#[derive(SerdeSerialize, SerdeDeserialize, Serial, Debug, Clone)]
+#[derive(SerdeSerialize, SerdeDeserialize, PartialEq, Eq, Serial, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct BakerPoolInfo {
     /// Whether the pool allows delegators.
@@ -501,7 +501,7 @@ impl BakerAggregationSignKey {
 }
 
 #[repr(transparent)]
-#[derive(SerdeBase16Serialize, Serialize, Clone, Debug)]
+#[derive(SerdeBase16Serialize, Serialize, Clone, Debug, PartialEq)]
 /// Public key corresponding to [`BakerAggregationVerifyKey`].
 pub struct BakerAggregationVerifyKey {
     pub(crate) verify_key: aggregate_sig::PublicKey<AggregateSigPairing>,
@@ -532,7 +532,7 @@ impl BakerSignatureSignKey {
 }
 
 #[repr(transparent)]
-#[derive(SerdeBase16Serialize, Serialize, Clone, Debug)]
+#[derive(SerdeBase16Serialize, Serialize, Clone, Debug, PartialEq, Eq)]
 /// A public key that corresponds to [`BakerSignatureVerifyKey`].
 pub struct BakerSignatureVerifyKey {
     pub(crate) verify_key: ed25519_dalek::PublicKey,
@@ -563,7 +563,7 @@ impl BakerElectionSignKey {
 }
 
 #[repr(transparent)]
-#[derive(SerdeBase16Serialize, Serialize, Clone, Debug)]
+#[derive(SerdeBase16Serialize, Serialize, Clone, Debug, PartialEq, Eq)]
 /// A public key that corresponds to [`BakerElectionSignKey`].
 pub struct BakerElectionVerifyKey {
     pub(crate) verify_key: ecvrf::PublicKey,
@@ -763,7 +763,9 @@ impl std::fmt::Display for UpdateKeysIndex {
 }
 
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, SerdeSerialize, SerdeDeserialize, Serialize, FromStr)]
+#[derive(
+    Debug, Clone, Copy, SerdeSerialize, SerdeDeserialize, Serialize, FromStr, PartialEq, Eq,
+)]
 #[serde(transparent)]
 /// Representation of the election difficulty as parts per `100_000`. The
 /// election difficulty is never more than `1`.
@@ -834,7 +836,7 @@ impl fmt::Display for PartsPerHundredThousands {
     }
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Serialize, Debug, Clone, Copy)]
+#[derive(SerdeSerialize, SerdeDeserialize, PartialEq, Eq, Serialize, Debug, Clone, Copy)]
 pub struct CommissionRates {
     /// Fraction of finalization rewards charged by the pool owner.
     #[serde(rename = "finalizationCommission")]

--- a/rust-src/concordium_base/src/smart_contracts.rs
+++ b/rust-src/concordium_base/src/smart_contracts.rs
@@ -15,7 +15,9 @@ use sha2::Digest;
 use std::convert::{TryFrom, TryInto};
 use thiserror::Error;
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Copy, Clone, Display)]
+#[derive(
+    SerdeSerialize, SerdeDeserialize, Debug, Copy, Clone, Display, PartialEq, Eq, PartialOrd, Ord,
+)]
 #[serde(try_from = "u8", into = "u8")]
 #[repr(u8)]
 /// Version of the module. This determines the chain API that the module can
@@ -75,7 +77,20 @@ pub enum ModuleRefMarker {}
 /// This reference is used when creating new instances.
 pub type ModuleRef = hashes::HashBytes<ModuleRefMarker>;
 
-#[derive(SerdeSerialize, SerdeDeserialize, Serial, Clone, Debug, AsRef, From, Into)]
+#[derive(
+    SerdeSerialize,
+    SerdeDeserialize,
+    Serial,
+    Clone,
+    Debug,
+    AsRef,
+    From,
+    Into,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+)]
 #[serde(transparent)]
 /// Unparsed Wasm module source.
 pub struct ModuleSource {
@@ -101,7 +116,7 @@ impl Deserial for ModuleSource {
     }
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Serialize, Clone, Debug)]
+#[derive(SerdeSerialize, SerdeDeserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 /// Unparsed module with a version indicating what operations are allowed.
 pub struct WasmModule {
     pub version: WasmVersion,

--- a/rust-src/crypto_common/src/version.rs
+++ b/rust-src/crypto_common/src/version.rs
@@ -74,7 +74,7 @@ impl Deserial for Version {
 /// which is serialized using variable integer encoding.
 /// The caller is responsible for ensuring the data structure `T`
 /// is compatible with the version number.
-#[derive(Debug, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Eq, PartialEq, SerdeSerialize, SerdeDeserialize)]
 pub struct Versioned<T> {
     #[serde(rename = "v")]
     pub version: Version,

--- a/rust-src/encrypted_transfers/src/types.rs
+++ b/rust-src/encrypted_transfers/src/types.rs
@@ -33,7 +33,7 @@ impl From<u64> for EncryptedAmountIndex {
     fn from(index: u64) -> Self { EncryptedAmountIndex { index } }
 }
 
-#[derive(Clone, Serialize, SerdeBase16Serialize, Debug)]
+#[derive(PartialEq, Eq, Clone, Serialize, SerdeBase16Serialize, Debug)]
 /// An encrypted amount, in two chunks in "little endian limbs". That is, the
 /// first chunk represents the low 32 bits of an amount, and the second chunk
 /// represents the high 32 bits. The JSON serialization of this is just base16

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -1671,7 +1671,7 @@ pub enum CredentialType {
 /// Account credential with values and commitments, but without proofs.
 /// Serialization must match the serializaiton of `AccountCredential` in
 /// Haskell.
-#[derive(SerdeSerialize, SerdeDeserialize, Debug)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Eq)]
 #[serde(tag = "type", content = "contents")]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",


### PR DESCRIPTION
## Purpose

Add some Eq/PartialEq instances to help with a state comparison tool for testing.

## Changes

Derive PartialEq/Eq instances where necessary.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.