### PR TITLE
Add helpers for update_credentials and update_credential_keys.

### DIFF
--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -1758,7 +1758,7 @@ pub mod cost {
     }
 
     /// Helper function. This together with [`UPDATE_CREDENTIALS_BASE`]
-    /// determine the cost of deploying a credential.
+    /// determines the cost of updating credentials on an account.
     fn update_credentials_variable(num_credentials_before: u16, num_keys: &[u16]) -> Energy {
         // the 500 * num_credentials_before is to account for transactions which do
         // nothing, e.g., don't add don't remove, and don't update the


### PR DESCRIPTION
## Purpose

Add helpers for constructing update_credentials and update_credential_keys transactions.

The helpers don't really add very much. The main thing is computing the cost, but it is good to have them for completeness.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.