### PR TITLE
Web3id key derivation

### DIFF
--- a/mobile_wallet/CHANGELOG.md
+++ b/mobile_wallet/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.25.0
+- Added a function `get_verifiable_credential_keys` for deriving the keys for a verifiable credential.
+
 ## 0.24.0
 - Changed parameter_to_json to support parameter schemas.
 

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -744,7 +744,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "mobile_wallet"
-version = "0.24.0"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.24.0"
+version = "0.25.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -26,7 +26,7 @@ base64 = "0.13"
 
 [dependencies.key_derivation]
 path = "../rust-src/key_derivation"
-version = "1.1.0"
+version = "1.2.0"
 
 [dependencies.ed25519_hd_key_derivation]
 path = "../rust-src/ed25519_hd_key_derivation"

--- a/mobile_wallet/android/mobile_wallet_lib/src/main/java/com/concordium/mobile_wallet_lib/wallet.kt
+++ b/mobile_wallet/android/mobile_wallet_lib/src/main/java/com/concordium/mobile_wallet_lib/wallet.kt
@@ -24,7 +24,7 @@ external fun parameter_to_json(input: String) : ReturnValue
 external fun sign_message(input: String) : ReturnValue
 external fun create_account_transaction(input: String) : ReturnValue
 external fun serialize_token_transfer_parameters(input: String) : ReturnValue
-
+external fun get_verifiable_credential_keys(input: String) : ReturnValue
 
 fun loadWalletLib() {
     System.loadLibrary("mobile_wallet")

--- a/mobile_wallet/mobile_wallet.h
+++ b/mobile_wallet/mobile_wallet.h
@@ -243,6 +243,21 @@ char *get_account_keys_and_randomness(const char *input_ptr, uint8_t *success);
  * The input pointer must point to a null-terminated buffer, otherwise this
  * function will fail in unspecified ways.
  */
+char *get_verifiable_credential_keys(const char *input_ptr, uint8_t *success);
+
+/**
+ * Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+ * UTF8-encoded string. The returned string must be freed by the caller by
+ * calling the function 'free_response_string'. In case of failure the function
+ * returns an error message as the response, and sets the 'success' flag to 0.
+ *
+ * See rust-bins/wallet-notes/README.md for the description of input and output
+ * formats.
+ *
+ * # Safety
+ * The input pointer must point to a null-terminated buffer, otherwise this
+ * function will fail in unspecified ways.
+ */
 char *parameter_to_json(const char *input_ptr, uint8_t *success);
 
 /**

--- a/mobile_wallet/src/android.rs
+++ b/mobile_wallet/src/android.rs
@@ -8,7 +8,8 @@ use crate::{
     create_id_request_and_private_data_v1, create_pub_to_sec_transfer, create_sec_to_pub_transfer,
     create_transfer, decrypt_encrypted_amount, generate_accounts, generate_baker_keys,
     generate_recovery_request, get_account_keys_and_randomness, get_identity_keys_and_randomness,
-    parameter_to_json, prove_id_statement, serialize_token_transfer_parameters, sign_message,
+    get_verifiable_credential_keys, parameter_to_json, prove_id_statement,
+    serialize_token_transfer_parameters, sign_message,
 };
 use jni::{
     objects::{JClass, JString, JValue},
@@ -454,6 +455,45 @@ pub extern "system" fn Java_com_concordium_mobile_1wallet_1lib_WalletKt_get_1acc
     let mut success: u8 = 127;
     let cstr_res = unsafe {
         let unsafe_res_ptr = get_account_keys_and_randomness(input_str.as_ptr(), &mut success);
+        if unsafe_res_ptr.is_null() {
+            return wrap_return_tuple(&env, 127, "Pointer returned from crypto library was NULL");
+        }
+        CString::from_raw(unsafe_res_ptr)
+    };
+
+    match cstr_res.to_str() {
+        Ok(str_ref) => wrap_return_tuple(&env, success, str_ref),
+        Err(e) => wrap_return_tuple(
+            &env,
+            127,
+            &format!("Could not read CString from crypto library {:?}", e),
+        ),
+    }
+}
+
+#[no_mangle]
+pub extern "system" fn Java_com_concordium_mobile_1wallet_1lib_WalletKt_get_1verifiable_1credential_1keys(
+    env: JNIEnv,
+    _: JClass,
+    input: JString,
+) -> jobject {
+    let input_str = match env.get_string(input) {
+        Ok(res_str) => res_str,
+        Err(e) => {
+            return wrap_return_tuple(
+                &env,
+                127,
+                &format!(
+                    "Could not read java.lang.String given as input due to {:?}",
+                    e
+                ),
+            )
+        }
+    };
+
+    let mut success: u8 = 127;
+    let cstr_res = unsafe {
+        let unsafe_res_ptr = get_verifiable_credential_keys(input_str.as_ptr(), &mut success);
         if unsafe_res_ptr.is_null() {
             return wrap_return_tuple(&env, 127, "Pointer returned from crypto library was NULL");
         }

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -1192,6 +1192,24 @@ fn get_account_keys_and_randomness_aux(input: &str) -> anyhow::Result<String> {
     Ok(to_string(&response)?)
 }
 
+fn get_verifiable_credential_keys_aux(input: &str) -> anyhow::Result<String> {
+    let v: Value = from_str(input)?;
+    let wallet = parse_wallet_input(&v)?;
+    let verifiable_credential_index = try_get(&v, "verifiableCredentialIndex")?;
+
+    let signing_key = wallet.get_verifiable_credential_signing_key(verifiable_credential_index)?;
+    let public_key = wallet.get_verifiable_credential_public_key(verifiable_credential_index)?;
+    let encryption_key =
+        wallet.get_verifiable_credential_encryption_key(verifiable_credential_index)?;
+
+    let response = serde_json::json!({
+        "signKey": hex::encode(signing_key),
+        "verifyKey": hex::encode(public_key),
+        "encryptionKey": hex::encode(encryption_key)
+    });
+    Ok(to_string(&response)?)
+}
+
 /// Set the flag to 0, and return a newly allocated string containing
 /// the error message. The returned string is NUL terminated.
 ///
@@ -1586,6 +1604,20 @@ make_wrapper!(
     /// The input pointer must point to a null-terminated buffer, otherwise this
     /// function will fail in unspecified ways.
     => sign_message -> sign_message_aux);
+
+make_wrapper!(
+    /// Take a pointer to a NUL-terminated UTF8-string and return a NUL-terminated
+    /// UTF8-encoded string. The returned string must be freed by the caller by
+    /// calling the function 'free_response_string'. In case of failure the function
+    /// returns an error message as the response, and sets the 'success' flag to 0.
+    ///
+    /// See rust-bins/wallet-notes/README.md for the description of input and output
+    /// formats.
+    ///
+    /// # Safety
+    /// The input pointer must point to a null-terminated buffer, otherwise this
+    /// function will fail in unspecified ways.
+    => get_verifiable_credential_keys -> get_verifiable_credential_keys_aux);
 
 /// Take pointers to a NUL-terminated UTF8-string and return a u64.
 ///

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -1139,7 +1139,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",

--- a/rust-bins/wallet-notes/README.md
+++ b/rust-bins/wallet-notes/README.md
@@ -672,6 +672,29 @@ The returned value is a JSON object with the following fields:
 An example input to this request is in the file [get_account_keys_and_randomness-input.json](files/get_account_keys_and_randomness-input.json).
 An example output to this request is in the file [get_account_keys_and_randomness-output.json](files/get_account_keys_and_randomness-output.json).
 
+## get_verifiable_credential_keys
+Semantics: Deterministically derives signing key, verification key and an encryption key for a verifiable credential.
+
+This function takes as input a NUL-terminated UTF8-encoded string. The string
+must be a valid JSON object with fields
+
+- `"seed"` ... the seed used to derive keys from, as a hex string.
+
+- `"net"` ... determines whether to derive keys for Mainnet or a Testnet. Has to be "Mainnet" or "Testnet", all other values will fail. Note that the value is case sensitive.
+
+- `"verifiableCredentialIndex"` ... the index of the verifiable credential to derive keys for, a u32 value
+
+The returned value is a JSON object with the following fields:
+
+- `"signKey"` ... the verifiable credential signing key as a hex encoded string, used to sign the encrypted verifiable credential.
+
+- `"verifyKey"` ... the verifiable credential verification key as a hex encoded string, used to identify the verifiable credential.
+
+- `"encryptionKey"` ... the verifiable credential encryption key as a hex encoded string, used to encrypt the verifiable credential.
+
+An example input to this request is in the file [get_verifiable_credential_keys-input.json](files/get_verifiable_credential_keys-input.json).
+An example output to this request is in the file [get_verifiable_credential_keys-output.json](files/get_verifiable_credential_keys-output.json).
+
 ## sign_message
 Semantics: Signs a message with the provided account keys.
 

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -883,7 +883,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key_derivation"
-version = "1.1.0"
+version = "1.2.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE"

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -95,6 +95,15 @@ impl ConcordiumHdWallet {
         Ok(derivation_path)
     }
 
+    fn make_verifiable_credential_path(&self, path: &[u32]) -> Result<Vec<u32>, DeriveError> {
+        let root_path: Vec<u32> = vec![harden(1958950021), harden(self.net.net_code())];
+        let mut derivation_path = root_path;
+        for &index in path {
+            derivation_path.push(checked_harden(index)?)
+        }
+        Ok(derivation_path)
+    }
+
     /// Construct [`ConcordiumHdWallet`](Self) from a seed phrase. The intention
     /// is that the `phrase` is a single-space separated list of words.
     ///
@@ -214,6 +223,46 @@ impl ConcordiumHdWallet {
         Ok(CommitmentRandomness::new(bls_key_bytes_from_seed(
             attribute_commitment_randomness_seed,
         )))
+    }
+
+    /// Get the signing key for the verifiable credential with the given index.
+    /// The signing key is used to sign the encrypted verifiable credential,
+    /// which is necessary for it to be submitted to the storage contract.
+    pub fn get_verifiable_credential_signing_key(
+        &self,
+        verifiable_credential_index: u32,
+    ) -> Result<SecretKey, DeriveError> {
+        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 0])?;
+        let keys = derive_from_parsed_path(&path, &self.seed)?;
+        Ok(SecretKey::from_bytes(&keys.private_key)
+            .expect("The byte array has correct length, so this cannot fail."))
+    }
+
+    /// Get the public key for the verifiable credential with the given index.
+    /// The public key is used to identify the specific verifiable credential
+    /// within the registry contract.
+    /// Note that this is just a convenience wrapper. The same can be achieved
+    /// by using [`PublicKey::from`] on the result of
+    /// [`get_verifiable_credential_signing_key`](Self::get_verifiable_credential_signing_key)
+    pub fn get_verifiable_credential_public_key(
+        &self,
+        verifiable_credential_index: u32,
+    ) -> Result<PublicKey, DeriveError> {
+        let signing_key =
+            self.get_verifiable_credential_signing_key(verifiable_credential_index)?;
+        let public_key = PublicKey::from(&signing_key);
+        Ok(public_key)
+    }
+
+    /// Get the encryption key for the verifiable credential with the given
+    /// index. The encryption key is used as the key when encrypting the
+    /// verifiable credential before it is stored in the storage contract.
+    pub fn get_verifiable_credential_encryption_key(
+        &self,
+        verifiable_credential_index: u32,
+    ) -> Result<[u8; 32], DeriveError> {
+        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 2])?;
+        Ok(derive_from_parsed_path(&path, &self.seed)?.private_key)
     }
 }
 
@@ -517,5 +566,105 @@ mod tests {
                         crush open amazing screen patrol group space point ten exist slush \
                         involve unfold";
         check_seed_vector(mnemonic, "01f5bced59dec48e362f2c45b5de68b9fd6c92c6634f44d6d40aab69056506f0e35524a518034ddc1192e1dacd32c1ed3eaa3c3b131c88ed8e7e54c49a5d0998");
+    }
+
+    #[test]
+    pub fn mainnet_verifiable_credential_signing_key() {
+        let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_verifiable_credential_signing_key(1)
+            .unwrap();
+        assert_eq!(
+            hex::encode(&signing_key),
+            "875df27dc69b0ebcb3b362b00fdc95ad50353819087fa75d39ef0aa3f9a8104a"
+        );
+    }
+
+    #[test]
+    pub fn mainnet_verifiable_credential_public_key() {
+        let public_key = create_wallet(Net::Mainnet, TEST_SEED_1)
+            .get_verifiable_credential_public_key(341)
+            .unwrap();
+        assert_eq!(
+            hex::encode(public_key),
+            "49efcf3adcfc87864cba5095dbf669fd9fa4529bba3fcecb3b1c0c12285530c8"
+        );
+    }
+
+    #[test]
+    pub fn mainnet_verifiable_credential_signing_key_matches_public_key() {
+        let wallet = create_wallet(Net::Mainnet, TEST_SEED_1);
+
+        let public_key = wallet.get_verifiable_credential_public_key(0).unwrap();
+        let signing_key = wallet.get_verifiable_credential_signing_key(0).unwrap();
+        let expanded_sk = ExpandedSecretKey::from(&signing_key);
+
+        let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
+        let signature = expanded_sk.sign(&data_to_sign, &public_key);
+
+        public_key.verify(&data_to_sign, &signature).expect(
+            "The public key should be able to verify the signature, otherwise the keys do not \
+             match.",
+        );
+    }
+
+    #[test]
+    pub fn mainnet_verifiable_credential_encryption_key() {
+        let wallet = create_wallet(Net::Mainnet, TEST_SEED_1);
+        let encryption_key = wallet.get_verifiable_credential_encryption_key(97).unwrap();
+
+        assert_eq!(
+            hex::encode(encryption_key),
+            "6f16f0d1b1fede12656e953cb8483d322b98dff1c81d989b9fb5596e0515ad8a"
+        );
+    }
+
+    #[test]
+    pub fn testnet_verifiable_credential_signing_key() {
+        let signing_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_verifiable_credential_signing_key(1)
+            .unwrap();
+        assert_eq!(
+            hex::encode(&signing_key),
+            "c53e2259d321b55637952951ea56bcae336404765b85c3ba78ca22a9d06bb40f"
+        );
+    }
+
+    #[test]
+    pub fn testnet_verifiable_credential_public_key() {
+        let public_key = create_wallet(Net::Testnet, TEST_SEED_1)
+            .get_verifiable_credential_public_key(341)
+            .unwrap();
+        assert_eq!(
+            hex::encode(public_key),
+            "20a5ce34364e1f1ce619fdfb12daa806e5e86ef44971f3c9cf1ec6b8b58e27d3"
+        );
+    }
+
+    #[test]
+    pub fn testnet_verifiable_credential_signing_key_matches_public_key() {
+        let wallet = create_wallet(Net::Testnet, TEST_SEED_1);
+
+        let public_key = wallet.get_verifiable_credential_public_key(0).unwrap();
+        let signing_key = wallet.get_verifiable_credential_signing_key(0).unwrap();
+        let expanded_sk = ExpandedSecretKey::from(&signing_key);
+
+        let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
+        let signature = expanded_sk.sign(&data_to_sign, &public_key);
+
+        public_key.verify(&data_to_sign, &signature).expect(
+            "The public key should be able to verify the signature, otherwise the keys do not \
+             match.",
+        );
+    }
+
+    #[test]
+    pub fn testnet_verifiable_credential_encryption_key() {
+        let wallet = create_wallet(Net::Testnet, TEST_SEED_1);
+        let encryption_key = wallet.get_verifiable_credential_encryption_key(97).unwrap();
+
+        assert_eq!(
+            hex::encode(encryption_key),
+            "0b999118bad636ad02720d891bbd7b67adb622a5f3b30d0cd2d528fdfb4f7131"
+        );
     }
 }

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -261,7 +261,7 @@ impl ConcordiumHdWallet {
         &self,
         verifiable_credential_index: u32,
     ) -> Result<[u8; 32], DeriveError> {
-        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 2])?;
+        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 1])?;
         Ok(derive_from_parsed_path(&path, &self.seed)?.private_key)
     }
 }
@@ -614,7 +614,7 @@ mod tests {
 
         assert_eq!(
             hex::encode(encryption_key),
-            "6f16f0d1b1fede12656e953cb8483d322b98dff1c81d989b9fb5596e0515ad8a"
+            "30be8892d89599867fca90dcd841ac62cc07ea0ea521e8708eb8ae143c093210"
         );
     }
 
@@ -664,7 +664,7 @@ mod tests {
 
         assert_eq!(
             hex::encode(encryption_key),
-            "0b999118bad636ad02720d891bbd7b67adb622a5f3b30d0cd2d528fdfb4f7131"
+            "f263c915c8000b5164e3fc1d84ce80a451eef2b32f9749a4d0d390844bb1673e"
         );
     }
 }


### PR DESCRIPTION
## Purpose
Add support for deriving keys for verifiable credentials. In particular also expose this functionality to the mobile libraries for when they are going to implement Web3 ID functionality.

## Changes
- Updated `key_derivation` with methods for getting the public key, signing key and encryption key required for a verifiable credential.
- Updated mobile libraries to expose the new functionality in `key_derivation`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.