### PR TITLE
Fix schema's to_json for contract addresses.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -206,7 +206,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "bs58",
  "chrono",

--- a/idiss/Cargo.lock
+++ b/idiss/Cargo.lock
@@ -200,7 +200,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "bs58",
  "chrono",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -210,7 +210,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "bs58",
  "chrono",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -252,7 +252,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "5.1.0"
+version = "5.1.1"
 dependencies = [
  "bs58",
  "chrono",


### PR DESCRIPTION
## Purpose

Fix a bug in JSON serialization of contract addresses according to the schema.

The fix in contracs-common. This just bumps the submodule.


Depends on
- [x] https://github.com/Concordium/concordium-contracts-common/pull/67/files

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
