### PR TITLE
Testnet variant.

### DIFF
--- a/rust-bins/docs/user-cli.md
+++ b/rust-bins/docs/user-cli.md
@@ -28,6 +28,17 @@ user_cli generate-request --cryptographic-parameters cryptographic-parameters.js
                           --id-use-data-out id-use-data.json \ # data that enables use of the identity object
                           --request-out request.json # request to send to the identity provider
 ```
+
+For Testnet woule be the following: 
+```console
+user_cli generate-request --cryptographic-parameters cryptographic-parameters-testnet.json \
+                          --ars ars-testnet.json \
+                          --ip-info ip-info-testnet.json \
+                          --initial-keys-out initial-keys.json \ # keys of the initial account together with its address.
+                          --id-use-data-out id-use-data.json \ # data that enables use of the identity object
+                          --request-out request.json # request to send to the identity provider
+```
+
 The above command will ask for some additional input. You have to choose anonymity revokers and revocation threshold. Use arrow keys to navigate through the lists and the space key to select and deselect list entries. 
 
 It outputs the following files


### PR DESCRIPTION
Hi Team
We got a message from a user that it would be nice 2 separate user manuals for ID creation.

"I think generate request instructions is wrong. It's only for mainnet. If testnet, I have to replace some words: cryptographic-parameters.json -> cryptographic-parameters-testnet.json ars.json -> ars-testnet.json
ip-info.json -> ip-info-testnet.json
Documents should be modified."

Thank you

## Purpose

Not clear to everyone the difference...

## Changes

Testnet added in the file names

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
