### PR TITLE
Mark functions that only apply to sending p1-p3 transactions as deprecated

### DIFF
--- a/rust-src/concordium_base/src/constants.rs
+++ b/rust-src/concordium_base/src/constants.rs
@@ -21,7 +21,7 @@ pub const MAX_WASM_MODULE_SIZE: u32 = 8 * 65536;
 /// revoker curve.
 pub type EncryptedAmountsCurve = id::constants::ArCurve;
 
-/// The maximum allowed length of a [UrlText](crate::basic::UrlText) in bytes.
+/// The maximum allowed length of a [`UrlText`](crate::base::UrlText) in bytes.
 pub const MAX_URL_TEXT_LENGTH: usize = 2048;
 
 /// Size of the sha256 digest in bytes.

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -2100,7 +2100,7 @@ pub mod construct {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2139,7 +2139,7 @@ pub mod construct {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2173,7 +2173,7 @@ pub mod construct {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2204,7 +2204,7 @@ pub mod construct {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2237,7 +2237,7 @@ pub mod construct {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2588,7 +2588,7 @@ pub mod send {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2621,7 +2621,7 @@ pub mod send {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2643,7 +2643,7 @@ pub mod send {
     /// after 4.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2660,7 +2660,7 @@ pub mod send {
     /// Update the amount the account stakes for being a baker.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]
@@ -2680,7 +2680,7 @@ pub mod send {
     /// or not.
     #[deprecated(
         since = "2.0.0",
-        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+        note = "This transaction only applies to protocol versions 1-3. Use configure_baker \
                 instead."
     )]
     #[doc(hidden)]

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -2094,6 +2094,16 @@ pub mod construct {
     }
 
     /// Register the sender account as a baker.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
     pub fn add_baker(
         num_sigs: u32,
         sender: AccountAddress,
@@ -2123,6 +2133,16 @@ pub mod construct {
     }
 
     /// Update keys of the baker associated with the sender account.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
     pub fn update_baker_keys(
         num_sigs: u32,
         sender: AccountAddress,
@@ -2147,6 +2167,16 @@ pub mod construct {
     }
 
     /// Deregister the account as a baker.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
     pub fn remove_baker(
         num_sigs: u32,
         sender: AccountAddress,
@@ -2168,6 +2198,16 @@ pub mod construct {
     }
 
     /// Update the amount the account stakes for being a baker.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
     pub fn update_baker_stake(
         num_sigs: u32,
         sender: AccountAddress,
@@ -2191,6 +2231,16 @@ pub mod construct {
 
     /// Update whether the earnings are automatically added to the baker's stake
     /// or not.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
     pub fn update_baker_restake_earnings(
         num_sigs: u32,
         sender: AccountAddress,
@@ -2532,6 +2582,17 @@ pub mod send {
     }
 
     /// Register the sender account as a baker.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn add_baker(
         signer: &impl ExactSizeTransactionSigner,
         sender: AccountAddress,
@@ -2554,6 +2615,17 @@ pub mod send {
     }
 
     /// Update keys of the baker associated with the sender account.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn update_baker_keys(
         signer: &impl ExactSizeTransactionSigner,
         sender: AccountAddress,
@@ -2565,6 +2637,17 @@ pub mod send {
     }
 
     /// Deregister the account as a baker.
+    ///
+    /// **Note that this transaction only applies to protocol versions 1-3.**
+    /// Use [`configure_baker`](Self::configure_baker) instead for protocols
+    /// after 4.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn remove_baker(
         signer: &impl ExactSizeTransactionSigner,
         sender: AccountAddress,
@@ -2575,6 +2658,13 @@ pub mod send {
     }
 
     /// Update the amount the account stakes for being a baker.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn update_baker_stake(
         signer: &impl ExactSizeTransactionSigner,
         sender: AccountAddress,
@@ -2588,6 +2678,13 @@ pub mod send {
 
     /// Update whether the earnings are automatically added to the baker's stake
     /// or not.
+    #[deprecated(
+        since = "2.0.0",
+        note = "This transaction only applies to protocol version 1-3. Use configure_baker \
+                instead."
+    )]
+    #[doc(hidden)]
+    #[allow(deprecated)]
     pub fn update_baker_restake_earnings(
         signer: &impl ExactSizeTransactionSigner,
         sender: AccountAddress,

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -425,7 +425,7 @@ impl AuthorizationsV1 {
 }
 
 /// Together with [`Authorizations`] this defines a type family allowing us to
-/// map [`ChainParametersVersion0`] and [`ChainParametersVersion1`] to the
+/// map [`ChainParameterVersion0`] and [`ChainParameterVersion1`] to the
 /// corresponding `Authorizations` version.
 pub trait AuthorizationsFamily {
     type Output: std::fmt::Debug;

--- a/rust-src/id/src/id_prover.rs
+++ b/rust-src/id/src/id_prover.rs
@@ -187,7 +187,7 @@ pub fn prove_ownership_of_account(
 /// The function outputs a proof that the attribute is in the given range, i.e.
 /// that lower <= attribute < upper.
 /// This is done by proving that attribute-upper+2^n and attribute-lower lie in
-/// [0, 2^n). For further details about this technique, see page 15 in https://arxiv.org/pdf/1907.06381.pdf.
+/// [0, 2^n). For further details about this technique, see page 15 in <https://arxiv.org/pdf/1907.06381.pdf>.
 pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     gens: &Generators<C>,
     keys: &PedersenKey<C>,

--- a/rust-src/id/src/id_verifier.rs
+++ b/rust-src/id/src/id_verifier.rs
@@ -51,8 +51,8 @@ pub fn verify_attribute<C: Curve, AttributeType: Attribute<C::Scalar>>(
 /// The function outputs a bool, indicating whether the proof is correct or not,
 /// i.e., wether is attribute inside the commitment lies in [lower,upper).
 /// This is done by verifying that the attribute inside the commitment satisfies
-/// that attribute-upper+2^n and attribute-lower lie in [0, 2^n).
-/// For further details about this technique, see page 15 in https://arxiv.org/pdf/1907.06381.pdf.
+/// that `attribute-upper+2^n` and attribute-lower lie in `[0, 2^n)`.
+/// For further details about this technique, see page 15 in <https://arxiv.org/pdf/1907.06381.pdf>.
 pub fn verify_attribute_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     keys: &PedersenKey<C>,
     gens: &Generators<C>,


### PR DESCRIPTION
## Purpose

Make it less confusing to use baker related transactions in the rust SDK.

## Changes

Mark baker related transactions that only apply to P1-P3 as deprecated, and hide them from generated documentation.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
