### PR TITLE
Extend default ID expirty to 2030.

### DIFF
--- a/identity-provider-service/CHANGELOG.md
+++ b/identity-provider-service/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+- Extend default ID doc expiry to 2030.
+
 ## 0.5.1
 
 - Do not count existing requests without issued identities as duplicate.

--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -813,7 +813,7 @@ dependencies = [
 
 [[package]]
 name = "identity-provider-service"
-version = "0.5.1"
+version = "0.5.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/identity-provider-service/Cargo.toml
+++ b/identity-provider-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-provider-service"
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -97,7 +97,7 @@ world scenario the attributes will be derived from the identity verification pro
         <input type="text" id="idDocIssuedAt" name="idDocIssuedAt" value="20200101">
 
         <label for="idDocExpiresAt">Identity document expires at (ISO8601 YYYYMMDD)</label>
-        <input type="text" id="idDocExpiresAt" name="idDocExpiresAt" value="20211231">
+        <input type="text" id="idDocExpiresAt" name="idDocExpiresAt" value="20300101">
 
         <label for="nationalIdNo">National id no</label>
         <input type="text" id="nationalIdNo" name="nationalIdNo" value="N-1234">


### PR DESCRIPTION
## Purpose

Extend default ID doc expiry in ID verifier to 2030.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
