### PR TITLE
Add Serialization for Proof and Statement types.

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Unreleased changes
 
+## 1.1.1 (2023-04-13)
+
+- Add Serialize instances to `Proof` and `Statement` types, and its constituent
+  parts (`AtomicProof` and `AtomicStatement`).
+- `Deserial` for `BTreeMap` and `BTreeSet` no longer requires `Copy`.
+
 ## 1.1.0 (2023-04-12)
 
 - Additions to `Energy` type:

--- a/rust-src/concordium_base/src/common/serialize.rs
+++ b/rust-src/concordium_base/src/common/serialize.rs
@@ -174,6 +174,24 @@ impl<T: Deserial> Deserial for Vec<T> {
     }
 }
 
+/// Read a set where the first 8 bytes are taken as length in big endian.
+/// The values must be serialized in strictly increasing order.
+impl<T: Deserial + std::cmp::Ord> Deserial for BTreeSet<T> {
+    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
+        let len: u64 = u64::deserial(source)?;
+        deserial_set_no_length(source, usize::try_from(len)?)
+    }
+}
+
+/// Read a map where the first 8 bytes are taken as length in big endian.
+/// The values must be serialized in strictly increasing order of keys.
+impl<K: Deserial + std::cmp::Ord, V: Deserial> Deserial for BTreeMap<K, V> {
+    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
+        let len: u64 = u64::deserial(source)?;
+        deserial_map_no_length(source, usize::try_from(len)?)
+    }
+}
+
 impl<T: Deserial, U: Deserial> Deserial for (T, U) {
     #[inline]
     fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
@@ -426,6 +444,24 @@ impl<T: Serial> Serial for Vec<T> {
     }
 }
 
+/// Serialize a set by encoding its size as a u64 in big endian and then
+/// the list of elements in increasing order.
+impl<V: Serial> Serial for BTreeSet<V> {
+    fn serial<B: Buffer>(&self, out: &mut B) {
+        (self.len() as u64).serial(out);
+        serial_set_no_length(self, out)
+    }
+}
+
+/// Serialize a map by encoding its size as a u64 in big endian and then
+/// the list of key-value pairs in increasing order of keys.
+impl<K: Serial, V: Serial> Serial for BTreeMap<K, V> {
+    fn serial<B: Buffer>(&self, out: &mut B) {
+        (self.len() as u64).serial(out);
+        serial_map_no_length(self, out)
+    }
+}
+
 /// Serialize all of the elements in the iterator.
 pub fn serial_iter<'a, B: Buffer, T: Serial + 'a, I: Iterator<Item = &'a T>>(xs: I, out: &mut B) {
     for x in xs {
@@ -449,7 +485,7 @@ pub fn serial_map_no_length<B: Buffer, K: Serial, V: Serial>(map: &BTreeMap<K, V
 
 /// Deserialize a map from a byte source. This ensures there are no duplicates,
 /// as well as that all keys are in strictly increasing order.
-pub fn deserial_map_no_length<R: ReadBytesExt, K: Deserial + Ord + Copy, V: Deserial>(
+pub fn deserial_map_no_length<R: ReadBytesExt, K: Deserial + Ord, V: Deserial>(
     source: &mut R,
     len: usize,
 ) -> ParseResult<BTreeMap<K, V>> {
@@ -458,19 +494,17 @@ pub fn deserial_map_no_length<R: ReadBytesExt, K: Deserial + Ord + Copy, V: Dese
     for _ in 0..len {
         let k = source.get()?;
         let v = source.get()?;
-        match x {
-            None => {
-                out.insert(k, v);
-            }
-            Some(kk) => {
-                if k > kk {
-                    out.insert(k, v);
-                } else {
-                    bail!("Keys not in order.")
-                }
+        if let Some((old_k, old_v)) = x.take() {
+            if k > old_k {
+                out.insert(old_k, old_v);
+            } else {
+                bail!("Keys not in order.")
             }
         }
-        x = Some(k);
+        x = Some((k, v));
+    }
+    if let Some((k, v)) = x {
+        out.insert(k, v);
     }
     Ok(out)
 }
@@ -485,7 +519,7 @@ pub fn serial_set_no_length<B: Buffer, K: Serial>(map: &BTreeSet<K>, out: &mut B
 /// Analogous to [deserial_map_no_length], but for sets.
 /// NB: This ensures there are no duplicates, and that all the keys are in
 /// strictly increasing order.
-pub fn deserial_set_no_length<R: ReadBytesExt, K: Deserial + Ord + Copy>(
+pub fn deserial_set_no_length<R: ReadBytesExt, K: Deserial + Ord>(
     source: &mut R,
     len: usize,
 ) -> ParseResult<BTreeSet<K>> {
@@ -493,19 +527,17 @@ pub fn deserial_set_no_length<R: ReadBytesExt, K: Deserial + Ord + Copy>(
     let mut x = None;
     for _ in 0..len {
         let k = source.get()?;
-        match x {
-            None => {
-                out.insert(k);
-            }
-            Some(kk) => {
-                if k > kk {
-                    out.insert(k);
-                } else {
-                    bail!("Keys not in order.")
-                }
+        if let Some(old_k) = x.take() {
+            if k > old_k {
+                out.insert(old_k);
+            } else {
+                bail!("Keys not in order.")
             }
         }
         x = Some(k);
+    }
+    if let Some(k) = x {
+        out.insert(k);
     }
     Ok(out)
 }


### PR DESCRIPTION
Remove the need for Copy in deserializing BTreeMap and BTreeSet.

## Purpose

The serialization is needed in some examples when efficiently storing proofs.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.