### PR TITLE
Add implementation for std::hash::Hash for HashBytes

### DIFF
--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -4,14 +4,14 @@ use crate::constants::*;
 use crypto_common::{Deserial, SerdeDeserialize, SerdeSerialize, Serial};
 use std::{
     convert::{TryFrom, TryInto},
-    fmt,
+    fmt, hash,
     marker::PhantomData,
     ops::Deref,
     str::FromStr,
 };
 use thiserror::Error;
 
-#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, SerdeSerialize)]
+#[derive(Eq, Ord, PartialOrd, Copy, SerdeSerialize)]
 #[serde(into = "String")]
 /// A general wrapper around Sha256 hash. This is used to add type safety to
 /// a hash that is used in different context. The underlying value is always the
@@ -21,6 +21,16 @@ pub struct HashBytes<Purpose> {
     pub(crate) bytes: [u8; SHA256 as usize],
     #[serde(skip)] // use default when deserializing
     _phantom:         PhantomData<Purpose>,
+}
+
+impl<Purpose> PartialEq for HashBytes<Purpose> {
+    fn eq(&self, other: &Self) -> bool {
+        self.bytes == other.bytes && self._phantom == other._phantom
+    }
+}
+
+impl<Purpose> hash::Hash for HashBytes<Purpose> {
+    fn hash<H: hash::Hasher>(&self, state: &mut H) { self.bytes.hash(state); }
 }
 
 impl<Purpose> Clone for HashBytes<Purpose> {

--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -25,7 +25,7 @@ pub struct HashBytes<Purpose> {
 
 impl<Purpose> PartialEq for HashBytes<Purpose> {
     fn eq(&self, other: &Self) -> bool {
-        self.bytes == other.bytes && self._phantom == other._phantom
+        self.bytes == other.bytes
     }
 }
 

--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -11,7 +11,7 @@ use std::{
 };
 use thiserror::Error;
 
-#[derive(Eq, Ord, PartialOrd, Copy, SerdeSerialize)]
+#[derive(Ord, PartialOrd, Copy, SerdeSerialize)]
 #[serde(into = "String")]
 /// A general wrapper around Sha256 hash. This is used to add type safety to
 /// a hash that is used in different context. The underlying value is always the
@@ -28,6 +28,8 @@ impl<Purpose> PartialEq for HashBytes<Purpose> {
         self.bytes == other.bytes && self._phantom == other._phantom
     }
 }
+
+impl<Purpose> Eq for HashBytes<Purpose> {}
 
 impl<Purpose> hash::Hash for HashBytes<Purpose> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) { self.bytes.hash(state); }

--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -24,9 +24,7 @@ pub struct HashBytes<Purpose> {
 }
 
 impl<Purpose> PartialEq for HashBytes<Purpose> {
-    fn eq(&self, other: &Self) -> bool {
-        self.bytes == other.bytes
-    }
+    fn eq(&self, other: &Self) -> bool { self.bytes == other.bytes }
 }
 
 impl<Purpose> Eq for HashBytes<Purpose> {}


### PR DESCRIPTION
## Purpose

Added Hash trait to hashbytes type to be able to use it in data structures requiring the Hash trait (such as HashMap)

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
