### PR TITLE
Add conversions between ModuleReference and ModuleRef.

### DIFF
--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -18,9 +18,9 @@ use thiserror::Error;
 /// same, but the phantom type variable makes it impossible to mistakenly misuse
 /// the hashes.
 pub struct HashBytes<Purpose> {
-    bytes:    [u8; SHA256 as usize],
+    pub(crate) bytes: [u8; SHA256 as usize],
     #[serde(skip)] // use default when deserializing
-    _phantom: PhantomData<Purpose>,
+    _phantom:         PhantomData<Purpose>,
 }
 
 impl<Purpose> Clone for HashBytes<Purpose> {

--- a/rust-src/concordium_base/src/smart_contracts.rs
+++ b/rust-src/concordium_base/src/smart_contracts.rs
@@ -1,5 +1,6 @@
 use super::hashes;
 use crate::constants::*;
+use concordium_contracts_common::ModuleReference;
 /// Re-export of common helper functionality for smart contract, such as types
 /// and serialization specific for smart contracts.
 pub use concordium_contracts_common::{
@@ -76,6 +77,14 @@ pub enum ModuleRefMarker {}
 /// Reference to a deployed Wasm module on the chain.
 /// This reference is used when creating new instances.
 pub type ModuleRef = hashes::HashBytes<ModuleRefMarker>;
+
+impl From<ModuleReference> for ModuleRef {
+    fn from(mr: ModuleReference) -> Self { Self::new(mr.into()) }
+}
+
+impl From<ModuleRef> for ModuleReference {
+    fn from(mr: ModuleRef) -> Self { ModuleReference::from(mr.bytes) }
+}
 
 #[derive(
     SerdeSerialize,


### PR DESCRIPTION
## Purpose

Since modulereference and moduleref both appear in the API we must sometimes convert between them. This adds helpers to achieve that.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.