### PR TITLE
Fix deployment configuration documentation for the identity provider

### DIFF
--- a/identity-provider-service/deployment.md
+++ b/identity-provider-service/deployment.md
@@ -47,20 +47,22 @@ This has the following parameters
 - `--port` (also envar `IDENTITY_PROVIDER_SERVICE_PORT`), the port on which the server will start listening.
 
 - `--retrieve-base` (envar `RETRIEVE_BASE`), the URL where this server can be
-  reached by the wallet. Example https://id-service.eu.staging.concordium.com
+  reached by the wallet. Example https://id-service.testnet.concordium.com
 
 - `--id-verification-url` (envar `ID_VERIFICATION_URL`), the Url where the
   identity verifier can be reached, example `http://localhost:8101/api/verify`.
-  The server will make POST requests to the URL.
+  The server will redirect the user/wallet to a URL derived from this one. As a
+  result this must be **publicly accessible**.
 
 - `--id-verification-query-url` (env var `ID_VERIFICATION_QUERY_URL`), the URL where the
   identity verifier can be reached for GET queries for attributes, example `http://localhost:8101/api/verify`.
-  The server will make GET requests to the URL. This can be private. If not
-  given it defaults to the value of `--id-verification-url`.
+  Only the identity provider server will make GET requests to the URL, so this
+  can be private. If not given it defaults to the value of
+  `--id-verification-url`.
 
 
 - `--wallet-proxy-base` (envar `WALLET_PROXY_BASE`), the base Url of the wallet
-  proxy. Example https://wallet-proxy.eu.staging.concordium.com.
+  proxy. Example https://wallet-proxy.testnet.concordium.com.
   This cannot have a path component, the way it is currently set-up. If that is
   necessary (e.g., if we want to deploy this behind a proxy) we need to change
   the use of this parameter a little bit.

--- a/identity-provider-service/deployment.md
+++ b/identity-provider-service/deployment.md
@@ -42,7 +42,7 @@ This has the following parameters
   This should point to `ip_private_keys/identity_provider-1.json` in genesis-data.
 
 - `--global` points to a file with cryptographic parameters, should point to
-  global.json in genesis_data. Can also be supplied by `GLOBAL` environment variable.
+  global.json in genesis_data. Can also be supplied by `GLOBAL_CONTEXT` environment variable.
 
 - `--port` (also envar `IDENTITY_PROVIDER_SERVICE_PORT`), the port on which the server will start listening.
 

--- a/scripts/docker-compose.identity-provider-service.yaml
+++ b/scripts/docker-compose.identity-provider-service.yaml
@@ -9,8 +9,9 @@ services:
       - IDENTITY_PROVIDER=/identity_provider.json
       - GLOBAL_CONTEXT=/global.json
       - RETRIEVE_BASE=https://id-service.eu.staging.concordium.com
-      - ID_VERIFICATION_URL=http://identity-verifier:7012/api/verify
-      - WALLET_PROXY_BASE=https://wallet-proxy.eu.staging.concordium.com
+      - ID_VERIFICATION_URL=http://localhost:7012/api/verify
+      - ID_VERIFICATION_QUERY_URL=http://identity-verifier:7012/api/verify
+      - WALLET_PROXY_BASE=https://wallet-proxy.testnet.concordium.com
     ports:
       - "7011:7011"
   identity-verifier:

--- a/scripts/docker-compose.identity-provider-service.yaml
+++ b/scripts/docker-compose.identity-provider-service.yaml
@@ -7,7 +7,7 @@ services:
       - IDENTITY_PROVIDER_SERVICE_PORT=7011
       - ANONYMITY_REVOKERS=/anonymity_revokers.json
       - IDENTITY_PROVIDER=/identity_provider.json
-      - GLOBAL=/global.json
+      - GLOBAL_CONTEXT=/global.json
       - RETRIEVE_BASE=https://id-service.eu.staging.concordium.com
       - ID_VERIFICATION_URL=http://identity-verifier:7012/api/verify
       - WALLET_PROXY_BASE=https://wallet-proxy.eu.staging.concordium.com

--- a/scripts/docker-compose.identity-provider-service.yaml
+++ b/scripts/docker-compose.identity-provider-service.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   identity-provider-service:
-    image: 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/identity-provider-service:debug
+    image: concordium/identity-provider-service:0.4.0-0
     environment:
       - MODE=identity-provider-service
       - IDENTITY_PROVIDER_SERVICE_PORT=7011
@@ -15,7 +15,7 @@ services:
     ports:
       - "7011:7011"
   identity-verifier:
-    image: 192549843005.dkr.ecr.eu-west-1.amazonaws.com/concordium/identity-provider-service:debug
+    image: concordium/identity-provider-service:0.4.0-0
     environment:
       - MODE=identity-verifier
       - IDENTITY_VERIFIER_PORT=7012


### PR DESCRIPTION
## Purpose

The actual variable name is `GLOBAL_CONTEXT`, not `GLOBAL`.

## Changes

Fix documentation. No code is changed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

