### PR TITLE
Build with stack 2.9.1. Update cabal file.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.24
 
--- This file has been generated from package.yaml by hpack version 0.34.4.
+-- This file has been generated from package.yaml by hpack version 0.35.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -147,12 +147,12 @@ library
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if os(windows)
     extra-libraries:
         userenv
         ws2_32
         bcrypt
-  default-language: Haskell2010
 
 executable generate-update-keys
   main-is: Main.hs
@@ -332,11 +332,11 @@ test-suite test
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if flag(static)
     ld-options: -static
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010
 
 benchmark bls-perf
   type: exitcode-stdio-1.0
@@ -384,9 +384,9 @@ benchmark bls-perf
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010
 
 benchmark ed25519-perf
   type: exitcode-stdio-1.0
@@ -434,9 +434,9 @@ benchmark ed25519-perf
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010
 
 benchmark ed25519dlog-perf
   type: exitcode-stdio-1.0
@@ -484,9 +484,9 @@ benchmark ed25519dlog-perf
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010
 
 benchmark sha256-perf
   type: exitcode-stdio-1.0
@@ -534,9 +534,9 @@ benchmark sha256-perf
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010
 
 benchmark verify-credential-perf
   type: exitcode-stdio-1.0
@@ -584,6 +584,6 @@ benchmark verify-credential-perf
     , transformers >=0.5
     , unordered-containers >=0.2
     , vector >=0.12
+  default-language: Haskell2010
   if !os(windows)
     ghc-options: -dynamic
-  default-language: Haskell2010


### PR DESCRIPTION
## Purpose

Build the project with stack 2.9.1 as stack 2.7.5 produces warnings when building with ghc 9.2.5.


## Changes

Updated the resulting cabal file. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
