### PR TITLE
Allow duplicate requests as long as identities are not issued yet.

### DIFF
--- a/identity-provider-service/CHANGELOG.md
+++ b/identity-provider-service/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.1
+
+- Do not count existing requests without issued identities as duplicate.
+
 ## 0.5.0
 
-Reject requests on duplicate credential registration ID.
+- Reject requests on duplicate credential registration ID.

--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "identity-provider-service"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/identity-provider-service/Cargo.toml
+++ b/identity-provider-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-provider-service"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/identity-provider-service/src/bin/main.rs
+++ b/identity-provider-service/src/bin/main.rs
@@ -451,7 +451,6 @@ impl DB {
             .lock()
             .expect("Cannot acquire a lock, which means something is very wrong.");
         Ok(self.root.join("identity").join(key).is_file()
-            || self.root.join("requests").join(key).is_file()
             || self.root.join("revocation").join(key).is_file())
     }
 


### PR DESCRIPTION
## Purpose

Allow duplicate requests as long as we don't have id object issued yet.

Note that this does mean that two concurrent requests with the same IDP will mean that only one of the identity objects is going to be retained.

That could also be fixed, but it requires adding more hacks on top of the hacky database we have at the moment, so I choose not to do this. In any case, that was a problem already before.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.