### PR TITLE
Proof helpers

### DIFF
--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -640,12 +640,16 @@ impl BakerCredentials {
 }
 
 // FIXME: Move to somewhere else in the dependency. This belongs to rust-src.
-#[derive(SerdeBase16Serialize, Serialize, Debug, Clone, Copy)]
+#[derive(SerdeBase16Serialize, Serialize, Debug, Clone, Copy, derive_more::AsRef)]
 /// A registration ID of a credential. This ID is generated from the user's PRF
 /// key and a sequential counter. [`CredentialRegistrationID`]'s generated from
 /// the same PRF key, but different counter values cannot easily be linked
 /// together.
 pub struct CredentialRegistrationID(id::constants::ArCurve);
+
+impl CredentialRegistrationID {
+    pub fn new(g: id::constants::ArCurve) -> Self { Self(g) }
+}
 
 impl fmt::Display for CredentialRegistrationID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -677,7 +677,7 @@ pub struct UpdateKeyPair {
         deserialize_with = "crypto_common::base16_decode"
     )]
     pub secret: ed25519_dalek::SecretKey,
-    #[serde(rename = "verifyKey")]
+    #[serde(flatten)]
     pub public: UpdatePublicKey,
 }
 

--- a/rust-src/crypto_common/src/version.rs
+++ b/rust-src/crypto_common/src/version.rs
@@ -74,7 +74,7 @@ impl Deserial for Version {
 /// which is serialized using variable integer encoding.
 /// The caller is responsible for ensuring the data structure `T`
 /// is compatible with the version number.
-#[derive(Debug, Eq, PartialEq, SerdeSerialize, SerdeDeserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, SerdeSerialize, SerdeDeserialize)]
 pub struct Versioned<T> {
     #[serde(rename = "v")]
     pub version: Version,

--- a/rust-src/id/src/id_proof_types.rs
+++ b/rust-src/id/src/id_proof_types.rs
@@ -265,8 +265,8 @@ impl Statement<G1, AttributeKind> {
         use chrono::Datelike;
         let now = chrono::Utc::now();
         let year = u64::try_from(now.year()).ok()?;
-        let lower_year = year.checked_sub(lower)?;
-        let upper_year = year.checked_sub(upper)?;
+        let lower_year = year.checked_sub(upper)?;
+        let upper_year = year.checked_sub(lower)?;
         let lower_date = format!("{:04}{:02}{:02}", lower_year, now.month(), now.day());
         let upper_date = format!("{:04}{:02}{:02}", upper_year, now.month(), now.day());
         let lower = AttributeKind(lower_date);

--- a/rust-src/id/src/id_proof_types.rs
+++ b/rust-src/id/src/id_proof_types.rs
@@ -427,6 +427,36 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Statement<C, AttributeType> 
             .push(AtomicStatement::AttributeInSet { statement });
         Some(self)
     }
+
+    /// For stating that the user's nationality is in a set.
+    /// The function returns `Some(statement)` where
+    /// `statement` is composed by the statements in `self` and
+    /// the "document issuer in" statement.
+    pub fn nationality_in(mut self, set: BTreeSet<AttributeType>) -> Option<Self> {
+        let statement = AttributeInSetStatement {
+            attribute_tag: AttributeTag::from_str("nationality").ok()?,
+            set,
+            _phantom: PhantomData::default(),
+        };
+        self.statements
+            .push(AtomicStatement::AttributeInSet { statement });
+        Some(self)
+    }
+
+    /// For stating that the user's nationality does not lie in a set.
+    /// The function returns `Some(statement)` where
+    /// `statement` is composed by the statements in `self` and
+    /// the "document issuer not in" statement.
+    pub fn nationality_not_in(mut self, set: BTreeSet<AttributeType>) -> Option<Self> {
+        let statement = AttributeInSetStatement {
+            attribute_tag: AttributeTag::from_str("nationality").ok()?,
+            set,
+            _phantom: PhantomData::default(),
+        };
+        self.statements
+            .push(AtomicStatement::AttributeInSet { statement });
+        Some(self)
+    }
 }
 
 /// A proof of a statement, composed of one or more atomic proofs.

--- a/rust-src/id/src/id_proof_types.rs
+++ b/rust-src/id/src/id_proof_types.rs
@@ -31,7 +31,7 @@ pub struct RevealAttributeStatement {
 /// For the case where the verifier wants the user to prove that an attribute is
 /// in a range. The statement is that the attribute value lies in `[lower,
 /// upper)` in the scalar field.
-#[derive(Debug, Clone, Serialize, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Clone, Serialize, PartialEq, SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",
     deserialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeDeserialize<'de>"
@@ -52,7 +52,7 @@ pub struct AttributeInRangeStatement<C: Curve, AttributeType: Attribute<C::Scala
 
 /// For the case where the verifier wants the user to prove that an attribute is
 /// in a set of attributes.
-#[derive(Debug, Clone, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Clone, PartialEq, SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",
     deserialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeDeserialize<'de>"
@@ -70,7 +70,7 @@ pub struct AttributeInSetStatement<C: Curve, AttributeType: Attribute<C::Scalar>
 
 /// For the case where the verifier wants the user to prove that an attribute is
 /// not in a set of attributes.
-#[derive(Debug, Clone, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Clone, PartialEq, SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",
     deserialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeDeserialize<'de>"
@@ -89,7 +89,7 @@ pub struct AttributeNotInSetStatement<C: Curve, AttributeType: Attribute<C::Scal
 
 /// Statements are composed of one or more atomic statements.
 /// This type defines the different types of atomic statements.
-#[derive(Debug, Clone, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Clone, PartialEq, SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> +
 SerdeSerialize",
@@ -182,7 +182,7 @@ pub struct StatementWithContext<C: Curve, AttributeType: Attribute<C::Scalar>> {
 }
 
 /// A statement is a list of atomic statements.
-#[derive(Debug, Clone, SerdeSerialize, SerdeDeserialize)]
+#[derive(Debug, Clone, PartialEq, SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",
     deserialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeDeserialize<'de>"

--- a/rust-src/id/src/id_proof_types.rs
+++ b/rust-src/id/src/id_proof_types.rs
@@ -448,13 +448,13 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Statement<C, AttributeType> 
     /// `statement` is composed by the statements in `self` and
     /// the "document issuer not in" statement.
     pub fn nationality_not_in(mut self, set: BTreeSet<AttributeType>) -> Option<Self> {
-        let statement = AttributeInSetStatement {
+        let statement = AttributeNotInSetStatement {
             attribute_tag: AttributeTag::from_str("nationality").ok()?,
             set,
             _phantom: PhantomData::default(),
         };
         self.statements
-            .push(AtomicStatement::AttributeInSet { statement });
+            .push(AtomicStatement::AttributeNotInSet { statement });
         Some(self)
     }
 }

--- a/rust-src/id/src/id_proof_types.rs
+++ b/rust-src/id/src/id_proof_types.rs
@@ -418,13 +418,13 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Statement<C, AttributeType> 
     /// `statement` is composed by the statements in `self` and
     /// the "document issuer not in" statement.
     pub fn document_issuer_not_in(mut self, set: BTreeSet<AttributeType>) -> Option<Self> {
-        let statement = AttributeInSetStatement {
+        let statement = AttributeNotInSetStatement {
             attribute_tag: AttributeTag::from_str("idDocIssuer").ok()?,
             set,
             _phantom: PhantomData::default(),
         };
         self.statements
-            .push(AtomicStatement::AttributeInSet { statement });
+            .push(AtomicStatement::AttributeNotInSet { statement });
         Some(self)
     }
 

--- a/rust-src/id/src/types.rs
+++ b/rust-src/id/src/types.rs
@@ -379,9 +379,9 @@ impl fmt::Display for AttributeTag {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let l: usize = (*self).into();
         if l < ATTRIBUTE_NAMES.len() {
-            write!(f, "{}", ATTRIBUTE_NAMES[l])
+            f.write_str(ATTRIBUTE_NAMES[l])
         } else {
-            Err(fmt::Error)
+            write!(f, "UNNAMED#{}", l)
         }
     }
 }
@@ -393,7 +393,11 @@ impl std::str::FromStr for AttributeTag {
         if let Some(idx) = ATTRIBUTE_NAMES.iter().position(|&x| x == s) {
             Ok(AttributeTag(idx as u8))
         } else {
-            Err(anyhow!("{} tag unknown.", s))
+            match s.strip_prefix("UNNAMED#").and_then(|x| x.parse().ok()) {
+                Some(num) if num < 254 => Ok(AttributeTag(num)), // 254 is the capacity of the
+                // BLS curve field
+                _ => Err(anyhow!("Unrecognized attribute tag.")),
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose

Various helpers related to id 2.0 proofs. This came up during development of an example for testing.

## Changes

- Fix some bugs in the high level helpers for constructing statements.
- Expose additional helpers.
- Add construction functions for credential registration IDs.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.