### PR TITLE
New parameters for deciding finalization committe eligibility

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -835,6 +835,13 @@ instance ToProto Parameters.TimeoutParameters where
         ProtoFields.timeoutIncrease .= toProto _tpTimeoutIncrease
         ProtoFields.timeoutDecrease .= toProto _tpTimeoutDecrease
 
+instance ToProto Parameters.FinalizationCommitteeParameters where
+    type Output Parameters.FinalizationCommitteeParameters = Proto.FinalizationCommitteeParameters
+    toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
+        ProtoFields.minimumFinalizers .= toProto _fcpMinFinalizers
+        ProtoFields.maximumFinalizers .= toProto _fcpMaxFinalizers
+        ProtoFields.finalizerThreshold .= toProto _fcpThreshold
+
 instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
     type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1
     toProto Parameters.ConsensusParametersV1{..} = Proto.make $ do
@@ -874,6 +881,7 @@ convertUpdatePayload ut pl = case (ut, pl) of
     (Updates.UpdateTimeoutParameters, Updates.TimeoutParametersUpdatePayload tp) -> Right . Proto.make $ ProtoFields.timeoutParametersUpdate .= toProto tp
     (Updates.UpdateMinBlockTime, Updates.MinBlockTimeUpdatePayload mbt) -> Right . Proto.make $ ProtoFields.minBlockTimeUpdate .= toProto mbt
     (Updates.UpdateBlockEnergyLimit, Updates.BlockEnergyLimitUpdatePayload bel) -> Right . Proto.make $ ProtoFields.blockEnergyLimitUpdate .= toProto bel
+    (Updates.UpdateFinalizationCommitteeParameters, Updates.FinalizationCommitteeParametersPayload fcp) -> Right . Proto.make $ ProtoFields.finalizationCommitteeParametersUpdate .= toProto tp
     _ -> Left CEInvalidUpdateResult
 
 -- |The different conversions errors possible in @toBlockItemStatus@ (and the helper to* functions it calls).

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1015,11 +1015,17 @@ instance Parameters.IsAuthorizationsVersion auv => ToProto (Updates.Authorizatio
                     ProtoFields.v0 .= v0
                     ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
                     ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
+                Parameters.SAuthorizationsVersion2 -> Proto.make $ do
+                    ProtoFields.v0 .= v0
+                    ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
+                    ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
+                    ProtoFields.finalizationCommitteeParameters .= toProto (Updates.asFinalizationCommitteeParameters auth ^. Parameters.unconditionally)
 
 -- |Defines a type family that is used in the ToProto instance for Updates.Authorizations.
 type family AuthorizationsFamily cpv where
     AuthorizationsFamily 'Parameters.AuthorizationsVersion0 = Proto.AuthorizationsV0
     AuthorizationsFamily 'Parameters.AuthorizationsVersion1 = Proto.AuthorizationsV1
+    AuthorizationsFamily 'Parameters.AuthorizationsVersion2 = Proto.AuthorizationsV2
 
 instance ToProto Updates.AccessStructure where
     type Output Updates.AccessStructure = Proto.AccessStructure

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -848,7 +848,6 @@ instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParameter
         ProtoFields.timeoutParameters .= toProto _cpTimeoutParameters
         ProtoFields.minBlockTime .= toProto _cpMinBlockTime
         ProtoFields.blockEnergyLimit .= toProto _cpBlockEnergyLimit
-        ProtoFields.finalizationCommitteeParameters .= toProto _cpFinalizationCommitteeParameters
 
 -- |Attempt to construct the protobuf updatepayload.
 --  See @toBlockItemStatus@ for more context.
@@ -2030,6 +2029,7 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
                                     ProtoFields.rootKeys .= toProto (Updates.rootKeys keys)
                                     ProtoFields.level1Keys .= toProto (Updates.level1Keys keys)
                                     ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
+                                    ProtoFields.finalizationCommitteeParameters .= toProto (Parameters.unOParam _cpFinalizationCommitteeParameters)
                                 )
 
 instance ToProto FinalizationIndex where

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -840,7 +840,7 @@ instance ToProto Parameters.FinalizationCommitteeParameters where
     toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
         ProtoFields.minimumFinalizers .= _fcpMinFinalizers
         ProtoFields.maximumFinalizers .= _fcpMaxFinalizers
-        ProtoFields.stakeThreshold .= toProto _fcpStakeThreshold
+        ProtoFields.finalizerRelativeStakeThreshold .= _fcpFinalizerRelativeStakeThreshold
 
 instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
     type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -835,19 +835,19 @@ instance ToProto Parameters.TimeoutParameters where
         ProtoFields.timeoutIncrease .= toProto _tpTimeoutIncrease
         ProtoFields.timeoutDecrease .= toProto _tpTimeoutDecrease
 
-instance ToProto Parameters.FinalizationCommitteeParameters where
-    type Output Parameters.FinalizationCommitteeParameters = Proto.FinalizationCommitteeParameters
-    toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
-        ProtoFields.minimumFinalizers .= toProto _fcpMinFinalizers
-        ProtoFields.maximumFinalizers .= toProto _fcpMaxFinalizers
-        ProtoFields.finalizerThreshold .= toProto _fcpThreshold
-
 instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
     type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1
     toProto Parameters.ConsensusParametersV1{..} = Proto.make $ do
         ProtoFields.timeoutParameters .= toProto _cpTimeoutParameters
         ProtoFields.minBlockTime .= toProto _cpMinBlockTime
         ProtoFields.blockEnergyLimit .= toProto _cpBlockEnergyLimit
+
+instance ToProto Parameters.FinalizationCommitteeParameters where
+    type Output Parameters.FinalizationCommitteeParameters = Proto.FinalizationCommitteeParameters
+    toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
+        ProtoFields.minimumFinalizers .= coerce _fcpMinFinalizers
+        ProtoFields.maximumFinalizers .= coerce _fcpMaxFinalizers
+        ProtoFields.finalizerThreshold .= toProto _fcpFinalizerThreshold
 
 -- |Attempt to construct the protobuf updatepayload.
 --  See @toBlockItemStatus@ for more context.
@@ -881,7 +881,7 @@ convertUpdatePayload ut pl = case (ut, pl) of
     (Updates.UpdateTimeoutParameters, Updates.TimeoutParametersUpdatePayload tp) -> Right . Proto.make $ ProtoFields.timeoutParametersUpdate .= toProto tp
     (Updates.UpdateMinBlockTime, Updates.MinBlockTimeUpdatePayload mbt) -> Right . Proto.make $ ProtoFields.minBlockTimeUpdate .= toProto mbt
     (Updates.UpdateBlockEnergyLimit, Updates.BlockEnergyLimitUpdatePayload bel) -> Right . Proto.make $ ProtoFields.blockEnergyLimitUpdate .= toProto bel
-    (Updates.UpdateFinalizationCommitteeParameters, Updates.FinalizationCommitteeParametersPayload fcp) -> Right . Proto.make $ ProtoFields.finalizationCommitteeParametersUpdate .= toProto tp
+    (Updates.UpdateFinalizationCommitteeParameters, Updates.FinalizationCommitteeParametersUpdatePayload fcp) -> Right . Proto.make $ ProtoFields.finalizationCommitteeParametersUpdate .= toProto fcp
     _ -> Left CEInvalidUpdateResult
 
 -- |The different conversions errors possible in @toBlockItemStatus@ (and the helper to* functions it calls).
@@ -1521,6 +1521,7 @@ instance ToProto Updates.UpdateType where
     toProto Updates.UpdateTimeoutParameters = Proto.UPDATE_TIMEOUT_PARAMETERS
     toProto Updates.UpdateMinBlockTime = Proto.UPDATE_MIN_BLOCK_TIME
     toProto Updates.UpdateBlockEnergyLimit = Proto.UPDATE_BLOCK_ENERGY_LIMIT
+    toProto Updates.UpdateFinalizationCommitteeParameters = Proto.UPDATE_FINALIZATION_COMMITTEE_PARAMETERS
 
 instance ToProto TransactionType where
     type Output TransactionType = Proto.TransactionType
@@ -1928,6 +1929,7 @@ instance ToProto (TransactionTime, QueryTypes.PendingUpdateEffect) where
             QueryTypes.PUETimeoutParameters timeoutParameters -> ProtoFields.timeoutParameters .= toProto timeoutParameters
             QueryTypes.PUEMinBlockTime minBlockTime -> ProtoFields.minBlockTime .= toProto minBlockTime
             QueryTypes.PUEBlockEnergyLimit blockEnergyLimit -> ProtoFields.blockEnergyLimit .= toProto blockEnergyLimit
+            QueryTypes.PUEFinalizationCommitteeParameters finalizationCommitteeParameters -> ProtoFields.finalizationCommitteeParameters .= toProto finalizationCommitteeParameters
 
 instance ToProto QueryTypes.NextUpdateSequenceNumbers where
     type Output QueryTypes.NextUpdateSequenceNumbers = Proto.NextUpdateSequenceNumbers
@@ -2027,6 +2029,7 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
                                     ProtoFields.rootKeys .= toProto (Updates.rootKeys keys)
                                     ProtoFields.level1Keys .= toProto (Updates.level1Keys keys)
                                     ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
+                                    ProtoFields.finalizationCommitteeParameters .= toProto (Parameters.unOParam _cpFinalizationCommitteeParameters)
                                 )
 
 instance ToProto FinalizationIndex where

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1954,6 +1954,10 @@ instance ToProto QueryTypes.NextUpdateSequenceNumbers where
         ProtoFields.addIdentityProvider .= toProto _nusnAddIdentityProvider
         ProtoFields.cooldownParameters .= toProto _nusnCooldownParameters
         ProtoFields.timeParameters .= toProto _nusnTimeParameters
+        ProtoFields.timeoutParameters .= toProto _nusnTimeoutParameters
+        ProtoFields.minBlockTime .= toProto _nusnMinBlockTime
+        ProtoFields.blockEnergyLimit .= toProto _nusnBlockEnergyLimit
+        ProtoFields.finalizationCommitteeParameters .= toProto _nusnFinalizationCommitteeParameters
 
 instance ToProto Epoch where
     type Output Epoch = Proto.Epoch

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -50,6 +50,7 @@ import Concordium.Types.Accounts.Releases
 import Concordium.Types.Block (AbsoluteBlockHeight (..))
 import Concordium.Types.Execution
 import qualified Concordium.Types.InvokeContract as InvokeContract
+import Concordium.Types.Parameters (ConsensusParameters' (_cpFinalizationCommitteeParameters))
 import qualified Concordium.Types.Parameters as Parameters
 import qualified Concordium.Types.Updates as Updates
 import qualified Concordium.Wasm as Wasm
@@ -835,19 +836,20 @@ instance ToProto Parameters.TimeoutParameters where
         ProtoFields.timeoutIncrease .= toProto _tpTimeoutIncrease
         ProtoFields.timeoutDecrease .= toProto _tpTimeoutDecrease
 
-instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
-    type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1
-    toProto Parameters.ConsensusParametersV1{..} = Proto.make $ do
-        ProtoFields.timeoutParameters .= toProto _cpTimeoutParameters
-        ProtoFields.minBlockTime .= toProto _cpMinBlockTime
-        ProtoFields.blockEnergyLimit .= toProto _cpBlockEnergyLimit
-
 instance ToProto Parameters.FinalizationCommitteeParameters where
     type Output Parameters.FinalizationCommitteeParameters = Proto.FinalizationCommitteeParameters
     toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
         ProtoFields.minimumFinalizers .= _fcpMinFinalizers
         ProtoFields.maximumFinalizers .= _fcpMaxFinalizers
         ProtoFields.finalizerThreshold .= toProto _fcpFinalizerThreshold
+
+instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
+    type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1
+    toProto Parameters.ConsensusParametersV1{..} = Proto.make $ do
+        ProtoFields.timeoutParameters .= toProto _cpTimeoutParameters
+        ProtoFields.minBlockTime .= toProto _cpMinBlockTime
+        ProtoFields.blockEnergyLimit .= toProto _cpBlockEnergyLimit
+        ProtoFields.finalizationCommitteeParameters .= toProto _cpFinalizationCommitteeParameters
 
 -- |Attempt to construct the protobuf updatepayload.
 --  See @toBlockItemStatus@ for more context.
@@ -1015,19 +1017,11 @@ instance Parameters.IsAuthorizationsVersion auv => ToProto (Updates.Authorizatio
                     ProtoFields.v0 .= v0
                     ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
                     ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
-                Parameters.SAuthorizationsVersion2 -> Proto.make $ do
-                    ProtoFields.v0 .= v0
-                    v1 <- Proto.make $ do
-                        ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
-                        ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
-                    ProtoFields.v1 .= v1
-                    ProtoFields.finalizationCommitteeParameters .= toProto (Updates.asFinalizationCommitteeParameters auth ^. Parameters.unconditionally)
 
 -- |Defines a type family that is used in the ToProto instance for Updates.Authorizations.
 type family AuthorizationsFamily cpv where
     AuthorizationsFamily 'Parameters.AuthorizationsVersion0 = Proto.AuthorizationsV0
     AuthorizationsFamily 'Parameters.AuthorizationsVersion1 = Proto.AuthorizationsV1
-    AuthorizationsFamily 'Parameters.AuthorizationsVersion2 = Proto.AuthorizationsV2
 
 instance ToProto Updates.AccessStructure where
     type Output Updates.AccessStructure = Proto.AccessStructure
@@ -2037,7 +2031,6 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
                                     ProtoFields.rootKeys .= toProto (Updates.rootKeys keys)
                                     ProtoFields.level1Keys .= toProto (Updates.level1Keys keys)
                                     ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
-                                    ProtoFields.finalizationCommitteeParameters .= toProto (Parameters.unOParam _cpFinalizationCommitteeParameters)
                                 )
 
 instance ToProto FinalizationIndex where

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -50,7 +50,6 @@ import Concordium.Types.Accounts.Releases
 import Concordium.Types.Block (AbsoluteBlockHeight (..))
 import Concordium.Types.Execution
 import qualified Concordium.Types.InvokeContract as InvokeContract
-import Concordium.Types.Parameters (ConsensusParameters' (_cpFinalizationCommitteeParameters))
 import qualified Concordium.Types.Parameters as Parameters
 import qualified Concordium.Types.Updates as Updates
 import qualified Concordium.Wasm as Wasm

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -845,8 +845,8 @@ instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParameter
 instance ToProto Parameters.FinalizationCommitteeParameters where
     type Output Parameters.FinalizationCommitteeParameters = Proto.FinalizationCommitteeParameters
     toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
-        ProtoFields.minimumFinalizers .= coerce _fcpMinFinalizers
-        ProtoFields.maximumFinalizers .= coerce _fcpMaxFinalizers
+        ProtoFields.minimumFinalizers .= _fcpMinFinalizers
+        ProtoFields.maximumFinalizers .= _fcpMaxFinalizers
         ProtoFields.finalizerThreshold .= toProto _fcpFinalizerThreshold
 
 -- |Attempt to construct the protobuf updatepayload.
@@ -1017,8 +1017,10 @@ instance Parameters.IsAuthorizationsVersion auv => ToProto (Updates.Authorizatio
                     ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
                 Parameters.SAuthorizationsVersion2 -> Proto.make $ do
                     ProtoFields.v0 .= v0
-                    ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
-                    ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
+                    v1 <- Proto.make $ do
+                        ProtoFields.parameterCooldown .= toProto (Updates.asCooldownParameters auth ^. Parameters.unconditionally)
+                        ProtoFields.parameterTime .= toProto (Updates.asTimeParameters auth ^. Parameters.unconditionally)
+                    ProtoFields.v1 .= v1
                     ProtoFields.finalizationCommitteeParameters .= toProto (Updates.asFinalizationCommitteeParameters auth ^. Parameters.unconditionally)
 
 -- |Defines a type family that is used in the ToProto instance for Updates.Authorizations.

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -421,6 +421,10 @@ instance ToProto UrlText where
     type Output UrlText = Text
     toProto (UrlText s) = s
 
+instance ToProto PartsPerHundredThousands where
+    type Output PartsPerHundredThousands = Proto.AmountFraction
+    toProto (PartsPerHundredThousands ppht) = Proto.make (ProtoFields.partsPerHundredThousand .= fromIntegral ppht)
+
 instance ToProto AmountFraction where
     type Output AmountFraction = Proto.AmountFraction
     toProto (AmountFraction ppht) = Proto.make (ProtoFields.partsPerHundredThousand .= fromIntegral ppht)
@@ -840,7 +844,7 @@ instance ToProto Parameters.FinalizationCommitteeParameters where
     toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
         ProtoFields.minimumFinalizers .= _fcpMinFinalizers
         ProtoFields.maximumFinalizers .= _fcpMaxFinalizers
-        ProtoFields.finalizerRelativeStakeThreshold .= _fcpFinalizerRelativeStakeThreshold
+        ProtoFields.finalizerRelativeStakeThreshold .= toProto _fcpFinalizerRelativeStakeThreshold
 
 instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
     type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -840,7 +840,7 @@ instance ToProto Parameters.FinalizationCommitteeParameters where
     toProto Parameters.FinalizationCommitteeParameters{..} = Proto.make $ do
         ProtoFields.minimumFinalizers .= _fcpMinFinalizers
         ProtoFields.maximumFinalizers .= _fcpMaxFinalizers
-        ProtoFields.finalizerThreshold .= toProto _fcpFinalizerThreshold
+        ProtoFields.stakeThreshold .= toProto _fcpStakeThreshold
 
 instance ToProto (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) where
     type Output (Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1) = Proto.ConsensusParametersV1

--- a/haskell-src/Concordium/Genesis/Data/Base.hs
+++ b/haskell-src/Concordium/Genesis/Data/Base.hs
@@ -235,7 +235,6 @@ toChainParameters genesisAccounts GenesisChainParameters{..} = ChainParameters{.
         Just i -> fromIntegral i
     _cpPoolParameters = gcpPoolParameters
     _cpConsensusParameters = gcpConsensusParameters
-    _cpFinalizationCommitteeParameters = gcpFinalizationCommitteeParameters
 
 -- |Convert 'GenesisParameters' to genesis data.
 -- This is an auxiliary function since much of the behaviour is shared between protocol versions.

--- a/haskell-src/Concordium/Genesis/Data/Base.hs
+++ b/haskell-src/Concordium/Genesis/Data/Base.hs
@@ -235,6 +235,7 @@ toChainParameters genesisAccounts GenesisChainParameters{..} = ChainParameters{.
         Just i -> fromIntegral i
     _cpPoolParameters = gcpPoolParameters
     _cpConsensusParameters = gcpConsensusParameters
+    _cpFinalizationCommitteeParameters = gcpFinalizationCommitteeParameters
 
 -- |Convert 'GenesisParameters' to genesis data.
 -- This is an auxiliary function since much of the behaviour is shared between protocol versions.

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -38,7 +38,9 @@ data GenesisChainParameters' (cpv :: ChainParametersVersion) = GenesisChainParam
       -- |Foundation account address.
       gcpFoundationAccount :: !AccountAddress,
       -- |Minimum threshold required for registering as a baker.
-      gcpPoolParameters :: !(PoolParameters cpv)
+      gcpPoolParameters :: !(PoolParameters cpv),
+      -- |Finalization committee parameters
+      gcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommittee cpv FinalizationCommitteeParameters)
     }
     deriving (Eq, Show)
 
@@ -66,6 +68,7 @@ parseJSONForGCPV0 =
             gcpTimeParameters = NoParam
             gcpPoolParameters = PoolParametersV0{..}
             gcpExchangeRates = makeExchangeRates _erEuroPerEnergy _erMicroGTUPerEuro
+            gcpFinalizationCommitteeParameters = NoParam
         return GenesisChainParameters{..}
 
 -- |Parse 'GenesisChainParameters' from JSON for 'ChainParametersV1'.
@@ -97,6 +100,7 @@ parseJSONForGCPV1 =
             gcpExchangeRates = makeExchangeRates _erEuroPerEnergy _erMicroGTUPerEuro
             _ppPassiveCommissions = CommissionRates{..}
             _ppCommissionBounds = CommissionRanges{..}
+            gcpFinalizationCommitteeParameters = NoParam
         return GenesisChainParameters{..}
 
 -- |Parse 'GenesisChainParameters' from JSON for 'ChainParametersV2'.
@@ -126,6 +130,9 @@ parseJSONForGCPV2 =
         _tpTimeoutDecrease <- v .: "timeoutDecrease"
         _cpMinBlockTime <- v .: "minBlockTime"
         _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
+        _fcpMinBakers <- v .: "minBakers"
+        _fcpMaxBakers <- v .: "maxBakers"
+        _fcpThreshold <- v .: "bakingThreshold"
         let gcpCooldownParameters = CooldownParametersV1{..}
             gcpTimeParameters = SomeParam TimeParametersV1{..}
             gcpPoolParameters = PoolParametersV1{..}
@@ -134,6 +141,7 @@ parseJSONForGCPV2 =
             _ppCommissionBounds = CommissionRanges{..}
             _cpTimeoutParameters = TimeoutParameters{..}
             gcpConsensusParameters = ConsensusParametersV1{..}
+            gcpFinalizationCommitteeParameters = SomeParam FinalizationCommitteeParameters{..}
         return GenesisChainParameters{..}
 
 instance ToJSON (GenesisChainParameters' 'ChainParametersV0) where

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -40,7 +40,7 @@ data GenesisChainParameters' (cpv :: ChainParametersVersion) = GenesisChainParam
       -- |Minimum threshold required for registering as a baker.
       gcpPoolParameters :: !(PoolParameters cpv),
       -- |Finalization committee parameters
-      gcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommittee cpv FinalizationCommitteeParameters)
+      gcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommitteeParameters cpv FinalizationCommitteeParameters)
     }
     deriving (Eq, Show)
 

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -130,9 +130,9 @@ parseJSONForGCPV2 =
         _tpTimeoutDecrease <- v .: "timeoutDecrease"
         _cpMinBlockTime <- v .: "minBlockTime"
         _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
-        _fcpMinBakers <- v .: "minBakers"
-        _fcpMaxBakers <- v .: "maxBakers"
-        _fcpThreshold <- v .: "bakingThreshold"
+        _fcpMinFinalizers <- v .: "minimumFinalizers"
+        _fcpMaxFinalizers <- v .: "maximumFinalizers"
+        _fcpFinalizerThreshold <- v .: "finalizerThreshold"
         let gcpCooldownParameters = CooldownParametersV1{..}
             gcpTimeParameters = SomeParam TimeParametersV1{..}
             gcpPoolParameters = PoolParametersV1{..}

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -132,7 +132,7 @@ parseJSONForGCPV2 =
         _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
         _fcpMinFinalizers <- v .: "minimumFinalizers"
         _fcpMaxFinalizers <- v .: "maximumFinalizers"
-        _fcpStakeThreshold <- v .: "stakeThreshold"
+        _fcpFinalizerRelativeStakeThreshold <- v .: "finalizerRelativeStakeThreshold"
         let gcpCooldownParameters = CooldownParametersV1{..}
             gcpTimeParameters = SomeParam TimeParametersV1{..}
             gcpPoolParameters = PoolParametersV1{..}
@@ -209,7 +209,7 @@ instance ToJSON (GenesisChainParameters' 'ChainParametersV2) where
               "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters,
               "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam gcpFinalizationCommitteeParameters),
               "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam gcpFinalizationCommitteeParameters),
-              "stakeThreshold" AE..= _fcpStakeThreshold (unOParam gcpFinalizationCommitteeParameters)
+              "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam gcpFinalizationCommitteeParameters)
             ]
 
 -- | 'GenesisParameters' provides a convenient abstraction for

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -205,7 +205,7 @@ instance ToJSON (GenesisChainParameters' 'ChainParametersV2) where
               "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters,
               "minimumFinalizers" AE..= _fcpMinFinalizers (_cpFinalizationCommitteeParameters gcpConsensusParameters),
               "maximumFinalizers" AE..= _fcpMaxFinalizers (_cpFinalizationCommitteeParameters gcpConsensusParameters),
-              "finalizerThreshold" AE..= _fcpFinalizerThreshold (_cpFinalizationCommitteeParameters gcpConsensusParameters)
+              "stakeThreshold" AE..= _fcpStakeThreshold (_cpFinalizationCommitteeParameters gcpConsensusParameters)
             ]
 
 -- | 'GenesisParameters' provides a convenient abstraction for

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -38,9 +38,7 @@ data GenesisChainParameters' (cpv :: ChainParametersVersion) = GenesisChainParam
       -- |Foundation account address.
       gcpFoundationAccount :: !AccountAddress,
       -- |Minimum threshold required for registering as a baker.
-      gcpPoolParameters :: !(PoolParameters cpv),
-      -- |Finalization committee parameters
-      gcpFinalizationCommitteeParameters :: !(OParam 'PTFinalizationCommitteeParameters cpv FinalizationCommitteeParameters)
+      gcpPoolParameters :: !(PoolParameters cpv)
     }
     deriving (Eq, Show)
 
@@ -68,7 +66,6 @@ parseJSONForGCPV0 =
             gcpTimeParameters = NoParam
             gcpPoolParameters = PoolParametersV0{..}
             gcpExchangeRates = makeExchangeRates _erEuroPerEnergy _erMicroGTUPerEuro
-            gcpFinalizationCommitteeParameters = NoParam
         return GenesisChainParameters{..}
 
 -- |Parse 'GenesisChainParameters' from JSON for 'ChainParametersV1'.
@@ -100,7 +97,6 @@ parseJSONForGCPV1 =
             gcpExchangeRates = makeExchangeRates _erEuroPerEnergy _erMicroGTUPerEuro
             _ppPassiveCommissions = CommissionRates{..}
             _ppCommissionBounds = CommissionRanges{..}
-            gcpFinalizationCommitteeParameters = NoParam
         return GenesisChainParameters{..}
 
 -- |Parse 'GenesisChainParameters' from JSON for 'ChainParametersV2'.
@@ -140,8 +136,8 @@ parseJSONForGCPV2 =
             _ppPassiveCommissions = CommissionRates{..}
             _ppCommissionBounds = CommissionRanges{..}
             _cpTimeoutParameters = TimeoutParameters{..}
+            _cpFinalizationCommitteeParameters = FinalizationCommitteeParameters{..}
             gcpConsensusParameters = ConsensusParametersV1{..}
-            gcpFinalizationCommitteeParameters = SomeParam FinalizationCommitteeParameters{..}
         return GenesisChainParameters{..}
 
 instance ToJSON (GenesisChainParameters' 'ChainParametersV0) where
@@ -206,7 +202,10 @@ instance ToJSON (GenesisChainParameters' 'ChainParametersV2) where
               "timeoutIncrease" AE..= _tpTimeoutIncrease (_cpTimeoutParameters gcpConsensusParameters),
               "timeoutDecrease" AE..= _tpTimeoutDecrease (_cpTimeoutParameters gcpConsensusParameters),
               "minBlockTime" AE..= _cpMinBlockTime gcpConsensusParameters,
-              "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters
+              "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters,
+              "minimumFinalizers" AE..= _fcpMinFinalizers (_cpFinalizationCommitteeParameters gcpConsensusParameters),
+              "maximumFinalizers" AE..= _fcpMaxFinalizers (_cpFinalizationCommitteeParameters gcpConsensusParameters),
+              "finalizerThreshold" AE..= _fcpFinalizerThreshold (_cpFinalizationCommitteeParameters gcpConsensusParameters)
             ]
 
 -- | 'GenesisParameters' provides a convenient abstraction for

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -173,6 +173,9 @@ module Concordium.Types (
     accountAddressEmbed,
     accountAddressPrefixSize,
     createAlias,
+
+    -- * PartsPerHundredThousands
+    PartsPerHundredThousands (..),
 ) where
 
 import Data.Data (Data, Typeable)

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -108,6 +108,7 @@ migrateChainParameters m@(StateMigrationParametersP3ToP4 migration) ChainParamet
                   ..
                 },
           _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
+          _cpFinalizationCommitteeParameters = NoParam,
           ..
         }
   where

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -108,7 +108,6 @@ migrateChainParameters m@(StateMigrationParametersP3ToP4 migration) ChainParamet
                   ..
                 },
           _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
-          _cpFinalizationCommitteeParameters = NoParam,
           ..
         }
   where

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1615,7 +1615,7 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
       _fcpMaxFinalizers :: !Word32,
       -- |Determining the staking threshold required for being eligible the finalization committee.
       -- The required amount is given by @total stake in pools * _fcpFinalizerRelativeStakeThreshold@
-      -- Accepted values are [0,1].
+      -- Accepted values are in the range [0,1].
       _fcpFinalizerRelativeStakeThreshold :: !PartsPerHundredThousands
     }
     deriving (Eq, Show)

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -349,8 +349,7 @@ module Concordium.Types.Parameters (
     -- The maximum number of bakers allowed to be in the finalization committee.
     fcpMaxFinalizers,
     -- The minimum (micro) CCD threshold required for joining the finalization committee.
-    -- (if there are more than 'fcpMinBakers' bakers on the chain).
-    fcpFinalizerThreshold,
+    fcpStakeThreshold,
 
     -- * Authorizations version
 
@@ -1611,7 +1610,7 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
       _fcpMaxFinalizers :: !Word64,
       -- |Minimum amount of (micro) CCD that a baker must have in order to
       -- be eligible for being part of the finalization committee.
-      _fcpFinalizerThreshold :: !Amount
+      _fcpStakeThreshold :: !Amount
     }
     deriving (Eq, Show)
 
@@ -1621,14 +1620,14 @@ instance Serialize FinalizationCommitteeParameters where
     put FinalizationCommitteeParameters{..} = do
         put _fcpMinFinalizers
         put _fcpMaxFinalizers
-        put _fcpFinalizerThreshold
+        put _fcpStakeThreshold
     get = do
         _fcpMinFinalizers <- get
         unless (_fcpMinFinalizers > 0) $ fail "the minimum number of finalizers must be positive."
         _fcpMaxFinalizers <- get
         unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
-        _fcpFinalizerThreshold <- get
-        unless (_fcpFinalizerThreshold > 0) $ fail "finalizer threshold must be positive."
+        _fcpStakeThreshold <- get
+        unless (_fcpStakeThreshold > 0) $ fail "stake threshold must be positive."
         return FinalizationCommitteeParameters{..}
 
 instance HashableTo Hash.Hash FinalizationCommitteeParameters where
@@ -1641,7 +1640,7 @@ instance ToJSON FinalizationCommitteeParameters where
         object
             [ "maximumFinalizers" AE..= _fcpMinFinalizers,
               "minimumFinalizers" AE..= _fcpMaxFinalizers,
-              "finalizerThreshold" AE..= _fcpFinalizerThreshold
+              "stakeThreshold" AE..= _fcpStakeThreshold
             ]
 
 instance FromJSON FinalizationCommitteeParameters where
@@ -1650,8 +1649,8 @@ instance FromJSON FinalizationCommitteeParameters where
         unless (_fcpMinFinalizers > 0) $ fail "the minimum number of finalizers must be positive."
         _fcpMaxFinalizers <- o .: "maximumFinalizers"
         unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
-        _fcpFinalizerThreshold <- o .: "finalizerThreshold"
-        unless (_fcpFinalizerThreshold > 0) $ fail "finalizer threshold must be positive."
+        _fcpStakeThreshold <- o .: "finalizerThreshold"
+        unless (_fcpStakeThreshold > 0) $ fail "stake threshold must be positive."
         return FinalizationCommitteeParameters{..}
 
 -- * Consensus parameters
@@ -1933,7 +1932,7 @@ parseJSONForCPV2 =
         _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
         _fcpMinFinalizers <- v .: "minimumFinalizers"
         _fcpMaxFinalizers <- v .: "maximumFinalizers"
-        _fcpFinalizerThreshold <- v .: "finalizerThreshold"
+        _fcpStakeThreshold <- v .: "stakeThreshold"
         let _cpCooldownParameters = CooldownParametersV1{..}
             _cpTimeParameters = SomeParam TimeParametersV1{..}
             _cpPoolParameters = PoolParametersV1{..}
@@ -2012,7 +2011,7 @@ instance forall cpv. IsChainParametersVersion cpv => ToJSON (ChainParameters' cp
                   "blockEnergyLimit" AE..= _cpBlockEnergyLimit _cpConsensusParameters,
                   "minimumFinalizers" AE..= _fcpMinFinalizers (_cpFinalizationCommitteeParameters _cpConsensusParameters),
                   "maximumFinalizers" AE..= _fcpMaxFinalizers (_cpFinalizationCommitteeParameters _cpConsensusParameters),
-                  "finalizerThreshold" AE..= _fcpFinalizerThreshold (_cpFinalizationCommitteeParameters _cpConsensusParameters)
+                  "finalizerThreshold" AE..= _fcpStakeThreshold (_cpFinalizationCommitteeParameters _cpConsensusParameters)
                 ]
 
 -- |Parameters that affect finalization.

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -619,15 +619,15 @@ $( singletons
             ConsensusParametersVersion1 -> False
         isSupported PTTimeParameters cpv = supportsTimeParameters (authorizationsVersionFor cpv)
         isSupported PTMintPerSlot cpv = supportsMintPerSlot (mintDistributionVersionFor cpv)
-        isSupported PTTimeoutParameters ChainParametersV0 = False
-        isSupported PTTimeoutParameters ChainParametersV1 = False
-        isSupported PTTimeoutParameters ChainParametersV2 = True
-        isSupported PTMinBlockTime ChainParametersV0 = False
-        isSupported PTMinBlockTime ChainParametersV1 = False
-        isSupported PTMinBlockTime ChainParametersV2 = True
-        isSupported PTBlockEnergyLimit ChainParametersV0 = False
-        isSupported PTBlockEnergyLimit ChainParametersV1 = False
-        isSupported PTBlockEnergyLimit ChainParametersV2 = True
+        isSupported PTTimeoutParameters cpv = case consensusParametersVersionFor cpv of
+            ConsensusParametersVersion0 -> False
+            ConsensusParametersVersion1 -> True
+        isSupported PTMinBlockTime cpv = case consensusParametersVersionFor cpv of
+            ConsensusParametersVersion0 -> False
+            ConsensusParametersVersion1 -> True
+        isSupported PTBlockEnergyLimit cpv = case consensusParametersVersionFor cpv of
+            ConsensusParametersVersion0 -> False
+            ConsensusParametersVersion1 -> True
         isSupported PTCooldownParametersAccessStructure cpv = supportsCooldownParametersAccessStructure (authorizationsVersionFor cpv)
         isSupported PTFinalizationProof ChainParametersV0 = True
         isSupported PTFinalizationProof ChainParametersV1 = True

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -351,12 +351,6 @@ module Concordium.Types.Parameters (
     -- The minimum (micro) CCD threshold required for joining the finalization committee.
     -- (if there are more than 'fcpMinBakers' bakers on the chain).
     fcpFinalizerThreshold,
-    -- |Whether finalization committee parameters are updatable for an 'AuthorizationsVersion'.
-    supportsFinalizationCommitteeParameters,
-    -- |Whether finalization committee parameters are updatable for an 'AuthorizationsVersion' (types).
-    SupportsFinalizationCommitteeParameters,
-    -- |Whether finalization committee parameters are updatable for an 'AuthorizationsVersion' (singletons).
-    sSupportsFinalizationCommitteeParameters,
 
     -- * Authorizations version
 
@@ -554,7 +548,7 @@ $( singletons
         -- \|Consensus parameters version.
         data ConsensusParametersVersion
             = ConsensusParametersVersion0 -- \^Election difficulty
-            | ConsensusParametersVersion1 -- \^Timeout parameters, block energy limit, min block time
+            | ConsensusParametersVersion1 -- \^Timeout parameters, block energy limit, min block time, finalization committee parameters
 
         -- \|The consensus parameters version associated with a chain parameters version.
         consensusParametersVersionFor :: ChainParametersVersion -> ConsensusParametersVersion
@@ -586,12 +580,6 @@ $( singletons
         supportsTimeParameters :: AuthorizationsVersion -> Bool
         supportsTimeParameters AuthorizationsVersion0 = False
         supportsTimeParameters AuthorizationsVersion1 = True
-
-        -- Whether finalization committee parameters are supported for an authorization version.
-        -- The finalization committee parameters were introduced as part of cpv2 (protocol 6).
-        supportsFinalizationCommitteeParameters :: AuthorizationsVersion -> Bool
-        supportsFinalizationCommitteeParameters AuthorizationsVersion0 = False
-        supportsFinalizationCommitteeParameters AuthorizationsVersion1 = True
 
         -- \|Parameter types that are conditionally supported at different 'ChainParametersVersion's.
         data ParameterType
@@ -1759,7 +1747,6 @@ instance IsConsensusParametersVersion cpv => Serialize (ConsensusParameters' cpv
             _cpFinalizationCommitteeParameters <- get
             return ConsensusParametersV1{..}
 
-            
 -- * Chain parameters
 
 -- |Witness the constraints implied by an 'SChainParametersVersion'.

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -558,7 +558,7 @@ $( singletons
         -- \|Consensus parameters version.
         data ConsensusParametersVersion
             = ConsensusParametersVersion0 -- \^Election difficulty
-            | ConsensusParametersVersion1 -- \^Timeout parameters, block energy limit, min block time, finalization committee parameters
+            | ConsensusParametersVersion1 -- \^Timeout parameters, block energy limit, min block time
 
         -- \|The consensus parameters version associated with a chain parameters version.
         consensusParametersVersionFor :: ChainParametersVersion -> ConsensusParametersVersion

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1612,6 +1612,7 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
       _fcpMaxFinalizers :: !Word32,
       -- |Determining the staking threshold required for being eligible the finalization committee.
       -- The required amount is given by @total staked ccd * _fcpFinalizerRelativeStakeThreshold@
+      -- Accepted values are [0,1].
       _fcpFinalizerRelativeStakeThreshold :: !PartsPerHundredThousands
     }
     deriving (Eq, Show)

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1611,8 +1611,8 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
       -- |Maximum number of bakers to include in the finalization committee.
       _fcpMaxFinalizers :: !Word32,
       -- |Determining the staking threshold required for being eligible the finalization committee.
-      -- The required amount is given by @total staked ccd / _fcpFinalizerRelativeStakeThreshold@
-      _fcpFinalizerRelativeStakeThreshold :: !Word32
+      -- The required amount is given by @total staked ccd * _fcpFinalizerRelativeStakeThreshold@
+      _fcpFinalizerRelativeStakeThreshold :: !PartsPerHundredThousands
     }
     deriving (Eq, Show)
 

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -344,7 +344,8 @@ module Concordium.Types.Parameters (
 
     -- * Finalization committee parameters
     FinalizationCommitteeParameters (..),
-    -- The minimum number of bakers in the finalization committee.
+    -- The number of bakers that are eligible for finalization committee before
+    -- the 'fcpFinalizerRelativeStakeThreshold' takes effect.
     fcpMinFinalizers,
     -- The maximum number of bakers allowed to be in the finalization committee.
     fcpMaxFinalizers,
@@ -1606,12 +1607,13 @@ instance (Monad m) => MHashableTo m Hash.Hash TimeoutParameters
 -- These parameters control who and how many bakers will be
 -- eligible for joinin the finalization committee.
 data FinalizationCommitteeParameters = FinalizationCommitteeParameters
-    { -- |Minimum number of bakers to include in the finalization committee.
+    { -- |Minimum number of bakers to include in the finalization committee before
+      -- the '_fcpFinalizerRelativeStakeThreshold' takes effect.
       _fcpMinFinalizers :: !Word32,
       -- |Maximum number of bakers to include in the finalization committee.
       _fcpMaxFinalizers :: !Word32,
       -- |Determining the staking threshold required for being eligible the finalization committee.
-      -- The required amount is given by @total staked ccd * _fcpFinalizerRelativeStakeThreshold@
+      -- The required amount is given by @total stake in pools * _fcpFinalizerRelativeStakeThreshold@
       -- Accepted values are [0,1].
       _fcpFinalizerRelativeStakeThreshold :: !PartsPerHundredThousands
     }
@@ -1628,7 +1630,7 @@ instance Serialize FinalizationCommitteeParameters where
         _fcpMinFinalizers <- get
         unless (_fcpMinFinalizers > 0) $ fail "the minimum number of finalizers must be positive."
         _fcpMaxFinalizers <- get
-        unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
+        unless (_fcpMaxFinalizers >= _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater or equal than minimumFinalizers."
         _fcpFinalizerRelativeStakeThreshold <- get
         return FinalizationCommitteeParameters{..}
 
@@ -1650,7 +1652,7 @@ instance FromJSON FinalizationCommitteeParameters where
         _fcpMinFinalizers <- o .: "minimumFinalizers"
         unless (_fcpMinFinalizers > 0) $ fail "the minimum number of finalizers must be positive."
         _fcpMaxFinalizers <- o .: "maximumFinalizers"
-        unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
+        unless (_fcpMaxFinalizers >= _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater or equal than minimumFinalizers."
         _fcpFinalizerRelativeStakeThreshold <- o .: "finalizerRelativeStakeThreshold"
         return FinalizationCommitteeParameters{..}
 

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -344,12 +344,12 @@ module Concordium.Types.Parameters (
 
     -- * Finalization committee parameters
     FinalizationCommitteeParameters (..),
-    -- The number of bakers that are eligible for finalization committee before
+    -- |The number of bakers that are eligible for finalization committee before
     -- the 'fcpFinalizerRelativeStakeThreshold' takes effect.
     fcpMinFinalizers,
-    -- The maximum number of bakers allowed to be in the finalization committee.
+    -- |The maximum number of bakers allowed to be in the finalization committee.
     fcpMaxFinalizers,
-    -- Determining the staking threshold required for being eligible the finalization committee.
+    -- |Determining the staking threshold required for being eligible the finalization committee.
     -- The minimum amount required to join the finalization committee
     -- is given by @total staked ccd / fcpFinalizerRelativeStakeThreshold@
     fcpFinalizerRelativeStakeThreshold,

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1569,7 +1569,13 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
     }
     deriving (Eq, Show)
 
-makeLenses ''FinalizationCommitteeParameters
+-- Define 'HasFinalizationCommitteeParameters' class with accessor lenses, and instance for 'FinalizationCommitteeParameters'.
+makeClassy ''FinalizationCommitteeParameters
+
+-- |An instance for 'HasFinalizationCommitteeParameters' that automatically unwraps the @OParam 'PTFinalizationCommitteeParameters cpv 'FinalizationCommitteeParameters@
+-- when @IsSupported 'PTFinalizationCommitteeParameters cpv ~ 'True@
+instance IsSupported 'PTFinalizationCommitteeParameters cpv ~ 'True => HasFinalizationCommitteeParameters (OParam 'PTFinalizationCommitteeParameters cpv FinalizationCommitteeParameters) where
+    finalizationCommitteeParameters = supportedOParam
 
 instance Serialize FinalizationCommitteeParameters where
     put FinalizationCommitteeParameters{..} = do

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1690,12 +1690,11 @@ data FinalizationCommitteeParameters = FinalizationCommitteeParameters
     { -- |Minimum number of bakers to include in the finalization committee.
       _fcpMinBakers :: !Word64,
       -- |Maximum number of bakers to include in the finalization committee.
-      -- If there are more than 'fcpMaxBakers' then the 'fcpMaxBakers' bakers with the
-      -- most stake will join the finalization committee.
+      -- If there are more than 'fcpMaxBakers' then the top ('fcpMaxBakers') bakers
+      -- will join the finalization committee.
       _fcpMaxBakers :: !Word64,
       -- |Minimum amount of (micro) CCD that a baker must have in order to
       -- be eligible for being part of the finalization committee.
-      -- (If there are more than '_fcpMinBakers' on chain.)
       _fcpThreshold :: !Amount
     }
     deriving (Eq, Show)

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1721,7 +1721,7 @@ cpBlockEnergyLimit =
     lens _cpBlockEnergyLimit (\cp x -> cp{_cpBlockEnergyLimit = x})
 
 -- |Lens for '_cpFinalizationCommitteeParameters'
--- This provides access to the block energy limit of 'ConsensusParametersV1'
+-- This provides access finalization committee parameters for 'ConsensusParametersV1'
 {-# INLINE cpFinalizationCommitteeParameters #-}
 cpFinalizationCommitteeParameters ::
     Lens' (ConsensusParameters' 'ConsensusParametersVersion1) FinalizationCommitteeParameters

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1604,8 +1604,9 @@ instance (Monad m) => MHashableTo m Hash.Hash TimeoutParameters
 -- * Finalization committee parameters for consensus v1.
 
 -- |Finalization committee parameters
--- These parameters control who and how many bakers will be
--- eligible for joinin the finalization committee.
+-- These parameters control which bakers are in the finalization committee.
+-- '_fcpMinFinalizers' MUST be at least 1.
+-- '_fcpMaxFinalizers' MUST be at least '_fcpMinFinalizers'.
 data FinalizationCommitteeParameters = FinalizationCommitteeParameters
     { -- |Minimum number of bakers to include in the finalization committee before
       -- the '_fcpFinalizerRelativeStakeThreshold' takes effect.

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -346,12 +346,12 @@ module Concordium.Types.Parameters (
     -- * Finalization committee parameters
     FinalizationCommitteeParameters (..),
     -- The minimum number of bakers in the finalization committee.
-    fcpMinBakers,
+    fcpMinFinalizers,
     -- The maximum number of bakers allowed to be in the finalization committee.
-    fcpMaxBakers,
+    fcpMaxFinalizers,
     -- The minimum (micro) CCD threshold required for joining the finalization committee.
     -- (if there are more than 'fcpMinBakers' bakers on the chain).
-    fcpThreshold,
+    fcpFinalizerThreshold,
 
     -- * Authorizations version
 
@@ -1688,14 +1688,12 @@ instance IsConsensusParametersVersion cpv => Serialize (ConsensusParameters' cpv
 -- eligible for joinin the finalization committee.
 data FinalizationCommitteeParameters = FinalizationCommitteeParameters
     { -- |Minimum number of bakers to include in the finalization committee.
-      _fcpMinBakers :: !Word64,
+      _fcpMinFinalizers :: !Word64,
       -- |Maximum number of bakers to include in the finalization committee.
-      -- If there are more than 'fcpMaxBakers' then the top ('fcpMaxBakers') bakers
-      -- will join the finalization committee.
-      _fcpMaxBakers :: !Word64,
+      _fcpMaxFinalizers :: !Word64,
       -- |Minimum amount of (micro) CCD that a baker must have in order to
       -- be eligible for being part of the finalization committee.
-      _fcpThreshold :: !Amount
+      _fcpFinalizerThreshold :: !Amount
     }
     deriving (Eq, Show)
 
@@ -1703,13 +1701,13 @@ makeLenses ''FinalizationCommitteeParameters
 
 instance Serialize FinalizationCommitteeParameters where
     put FinalizationCommitteeParameters{..} = do
-        put _fcpMinBakers
-        put _fcpMaxBakers
-        put _fcpThreshold
+        put _fcpMinFinalizers
+        put _fcpMaxFinalizers
+        put _fcpFinalizerThreshold
     get = do
-        _fcpMinBakers <- get
-        _fcpMaxBakers <- get
-        _fcpThreshold <- get
+        _fcpMinFinalizers <- get
+        _fcpMaxFinalizers <- get
+        _fcpFinalizerThreshold <- get
         return FinalizationCommitteeParameters{..}
 
 -- * Chain parameters
@@ -1901,9 +1899,9 @@ parseJSONForCPV2 =
         let _cpTimeoutParameters = TimeoutParameters{..}
         _cpMinBlockTime <- v .: "minBlockTime"
         _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
-        _fcpMinBakers <- v .: "minimumBakers"
-        _fcpMaxBakers <- v .: "maximumBakers"
-        _fcpThreshold <- v .: "bakingThreshold"
+        _fcpMinFinalizers <- v .: "minimumFinalizers"
+        _fcpMaxFinalizers <- v .: "maximumFinalizers"
+        _fcpFinalizerThreshold <- v .: "finalizerThreshold"
         let _cpCooldownParameters = CooldownParametersV1{..}
             _cpTimeParameters = SomeParam TimeParametersV1{..}
             _cpPoolParameters = PoolParametersV1{..}
@@ -1980,9 +1978,9 @@ instance forall cpv. IsChainParametersVersion cpv => ToJSON (ChainParameters' cp
                   "timeoutDecrease" AE..= _tpTimeoutDecrease (_cpTimeoutParameters _cpConsensusParameters),
                   "minBlockTime" AE..= _cpMinBlockTime _cpConsensusParameters,
                   "blockEnergyLimit" AE..= _cpBlockEnergyLimit _cpConsensusParameters,
-                  "minimumBakers" AE..= _fcpMinBakers (unOParam _cpFinalizationCommitteeParameters),
-                  "maximumBakers" AE..= _fcpMaxBakers (unOParam _cpFinalizationCommitteeParameters),
-                  "bakingThreshold" AE..= _fcpThreshold (unOParam _cpFinalizationCommitteeParameters)
+                  "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam _cpFinalizationCommitteeParameters),
+                  "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam _cpFinalizationCommitteeParameters),
+                  "finalizerThreshold" AE..= _fcpFinalizerThreshold (unOParam _cpFinalizationCommitteeParameters)
                 ]
 
 -- |Parameters that affect finalization.

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1981,8 +1981,8 @@ instance forall cpv. IsChainParametersVersion cpv => ToJSON (ChainParameters' cp
                   "timeoutDecrease" AE..= _tpTimeoutDecrease (_cpTimeoutParameters _cpConsensusParameters),
                   "minBlockTime" AE..= _cpMinBlockTime _cpConsensusParameters,
                   "blockEnergyLimit" AE..= _cpBlockEnergyLimit _cpConsensusParameters,
-                  "minBakers" AE..= _fcpMinBakers (unOParam _cpFinalizationCommitteeParameters),
-                  "maxBakers" AE..= _fcpMaxBakers (unOParam _cpFinalizationCommitteeParameters),
+                  "minimumBakers" AE..= _fcpMinBakers (unOParam _cpFinalizationCommitteeParameters),
+                  "maximumBakers" AE..= _fcpMaxBakers (unOParam _cpFinalizationCommitteeParameters),
                   "bakingThreshold" AE..= _fcpThreshold (unOParam _cpFinalizationCommitteeParameters)
                 ]
 

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1629,7 +1629,6 @@ instance Serialize FinalizationCommitteeParameters where
         _fcpMaxFinalizers <- get
         unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
         _fcpFinalizerRelativeStakeThreshold <- get
-        unless (_fcpFinalizerRelativeStakeThreshold > 0) $ fail "stake threshold must be positive."
         return FinalizationCommitteeParameters{..}
 
 instance HashableTo Hash.Hash FinalizationCommitteeParameters where
@@ -1642,7 +1641,7 @@ instance ToJSON FinalizationCommitteeParameters where
         object
             [ "maximumFinalizers" AE..= _fcpMinFinalizers,
               "minimumFinalizers" AE..= _fcpMaxFinalizers,
-              "stakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold
+              "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold
             ]
 
 instance FromJSON FinalizationCommitteeParameters where
@@ -1651,8 +1650,7 @@ instance FromJSON FinalizationCommitteeParameters where
         unless (_fcpMinFinalizers > 0) $ fail "the minimum number of finalizers must be positive."
         _fcpMaxFinalizers <- o .: "maximumFinalizers"
         unless (_fcpMaxFinalizers > _fcpMinFinalizers) $ fail "The maximum number of finalizers must be greater than minimumFinalizers."
-        _fcpFinalizerRelativeStakeThreshold <- o .: "stakeThreshold"
-        unless (_fcpFinalizerRelativeStakeThreshold > 0) $ fail "stake threshold must be positive."
+        _fcpFinalizerRelativeStakeThreshold <- o .: "finalizerRelativeStakeThreshold"
         return FinalizationCommitteeParameters{..}
 
 -- * Consensus parameters
@@ -1931,7 +1929,7 @@ parseJSONForCPV2 =
         _fcpMinFinalizers <- v .: "minimumFinalizers"
         _fcpMaxFinalizers <- v .: "maximumFinalizers"
 
-        _fcpFinalizerRelativeStakeThreshold <- v .: "stakeThreshold"
+        _fcpFinalizerRelativeStakeThreshold <- v .: "finalizerRelativeStakeThreshold"
         let _cpCooldownParameters = CooldownParametersV1{..}
             _cpTimeParameters = SomeParam TimeParametersV1{..}
             _cpPoolParameters = PoolParametersV1{..}
@@ -2010,7 +2008,7 @@ instance forall cpv. IsChainParametersVersion cpv => ToJSON (ChainParameters' cp
                   "blockEnergyLimit" AE..= _cpBlockEnergyLimit _cpConsensusParameters,
                   "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam _cpFinalizationCommitteeParameters),
                   "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam _cpFinalizationCommitteeParameters),
-                  "stakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam _cpFinalizationCommitteeParameters)
+                  "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam _cpFinalizationCommitteeParameters)
                 ]
 
 -- |Parameters that affect finalization.

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -33,6 +33,7 @@ import Concordium.Types.Parameters (
     AuthorizationsVersionFor,
     ChainParameters',
     CooldownParameters,
+    FinalizationCommitteeParameters,
     GASRewards,
     GASRewardsVersion (..),
     MintDistribution,
@@ -620,6 +621,8 @@ data PendingUpdateEffect
       PUEMinBlockTime !Duration
     | -- |Updates to the block energy limit for chain parameters version 2.
       PUEBlockEnergyLimit !Energy
+    | -- |Updates to the finalization committee parameters for chain parameters version 2.
+      PUEFinalizationCommitteeParameters !FinalizationCommitteeParameters
 
 -- | Next available sequence numbers for updating any of the chain parameters.
 data NextUpdateSequenceNumbers = NextUpdateSequenceNumbers
@@ -660,7 +663,9 @@ data NextUpdateSequenceNumbers = NextUpdateSequenceNumbers
       -- |Updates to the consensus version 2 minimum time between blocks.
       _nusnMinBlockTime :: !U.UpdateSequenceNumber,
       -- |Updates to the consensus version 2 block energy limit.
-      _nusnBlockEnergyLimit :: !U.UpdateSequenceNumber
+      _nusnBlockEnergyLimit :: !U.UpdateSequenceNumber,
+      -- |Updates to the consensus version 2 finalization committee parameters
+      _nusnFinalizationCommitteeParameters :: !U.UpdateSequenceNumber
     }
     deriving (Show, Eq)
 
@@ -687,7 +692,8 @@ updateQueuesNextSequenceNumbers UQ.PendingUpdates{..} =
           _nusnTimeParameters = mNextSequenceNumber _pTimeParametersQueue,
           _nusnTimeoutParameters = mNextSequenceNumber _pTimeoutParametersQueue,
           _nusnMinBlockTime = mNextSequenceNumber _pMinBlockTimeQueue,
-          _nusnBlockEnergyLimit = mNextSequenceNumber _pBlockEnergyLimitQueue
+          _nusnBlockEnergyLimit = mNextSequenceNumber _pBlockEnergyLimitQueue,
+          _nusnFinalizationCommitteeParameters = mNextSequenceNumber _pFinalizationCommitteeParametersQueue
         }
   where
     -- Get the next sequence number or 1, if not supported.

--- a/haskell-src/Concordium/Types/Updates.hs
+++ b/haskell-src/Concordium/Types/Updates.hs
@@ -967,7 +967,7 @@ extractKeysIndices p =
         TimeoutParametersUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
         MinBlockTimeUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
         BlockEnergyLimitUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
-        FinalizationCommitteeParametersUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
+        FinalizationCommitteeParametersUpdatePayload{} -> getLevel2KeysAndThreshold asPoolParameters
   where
     getLevel2KeysAndThreshold accessStructure = (\AccessStructure{..} -> (accessPublicKeys, accessThreshold)) . accessStructure . level2Keys
     getOptionalLevel2KeysAndThreshold accessStructure = keysForOParam . accessStructure . level2Keys

--- a/haskell-src/Concordium/Types/Updates.hs
+++ b/haskell-src/Concordium/Types/Updates.hs
@@ -187,7 +187,9 @@ data Authorizations (auv :: AuthorizationsVersion) = Authorizations
       -- |Parameter keys: Cooldown periods for pool owners and delegators
       asCooldownParameters :: !(Conditionally (SupportsCooldownParametersAccessStructure auv) AccessStructure),
       -- |Parameter keys: Length of reward period / payday
-      asTimeParameters :: !(Conditionally (SupportsTimeParameters auv) AccessStructure)
+      asTimeParameters :: !(Conditionally (SupportsTimeParameters auv) AccessStructure),
+      -- |Parameter keys: Finalization committee parameters
+      asFinalizationCommitteeParameters :: !(Conditionally (SupportsFinalizationCommitteeParameters auv) AccessStructure)
     }
 
 deriving instance Eq (Authorizations auv)
@@ -211,6 +213,7 @@ putAuthorizations Authorizations{..} = do
     put asAddIdentityProvider
     mapM_ put asCooldownParameters
     mapM_ put asTimeParameters
+    mapM_ put asFinalizationCommitteeParameters
 
 getAuthorizations :: forall auv. IsAuthorizationsVersion auv => Get (Authorizations auv)
 getAuthorizations = label "deserialization update authorizations" $ do
@@ -237,6 +240,7 @@ getAuthorizations = label "deserialization update authorizations" $ do
     asAddIdentityProvider <- getChecked
     asCooldownParameters <- conditionallyA (sSupportsCooldownParametersAccessStructure (sing @auv)) getChecked
     asTimeParameters <- conditionallyA (sSupportsTimeParameters (sing @auv)) getChecked
+    asFinalizationCommitteeParameters <- conditionallyA (sSupportsFinalizationCommitteeParameters (sing @auv)) getChecked
     return Authorizations{..}
 
 instance IsAuthorizationsVersion auv => Serialize (Authorizations auv) where
@@ -281,6 +285,7 @@ parseAuthorizationsJSON = AE.withObject "Authorizations" $ \v -> do
     let auv = sing @auv
     asCooldownParameters <- conditionallyA (sSupportsCooldownParametersAccessStructure auv) $ parseAS "cooldownParameters"
     asTimeParameters <- conditionallyA (sSupportsTimeParameters auv) $ parseAS "timeParameters"
+    asFinalizationCommitteeParameters <- conditionallyA (sSupportsFinalizationCommitteeParameters auv) $ parseAS "finalizationCommitteeParameters"
     return Authorizations{..}
 
 instance IsAuthorizationsVersion auv => AE.FromJSON (Authorizations auv) where
@@ -306,6 +311,7 @@ instance IsAuthorizationsVersion auv => AE.ToJSON (Authorizations auv) where
               ]
                 ++ cooldownParameters
                 ++ timeParameters'
+                ++ finalizationCommitteeParameters
             )
       where
         t AccessStructure{..} =
@@ -315,6 +321,7 @@ instance IsAuthorizationsVersion auv => AE.ToJSON (Authorizations auv) where
                 ]
         cooldownParameters = foldMap (\as -> ["cooldownParameters" AE..= t as]) asCooldownParameters
         timeParameters' = foldMap (\as -> ["timeParameters" AE..= t as]) asTimeParameters
+        finalizationCommitteeParameters = foldMap (\as -> ["finalizationCommitteeParameters" AE..= t as]) asFinalizationCommitteeParameters
 
 -----------------
 
@@ -685,6 +692,8 @@ data UpdateType
       UpdateMinBlockTime
     | -- |Update block energy limit for consensus version 2
       UpdateBlockEnergyLimit
+    | -- |Update the finalization committee parameters for consensus version 2
+      UpdateFinalizationCommitteeParameters
     deriving (Eq, Ord, Show, Ix, Bounded, Enum)
 
 -- The JSON instance will encode all values as strings, lower-casing the first
@@ -717,6 +726,7 @@ instance Serialize UpdateType where
     put UpdateTimeoutParameters = putWord8 17
     put UpdateMinBlockTime = putWord8 18
     put UpdateBlockEnergyLimit = putWord8 19
+    put UpdateFinalizationCommitteeParameters = putWord8 20
     get =
         getWord8 >>= \case
             1 -> return UpdateProtocol
@@ -738,6 +748,7 @@ instance Serialize UpdateType where
             17 -> return UpdateTimeoutParameters
             18 -> return UpdateMinBlockTime
             19 -> return UpdateBlockEnergyLimit
+            20 -> return UpdateFinalizationCommitteeParameters
             n -> fail $ "invalid update type: " ++ show n
 
 -- |Sequence number for updates of a given type.
@@ -828,6 +839,8 @@ data UpdatePayload
       BlockEnergyLimitUpdatePayload !Energy
     | -- |Update the GAS rewards (chain parameters version 2)
       GASRewardsCPV2UpdatePayload !(GASRewards 'GASRewardsVersion1)
+    | -- |Update the finalization committee parameters (chain parameters version 2)
+      FinalizationCommitteeParametersUpdatePayload !FinalizationCommitteeParameters
     deriving (Eq, Show)
 
 putUpdatePayload :: Putter UpdatePayload
@@ -852,6 +865,7 @@ putUpdatePayload (TimeoutParametersUpdatePayload u) = putWord8 18 >> put u
 putUpdatePayload (MinBlockTimeUpdatePayload u) = putWord8 19 >> put u
 putUpdatePayload (BlockEnergyLimitUpdatePayload u) = putWord8 20 >> put u
 putUpdatePayload (GASRewardsCPV2UpdatePayload u) = putWord8 21 >> put u
+putUpdatePayload (FinalizationCommitteeParametersUpdatePayload u) = putWord8 22 >> put u
 
 getUpdatePayload :: SProtocolVersion pv -> Get UpdatePayload
 getUpdatePayload spv =
@@ -891,6 +905,7 @@ getUpdatePayload spv =
         19 | isSupported PTMinBlockTime cpv -> MinBlockTimeUpdatePayload <$> get
         20 | isSupported PTBlockEnergyLimit cpv -> BlockEnergyLimitUpdatePayload <$> get
         21 | GASRewardsVersion1 <- gasRewardsVersionFor cpv -> GASRewardsCPV2UpdatePayload <$> get
+        22 | isSupported PTFinalizationCommitteeParameters cpv -> FinalizationCommitteeParametersUpdatePayload <$> get
         x -> fail $ "Unknown update payload kind: " ++ show x
   where
     scpv = sChainParametersVersionFor spv
@@ -932,6 +947,7 @@ updateType (Level1UpdatePayload Level2KeysLevel1UpdateV1{}) = UpdateLevel2Keys
 updateType TimeoutParametersUpdatePayload{} = UpdateTimeoutParameters
 updateType MinBlockTimeUpdatePayload{} = UpdateMinBlockTime
 updateType BlockEnergyLimitUpdatePayload{} = UpdateBlockEnergyLimit
+updateType FinalizationCommitteeParametersUpdatePayload{} = UpdateFinalizationCommitteeParameters
 
 -- |Extract the relevant set of key indices and threshold authorized for the given update instruction.
 extractKeysIndices :: UpdatePayload -> UpdateKeysCollection cpv -> (Set.Set UpdateKeyIndex, UpdateKeysThreshold)
@@ -958,6 +974,7 @@ extractKeysIndices p =
         TimeoutParametersUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
         MinBlockTimeUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
         BlockEnergyLimitUpdatePayload{} -> getLevel2KeysAndThreshold asParamConsensusParameters
+        FinalizationCommitteeParametersUpdatePayload{} -> getOptionalLevel2KeysAndThreshold asFinalizationCommitteeParameters
   where
     getLevel2KeysAndThreshold accessStructure = (\AccessStructure{..} -> (accessPublicKeys, accessThreshold)) . accessStructure . level2Keys
     getOptionalLevel2KeysAndThreshold accessStructure = keysForOParam . accessStructure . level2Keys

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -374,6 +374,7 @@ genChainParametersV0 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV0
+    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
 
 genChainParametersV1 :: Gen (ChainParameters' 'ChainParametersV1)
@@ -386,6 +387,7 @@ genChainParametersV1 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
+    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
 
 genConsensusParametersV1 ::
@@ -406,6 +408,7 @@ genChainParametersV2 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
+    _cpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return ChainParameters{..}
 
 genGenesisChainParametersV0 :: Gen (GenesisChainParameters' 'ChainParametersV0)
@@ -418,6 +421,7 @@ genGenesisChainParametersV0 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV0
+    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV1 :: Gen (GenesisChainParameters' 'ChainParametersV1)
@@ -430,6 +434,7 @@ genGenesisChainParametersV1 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
+    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV2 :: Gen (GenesisChainParameters' 'ChainParametersV2)
@@ -442,6 +447,7 @@ genGenesisChainParametersV2 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
+    gcpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return GenesisChainParameters{..}
 
 genCooldownParametersV0 :: Gen (CooldownParameters' 'CooldownParametersVersion0)
@@ -499,6 +505,13 @@ genTimeoutParameters = do
     _tpTimeoutIncrease <- genTimeoutIncrease
     _tpTimeoutDecrease <- genTimeoutDecrease
     return TimeoutParameters{..}
+
+genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
+genFinalizationCommitteeParameters = do
+    _fcpMinFinalizers <- choose (20, 100)
+    _fcpMaxFinalizers <- choose (200, 800)
+    _fcpFinalizerThreshold <- genAmount
+    return FinalizationCommitteeParameters{..}
 
 transactionTypes :: [TransactionType]
 transactionTypes =

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -393,7 +393,7 @@ genChainParametersV1 = do
 genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
 genFinalizationCommitteeParameters = do
     _fcpMinFinalizers <- choose (20, 100)
-    _fcpMaxFinalizers <- choose (200, 800)
+    _fcpMaxFinalizers <- choose (100, 800)
     _fcpFinalizerRelativeStakeThreshold <- arbitrary
     return FinalizationCommitteeParameters{..}
 

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -374,7 +374,6 @@ genChainParametersV0 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV0
-    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
 
 genChainParametersV1 :: Gen (ChainParameters' 'ChainParametersV1)
@@ -387,8 +386,14 @@ genChainParametersV1 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
-    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
+
+genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
+genFinalizationCommitteeParameters = do
+    _fcpMinFinalizers <- choose (20, 100)
+    _fcpMaxFinalizers <- choose (200, 800)
+    _fcpFinalizerThreshold <- genAmount
+    return FinalizationCommitteeParameters{..}
 
 genConsensusParametersV1 ::
     Gen (ConsensusParameters' 'ConsensusParametersVersion1)
@@ -396,6 +401,7 @@ genConsensusParametersV1 = do
     _cpTimeoutParameters <- genTimeoutParameters
     _cpMinBlockTime <- genDuration
     _cpBlockEnergyLimit <- Energy <$> arbitrary
+    _cpFinalizationCommitteeParameters <- genFinalizationCommitteeParameters
     return ConsensusParametersV1{..}
 
 genChainParametersV2 :: Gen (ChainParameters' 'ChainParametersV2)
@@ -408,7 +414,6 @@ genChainParametersV2 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
-    _cpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return ChainParameters{..}
 
 genGenesisChainParametersV0 :: Gen (GenesisChainParameters' 'ChainParametersV0)
@@ -421,7 +426,6 @@ genGenesisChainParametersV0 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV0
-    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV1 :: Gen (GenesisChainParameters' 'ChainParametersV1)
@@ -434,7 +438,6 @@ genGenesisChainParametersV1 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
-    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV2 :: Gen (GenesisChainParameters' 'ChainParametersV2)
@@ -447,7 +450,6 @@ genGenesisChainParametersV2 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
-    gcpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return GenesisChainParameters{..}
 
 genCooldownParametersV0 :: Gen (CooldownParameters' 'CooldownParametersVersion0)
@@ -505,13 +507,6 @@ genTimeoutParameters = do
     _tpTimeoutIncrease <- genTimeoutIncrease
     _tpTimeoutDecrease <- genTimeoutDecrease
     return TimeoutParameters{..}
-
-genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
-genFinalizationCommitteeParameters = do
-    _fcpMinFinalizers <- choose (20, 100)
-    _fcpMaxFinalizers <- choose (200, 800)
-    _fcpFinalizerThreshold <- genAmount
-    return FinalizationCommitteeParameters{..}
 
 transactionTypes :: [TransactionType]
 transactionTypes =

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -374,6 +374,7 @@ genChainParametersV0 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV0
+    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
 
 genChainParametersV1 :: Gen (ChainParameters' 'ChainParametersV1)
@@ -386,13 +387,14 @@ genChainParametersV1 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
+    let _cpFinalizationCommitteeParameters = NoParam
     return ChainParameters{..}
 
 genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
 genFinalizationCommitteeParameters = do
     _fcpMinFinalizers <- choose (20, 100)
     _fcpMaxFinalizers <- choose (200, 800)
-    _fcpFinalizerThreshold <- genAmount
+    _fcpStakeThreshold <- genAmount
     return FinalizationCommitteeParameters{..}
 
 genConsensusParametersV1 ::
@@ -414,6 +416,7 @@ genChainParametersV2 = do
     _cpRewardParameters <- genRewardParameters
     _cpFoundationAccount <- AccountIndex <$> arbitrary
     _cpPoolParameters <- genPoolParametersV1
+    _cpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return ChainParameters{..}
 
 genGenesisChainParametersV0 :: Gen (GenesisChainParameters' 'ChainParametersV0)
@@ -426,6 +429,7 @@ genGenesisChainParametersV0 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV0
+    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV1 :: Gen (GenesisChainParameters' 'ChainParametersV1)
@@ -438,6 +442,7 @@ genGenesisChainParametersV1 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
+    let gcpFinalizationCommitteeParameters = NoParam
     return GenesisChainParameters{..}
 
 genGenesisChainParametersV2 :: Gen (GenesisChainParameters' 'ChainParametersV2)
@@ -450,6 +455,7 @@ genGenesisChainParametersV2 = do
     gcpRewardParameters <- genRewardParameters
     gcpFoundationAccount <- genAccountAddress
     gcpPoolParameters <- genPoolParametersV1
+    gcpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return GenesisChainParameters{..}
 
 genCooldownParametersV0 :: Gen (CooldownParameters' 'CooldownParametersVersion0)

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -394,7 +394,7 @@ genFinalizationCommitteeParameters :: Gen FinalizationCommitteeParameters
 genFinalizationCommitteeParameters = do
     _fcpMinFinalizers <- choose (20, 100)
     _fcpMaxFinalizers <- choose (200, 800)
-    _fcpStakeThreshold <- genAmount
+    _fcpFinalizerRelativeStakeThreshold <- arbitrary
     return FinalizationCommitteeParameters{..}
 
 genConsensusParametersV1 ::


### PR DESCRIPTION
## Purpose

Addresses https://github.com/Concordium/concordium-base/issues/303


## Changes

Added a new `FinalizationCommitteeParameters` structure for holding the parameters deciding which bakers gets to join the finalization committee for the new consensus protocol.

In particular it holds the following: 

- Minimum number of bakers that should reside in the finalization committee. `minFinalizers`
- Maximum number of bakers allowed to join the finalization committee. `maxFinalizers`
- A threshold that together with the total staked ccd constitutes the minimum stake requirement for joining the finalization committee.

- Added the corresponding update queue
- Added the associated update and update payload types
- Supporting the updated grpc2 api https://github.com/Concordium/concordium-grpc-api/pull/35

**The parameters are controlled by the same authorization that controls the pool parameters**
## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
