### PR TITLE
Add display implementation for contract parameters.

### DIFF
--- a/rust-src/concordium_base/src/smart_contracts.rs
+++ b/rust-src/concordium_base/src/smart_contracts.rs
@@ -157,6 +157,16 @@ pub struct Parameter {
     bytes: Vec<u8>,
 }
 
+/// Display the entire parameter in hex.
+impl std::fmt::Display for Parameter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for b in &self.bytes {
+            f.write_fmt(format_args!("{:02x}", b))?
+        }
+        Ok(())
+    }
+}
+
 impl Parameter {
     /// Construct a parameter without checking that it fits the size limit.
     /// The caller is assumed to ensure this via external means.


### PR DESCRIPTION
## Purpose

Add missing display implementation for parameters. Based on hex as other binary data is displayed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
