### PR TITLE
Add types for P6 GenesisData

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-- Implement Serial for `num::rational::Ratio<u64>` and `Duration`.
+- Implement `Serial` and `Deserial` for `num::rational::Ratio<u64>` and `Duration`.
 - Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
 
 ## 1.2.0 (2023-05-08)

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased changes
 
 - Implement Serial for `num::rational::Ratio<u64>` and `Duration`.
-- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
+- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
 
 ## 1.2.0 (2023-05-08)
 

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased changes
 
+- Extend types `UpdatePayload` and `UpdateType` with variants introduced in protocol version 6.
 - Implement `Serial` and `Deserial` for `num::rational::Ratio<u64>` and `Duration`.
-- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
+- Introduce types for protocol version 6: `Ratio`, `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
 
 ## 1.2.0 (2023-05-08)
 

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased changes
 
+- Implement Serial for `num::rational::Ratio<u64>` and `Duration`.
+- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
+
 ## 1.2.0 (2023-05-08)
 
 - Add helpers to extract policy from credentials.

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     pedersen_commitment::{Randomness, Value},
     random_oracle::RandomOracle,
-    updates::{GASRewards, GASRewardsV1},
+    updates::{GASRewards, GASRewardsCPV2},
 };
 use concordium_contracts_common::AccountAddress;
 pub use concordium_contracts_common::{
@@ -1166,7 +1166,7 @@ impl GASRewardsFamily for ChainParameterVersion1 {
 }
 
 impl GASRewardsFamily for ChainParameterVersion2 {
-    type Output = GASRewardsV1;
+    type Output = GASRewardsCPV2;
 }
 
 pub type GASRewardsFor<CPV> = <CPV as GASRewardsFamily>::Output;

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -1135,6 +1135,7 @@ impl Deserial for MintDistributionV1 {
     }
 }
 
+/// Trait used to define mapping from a type to a `MintDistribution` type.
 pub trait MintDistributionFamily {
     type Output;
 }
@@ -1151,8 +1152,11 @@ impl MintDistributionFamily for ChainParameterVersion2 {
     type Output = MintDistributionV1;
 }
 
+/// Type family mapping a `ChainParameterVersion` to its corresponding type for
+/// the `MintDistribution`.
 pub type MintDistribution<CPV> = <CPV as MintDistributionFamily>::Output;
 
+/// Trait used to define mapping from a type to a `GasRewards` type.
 pub trait GASRewardsFamily {
     type Output;
 }
@@ -1169,6 +1173,8 @@ impl GASRewardsFamily for ChainParameterVersion2 {
     type Output = GASRewardsCPV2;
 }
 
+/// Type family mapping a `ChainParameterVersion` to its corresponding type for
+/// the `GasRewards`.
 pub type GASRewardsFor<CPV> = <CPV as GASRewardsFamily>::Output;
 
 #[derive(Debug, Serialize, Clone, Copy)]

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     pedersen_commitment::{Randomness, Value},
     random_oracle::RandomOracle,
+    updates::{GASRewards, GASRewardsV1},
 };
 use concordium_contracts_common::AccountAddress;
 pub use concordium_contracts_common::{
@@ -493,6 +494,7 @@ impl Deserial for ProtocolVersion {
 
 pub struct ChainParameterVersion0;
 pub struct ChainParameterVersion1;
+pub struct ChainParameterVersion2;
 
 /// Height of a block since chain genesis.
 #[repr(transparent)]
@@ -1145,7 +1147,29 @@ impl MintDistributionFamily for ChainParameterVersion1 {
     type Output = MintDistributionV1;
 }
 
+impl MintDistributionFamily for ChainParameterVersion2 {
+    type Output = MintDistributionV1;
+}
+
 pub type MintDistribution<CPV> = <CPV as MintDistributionFamily>::Output;
+
+pub trait GASRewardsFamily {
+    type Output;
+}
+
+impl GASRewardsFamily for ChainParameterVersion0 {
+    type Output = GASRewards;
+}
+
+impl GASRewardsFamily for ChainParameterVersion1 {
+    type Output = GASRewards;
+}
+
+impl GASRewardsFamily for ChainParameterVersion2 {
+    type Output = GASRewardsV1;
+}
+
+pub type GASRewardsFor<CPV> = <CPV as GASRewardsFamily>::Output;
 
 #[derive(Debug, Serialize, Clone, Copy)]
 /// Rate of creation of new CCDs. For example, A value of `0.05` would mean an

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     pedersen_commitment::{Randomness, Value},
     random_oracle::RandomOracle,
-    updates::{GASRewards, GASRewardsCPV2},
+    updates::{GASRewards, GASRewardsV1},
 };
 use concordium_contracts_common::AccountAddress;
 pub use concordium_contracts_common::{
@@ -1170,7 +1170,7 @@ impl GASRewardsFamily for ChainParameterVersion1 {
 }
 
 impl GASRewardsFamily for ChainParameterVersion2 {
-    type Output = GASRewardsCPV2;
+    type Output = GASRewardsV1;
 }
 
 /// Type family mapping a `ChainParameterVersion` to its corresponding type for

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -587,7 +587,7 @@ pub struct PoolParameters {
 /// in the finalization committee.
 pub struct FinalizationCommitteeParameters {
     /// Minimum number of bakers to include in the finalization committee before
-    /// the '_fcpFinalizerRelativeStakeThreshold' takes effect.
+    /// the 'finalizer_relative_stake_threshold' takes effect.
     pub min_finalizers: u32,
     /// Maximum number of bakers to include in the finalization committee.
     pub max_finalizers: u32,

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -161,7 +161,7 @@ pub struct GASRewards {
 #[serde(rename_all = "camelCase")]
 /// The reward fractions related to the gas account and inclusion of special
 /// transactions.
-pub struct GASRewardsV1 {
+pub struct GASRewardsCPV2 {
     /// `BakerPrevTransFrac`: fraction of the previous gas account paid to the
     /// baker.
     pub baker:            AmountFraction,

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -15,6 +15,7 @@ use crate::{
     transactions::PayloadSize,
 };
 use derive_more::*;
+use num::rational::Ratio;
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -154,6 +155,22 @@ pub struct GASRewards {
     /// `FeeUpdate`: fraction paid for including an update transaction in a
     /// block.
     pub chain_update:       AmountFraction,
+}
+
+#[derive(Debug, SerdeSerialize, SerdeDeserialize, common::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+/// The reward fractions related to the gas account and inclusion of special
+/// transactions.
+pub struct GASRewardsV1 {
+    /// `BakerPrevTransFrac`: fraction of the previous gas account paid to the
+    /// baker.
+    pub baker:            AmountFraction,
+    /// `FeeAccountCreation`: fraction paid for including each account creation
+    /// transaction in a block.
+    pub account_creation: AmountFraction,
+    /// `FeeUpdate`: fraction paid for including an update transaction in a
+    /// block.
+    pub chain_update:     AmountFraction,
 }
 
 #[derive(Debug, SerdeSerialize, SerdeDeserialize, Clone)]
@@ -443,6 +460,10 @@ impl AuthorizationsFamily for ChainParameterVersion1 {
     type Output = AuthorizationsV1;
 }
 
+impl AuthorizationsFamily for ChainParameterVersion2 {
+    type Output = AuthorizationsV1;
+}
+
 /// A mapping of chain parameter versions to authorization versions.
 pub type Authorizations<CPV> = <CPV as AuthorizationsFamily>::Output;
 
@@ -463,6 +484,18 @@ pub struct CooldownParameters {
     /// Number of seconds that a delegator must cooldown
     /// when reducing their delegated stake.
     pub delegator_cooldown:  DurationSeconds,
+}
+
+/// Parameters controlling consensus timeouts for the consensus protocol version
+/// 2.
+#[derive(Debug, common::Serial, Copy, Clone)]
+pub struct TimeoutParameters {
+    /// The base value for triggering a timeout.
+    pub base:     concordium_contracts_common::Duration,
+    /// Factor for increasing the timeout. Must be greater than 1.
+    pub increase: Ratio<u64>,
+    /// Factor for decreasing the timeout. Must be between 0 and 1.
+    pub decrease: Ratio<u64>,
 }
 
 /// Length of a reward period in epochs.
@@ -520,6 +553,22 @@ pub struct PoolParameters {
     /// The maximum leverage that a baker can have as a ratio of total stake
     /// to equity capital.
     pub leverage_bound:                  LeverageFactor,
+}
+
+#[derive(Debug, common::Serial, Clone)]
+/// Finalization committee parameters. These parameters control which bakers are
+/// in the finalization committee.
+pub struct FinalizationCommitteeParameters {
+    /// Minimum number of bakers to include in the finalization committee before
+    /// the '_fcpFinalizerRelativeStakeThreshold' takes effect.
+    pub min_finalizers: u32,
+    /// Maximum number of bakers to include in the finalization committee.
+    pub max_finalizers: u32,
+    /// Determining the staking threshold required for being eligible the
+    /// finalization committee. The required amount is given by `total stake
+    /// in pools * finalizer_relative_stake_threshold` Provided as part per
+    /// hundred thousands. Accepted values are between a value of 0 and 1.
+    pub finalizers_relative_stake_threshold: PartsPerHundredThousands,
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]


### PR DESCRIPTION
## Purpose

Introduces changes needed for genesis-creator to support P6
Related to https://github.com/Concordium/concordium-misc-tools/pull/51

## Changes

- Implement `Serial` for `num::rational::Ratio<u64>` and `Duration`.
- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
