### PR TITLE
Update Rust fmt to `2023-04-01`

### DIFF
--- a/.github/workflows/build-test-smart-contracts.yaml
+++ b/.github/workflows/build-test-smart-contracts.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch: # allows manual trigger
 
 env:
-  RUST_FMT: nightly-2022-06-09-x86_64-unknown-linux-gnu
+  RUST_FMT: nightly-2023-04-01-x86_64-unknown-linux-gnu
   RUST_CLIPPY: 1.68
 
 jobs:

--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: "nightly-2022-06-09-x86_64-unknown-linux-gnu"
+        - rust: "nightly-2023-04-01-x86_64-unknown-linux-gnu"
 
     steps:
     - name: Checkout

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -372,7 +372,7 @@ pub enum ConfigureBakerKeysMarker {}
 /// markers: `AddBakerKeysMarker` and `UpdateBakerKeysMarker`.
 pub struct BakerKeysPayload<V> {
     #[serde(skip)] // use default when deserializing
-    phantom:                    PhantomData<V>,
+    phantom: PhantomData<V>,
     /// New public key for participating in the election lottery.
     pub election_verify_key:    BakerElectionVerifyKey,
     /// New public key for verifying this baker's signatures.

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -270,7 +270,7 @@ pub struct HigherLevelAccessStructure<Kind> {
     pub keys:      Vec<UpdatePublicKey>,
     pub threshold: UpdateKeysThreshold,
     #[serde(skip)] // use default when deserializing
-    pub _phantom:  PhantomData<Kind>,
+    pub _phantom: PhantomData<Kind>,
 }
 
 impl<Kind> Deserial for HigherLevelAccessStructure<Kind> {


### PR DESCRIPTION
## Purpose

Update Rust fmt to `2023-04-01` to match other Rust repos

## Changes

- Update version in CI jobs
- Fix minor formatting issues

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.