### PR TITLE
remove Display trait

### DIFF
--- a/rust-src/curve_arithmetic/src/curve_arithmetic.rs
+++ b/rust-src/curve_arithmetic/src/curve_arithmetic.rs
@@ -4,7 +4,7 @@ use ff::{Field, PrimeField};
 use rand::*;
 use std::{
     borrow::Borrow,
-    fmt::{Debug, Display},
+    fmt::{Debug},
 };
 use thiserror::Error;
 
@@ -19,7 +19,7 @@ pub enum CurveDecodingError {
 /// prime order size. More correctly this would be called a group, since it is
 /// generally a subset of an elliptic curve, but the name is in use now.
 pub trait Curve:
-    Serialize + Copy + Clone + Sized + Send + Sync + Debug + Display + PartialEq + Eq + 'static {
+    Serialize + Copy + Clone + Sized + Send + Sync + Debug + PartialEq + Eq + 'static {
     /// The prime field of the group order size.
     type Scalar: PrimeField + Field + Serialize;
     /// The base field of the curve. In general larger than the Scalar field.

--- a/rust-src/curve_arithmetic/src/curve_arithmetic.rs
+++ b/rust-src/curve_arithmetic/src/curve_arithmetic.rs
@@ -2,10 +2,7 @@ use byteorder::ReadBytesExt;
 use crypto_common::{Serial, Serialize};
 use ff::{Field, PrimeField};
 use rand::*;
-use std::{
-    borrow::Borrow,
-    fmt::{Debug},
-};
+use std::{borrow::Borrow, fmt::Debug};
 use thiserror::Error;
 
 #[derive(Error, Debug)]


### PR DESCRIPTION
## Purpose

Remove the unnecessary `Display` supertrait from the `Curve` trait in `curve_arithmetics`.

## Changes

Remove the `Display` supertrait from the `Curve` trait. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.