### PR TITLE
Release updated version of smart-contracts-engine.

### DIFF
--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased changes
 
+## concordium-smart-contract-engine 1.0.1 (2023-03-20)
+
+- Bump concordium-contracts-common dependency to 5.3.
+
 ## concordium-smart-contract-engine 1.0.0 (2023-02-03)
 
 - Initial release.

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -329,7 +329,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-smart-contract-engine"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arbitrary",

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-smart-contract-engine"
-version = "1.0.0"
+version = "1.0.1"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE"
@@ -45,7 +45,7 @@ path = "../wasm-transform"
 version = "1"
 
 [dependencies.concordium-contracts-common]
-version = "5"
+version = ">= 5.3"
 path = "../../concordium-contracts-common/concordium-contracts-common"
 features = ["derive-serde"]
 


### PR DESCRIPTION
## Purpose

The sc-engine version 1.0.0 only works with ccc 5.2 due to renamings.

This release fixes that issue and allows the release of concordium-rust-sdk.
