### PR TITLE
Add a few helpers to get the election difficulty in a reasonable format.

### DIFF
--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -792,6 +792,10 @@ impl ElectionDifficulty {
     }
 }
 
+impl From<ElectionDifficulty> for rust_decimal::Decimal {
+    fn from(ed: ElectionDifficulty) -> Self { ed.parts_per_hundred_thousands.into() }
+}
+
 #[repr(transparent)]
 #[derive(Default, Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Into)]
 /// A fraction between 0 and 1 with a precision of 1/100_000.
@@ -814,6 +818,10 @@ impl PartsPerHundredThousands {
     /// Construct a new fraction, but does not check that the resulting fraction
     /// is valid.
     pub fn new_unchecked(parts: u32) -> Self { Self { parts } }
+}
+
+impl From<PartsPerHundredThousands> for rust_decimal::Decimal {
+    fn from(pp: PartsPerHundredThousands) -> Self { rust_decimal::Decimal::new(pp.parts.into(), 5) }
 }
 
 impl Serial for PartsPerHundredThousands {


### PR DESCRIPTION
## Purpose

Helpers to extract pretty-printable election difficulty. This is needed in the new genesis creator tool.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
