### PR TITLE
A bit of documentation and make the inner hash field public.

### DIFF
--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -18,9 +18,9 @@ use thiserror::Error;
 /// same, but the phantom type variable makes it impossible to mistakenly misuse
 /// the hashes.
 pub struct HashBytes<Purpose> {
-    pub(crate) bytes: [u8; SHA256 as usize],
+    pub bytes: [u8; SHA256 as usize],
     #[serde(skip)] // use default when deserializing
-    _phantom:         PhantomData<Purpose>,
+    _phantom:  PhantomData<Purpose>,
 }
 
 impl<Purpose> PartialEq for HashBytes<Purpose> {

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -1395,7 +1395,9 @@ pub fn sign_transaction<S: TransactionSigner, P: PayloadLike>(
 /// Implementations of this trait are structures which can produce public keys
 /// with which transaction signatures can be verified.
 pub trait HasAccountAccessStructure {
+    /// The number of credentials that must sign a transaction.
     fn threshold(&self) -> AccountThreshold;
+    /// Access a credential at the provided index.
     fn credential_keys(&self, idx: CredentialIndex) -> Option<&CredentialPublicKeys>;
 }
 


### PR DESCRIPTION
## Purpose

Allow for accessing the byte array of the hash directly.

There is no reason to hide this since the SHA256 hash will not change.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.