### PR TITLE
Introduce Ratio type and add p6 variants to UpdatePayload and UpdateType

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased changes
 
+- Extend types `UpdatePayload` and `UpdateType` with variants introduced in protocol version 6.
 - Implement `Serial` and `Deserial` for `num::rational::Ratio<u64>` and `Duration`.
-- Introduce types for protocol version 6: `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
+- Introduce types for protocol version 6: `Ratio`, `ChainParameterVersion2`, `GASRewardsCPV1`, `TimeoutParameters` and `FinalizationCommitteeParameters`.
 
 ## 1.2.0 (2023-05-08)
 

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     pedersen_commitment::{Randomness, Value},
     random_oracle::RandomOracle,
-    updates::{GASRewards, GASRewardsCPV2},
+    updates::{GASRewards, GASRewardsV1},
 };
 use concordium_contracts_common::AccountAddress;
 pub use concordium_contracts_common::{
@@ -1170,7 +1170,7 @@ impl GASRewardsFamily for ChainParameterVersion1 {
 }
 
 impl GASRewardsFamily for ChainParameterVersion2 {
-    type Output = GASRewardsCPV2;
+    type Output = GASRewardsV1;
 }
 
 /// Type family mapping a `ChainParameterVersion` to its corresponding type for

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -14,7 +14,6 @@ use crate::{
     hashes,
     transactions::PayloadSize,
 };
-use anyhow::ensure;
 use derive_more::*;
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
@@ -508,17 +507,18 @@ pub enum NewTimeoutParametersError {
 }
 
 impl TimeoutParameters {
-    /// Construct [`Self`] ensuring the provided values are valid.
+    /// Construct [`Self`] ensuring the ratio `increase` is greater than 1 and
+    /// the `decrease` is between 0 and 1.
     pub fn new(
         base: concordium_contracts_common::Duration,
         increase: Ratio,
         decrease: Ratio,
     ) -> Result<Self, NewTimeoutParametersError> {
-        if increase.numerator <= increase.denominator {
+        if increase.numerator() <= increase.denominator() {
             return Err(NewTimeoutParametersError::InvalidIncrease);
         }
 
-        if decrease.numerator == 0 || decrease.denominator <= decrease.numerator {
+        if decrease.numerator() == 0 || decrease.denominator() <= decrease.numerator() {
             return Err(NewTimeoutParametersError::InvalidDecrease);
         }
 
@@ -529,7 +529,8 @@ impl TimeoutParameters {
         })
     }
 
-    /// Construct [`Self`] without checking the provided values.
+    /// Construct [`Self`] without ensuring the ratio `increase` is greater than
+    /// 1 and the `decrease` is between 0 and 1.
     pub fn new_unchecked(
         base: concordium_contracts_common::Duration,
         increase: Ratio,

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -160,7 +160,8 @@ pub struct GASRewards {
 #[serde(rename_all = "camelCase")]
 /// The reward fractions related to the gas account and inclusion of special
 /// transactions.
-pub struct GASRewardsCPV2 {
+/// Introduce for protocol version 6.
+pub struct GASRewardsV1 {
     /// `BakerPrevTransFrac`: fraction of the previous gas account paid to the
     /// baker.
     pub baker:            AmountFraction,
@@ -665,7 +666,7 @@ pub enum UpdatePayload {
     #[serde(rename = "mintDistributionCPV1")]
     MintDistributionCPV1(MintDistribution<ChainParameterVersion1>),
     #[serde(rename = "gASRewardsCPV2")]
-    GASRewardsCPV2(GASRewardsCPV2),
+    GASRewardsCPV2(GASRewardsV1),
     #[serde(rename = "TimeoutParametersCPV2")]
     TimeoutParametersCPV2(TimeoutParameters),
     #[serde(rename = "minBlockTimeCPV2")]

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 use anyhow::ensure;
 use derive_more::*;
-use num::rational::Ratio;
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
@@ -489,39 +488,67 @@ pub struct CooldownParameters {
 
 /// Parameters controlling consensus timeouts for the consensus protocol version
 /// 2.
-#[derive(Debug, common::Serial, Copy, Clone)]
+#[derive(Debug, common::Serial, Copy, Clone, SerdeSerialize, SerdeDeserialize)]
 pub struct TimeoutParameters {
     /// The base value for triggering a timeout.
     pub base:     concordium_contracts_common::Duration,
     /// Factor for increasing the timeout. Must be greater than 1.
-    pub increase: Ratio<u64>,
+    pub increase: Ratio,
     /// Factor for decreasing the timeout. Must be between 0 and 1.
-    pub decrease: Ratio<u64>,
+    pub decrease: Ratio,
 }
 
-impl Deserial for TimeoutParameters {
-    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
-        let base = source.get()?;
-        let increase: Ratio<u64> = source.get()?;
-        ensure!(
-            increase.numer() > increase.denom(),
-            "Timeout increase must be greater than 1."
-        );
-        let decrease: Ratio<u64> = source.get()?;
-        ensure!(
-            decrease.numer() > &0,
-            "Timeout decrease must be greater than 0."
-        );
-        ensure!(
-            decrease.denom() < decrease.numer(),
-            "Timeout decrease must be less than 1."
-        );
+/// Error type for when constructing [`TimeoutParameters`].
+#[derive(Debug, thiserror::Error)]
+pub enum NewTimeoutParametersError {
+    #[error("Timeout increase must be greater than 1.")]
+    InvalidIncrease,
+    #[error("Timeout decrease must be between 0 and 1.")]
+    InvalidDecrease,
+}
+
+impl TimeoutParameters {
+    /// Construct [`Self`] ensuring the provided values are valid.
+    pub fn new(
+        base: concordium_contracts_common::Duration,
+        increase: Ratio,
+        decrease: Ratio,
+    ) -> Result<Self, NewTimeoutParametersError> {
+        if increase.numerator <= increase.denominator {
+            return Err(NewTimeoutParametersError::InvalidIncrease);
+        }
+
+        if decrease.numerator == 0 || decrease.denominator <= decrease.numerator {
+            return Err(NewTimeoutParametersError::InvalidDecrease);
+        }
 
         Ok(Self {
             base,
             increase,
             decrease,
         })
+    }
+
+    /// Construct [`Self`] without checking the provided values.
+    pub fn new_unchecked(
+        base: concordium_contracts_common::Duration,
+        increase: Ratio,
+        decrease: Ratio,
+    ) -> Self {
+        Self {
+            base,
+            increase,
+            decrease,
+        }
+    }
+}
+
+impl Deserial for TimeoutParameters {
+    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
+        let base = source.get()?;
+        let increase: Ratio = source.get()?;
+        let decrease: Ratio = source.get()?;
+        Ok(Self::new(base, increase, decrease)?)
     }
 }
 
@@ -582,7 +609,7 @@ pub struct PoolParameters {
     pub leverage_bound:                  LeverageFactor,
 }
 
-#[derive(Debug, common::Serialize, Clone, Copy)]
+#[derive(Debug, common::Serialize, Clone, Copy, SerdeSerialize, SerdeDeserialize)]
 /// Finalization committee parameters. These parameters control which bakers are
 /// in the finalization committee.
 pub struct FinalizationCommitteeParameters {
@@ -636,6 +663,16 @@ pub enum UpdatePayload {
     TimeParametersCPV1(TimeParameters),
     #[serde(rename = "mintDistributionCPV1")]
     MintDistributionCPV1(MintDistribution<ChainParameterVersion1>),
+    #[serde(rename = "gASRewardsCPV2")]
+    GASRewardsCPV2(GASRewardsCPV2),
+    #[serde(rename = "TimeoutParametersCPV2")]
+    TimeoutParametersCPV2(TimeoutParameters),
+    #[serde(rename = "minBlockTimeCPV2")]
+    MinBlockTimeCPV2(concordium_contracts_common::Duration),
+    #[serde(rename = "blockEnergyLimitCPV2")]
+    BlockEnergyLimitCPV2(Energy),
+    #[serde(rename = "finalizationCommitteeParametersCPV2")]
+    FinalizationCommitteeParametersCPV2(FinalizationCommitteeParameters),
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, Copy)]
@@ -658,7 +695,8 @@ pub enum UpdateType {
     UpdateMintDistribution,
     /// Update the distribution of transaction fees
     UpdateTransactionFeeDistribution,
-    /// Update the GAS rewards
+    /// Update the GAS rewards. Only applies to and including protocol version
+    /// 5.
     UpdateGASRewards,
     /// Add new anonymity revoker
     UpdateAddAnonymityRevoker,
@@ -680,6 +718,21 @@ pub enum UpdateType {
     /// Update of the time parameters. Only applies to protocol version
     /// [`P4`](ProtocolVersion::P4) and up.
     UpdateTimeParameters,
+    /// Update of the GAS rewards for chain parameter version 2. Only applies to
+    /// protocol version [`P6`](ProtocolVersion::P6) and up.
+    UpdateGASRewardsCPV2,
+    /// Update of the timeout parameters. Only applies to
+    /// protocol version [`P6`](ProtocolVersion::P6) and up.
+    UpdateTimeoutParameters,
+    /// Update of the min block time. Only applies to
+    /// protocol version [`P6`](ProtocolVersion::P6) and up.
+    UpdateMinBlockTime,
+    /// Update of the block energy limit. Only applies to
+    /// protocol version [`P6`](ProtocolVersion::P6) and up.
+    UpdateBlockEnergyLimit,
+    /// Update of the finalization committee parameters. Only applies to
+    /// protocol version [`P6`](ProtocolVersion::P6) and up.
+    UpdateFinalizationCommitteeParameters,
 }
 
 impl UpdatePayload {
@@ -703,6 +756,13 @@ impl UpdatePayload {
             UpdatePayload::PoolParametersCPV1(_) => UpdatePoolParameters,
             UpdatePayload::TimeParametersCPV1(_) => UpdateTimeParameters,
             UpdatePayload::MintDistributionCPV1(_) => UpdateMintDistribution,
+            UpdatePayload::GASRewardsCPV2(_) => UpdateGASRewardsCPV2,
+            UpdatePayload::TimeoutParametersCPV2(_) => UpdateTimeoutParameters,
+            UpdatePayload::MinBlockTimeCPV2(_) => UpdateMinBlockTime,
+            UpdatePayload::BlockEnergyLimitCPV2(_) => UpdateBlockEnergyLimit,
+            UpdatePayload::FinalizationCommitteeParametersCPV2(_) => {
+                UpdateFinalizationCommitteeParameters
+            }
         }
     }
 }
@@ -900,6 +960,26 @@ impl Serial for UpdatePayload {
                 17u8.serial(out);
                 md.serial(out)
             }
+            UpdatePayload::TimeoutParametersCPV2(update) => {
+                18u8.serial(out);
+                update.serial(out)
+            }
+            UpdatePayload::MinBlockTimeCPV2(update) => {
+                19u8.serial(out);
+                update.serial(out)
+            }
+            UpdatePayload::BlockEnergyLimitCPV2(update) => {
+                20u8.serial(out);
+                update.serial(out)
+            }
+            UpdatePayload::GASRewardsCPV2(update) => {
+                21u8.serial(out);
+                update.serial(out)
+            }
+            UpdatePayload::FinalizationCommitteeParametersCPV2(update) => {
+                22u8.serial(out);
+                update.serial(out)
+            }
         }
     }
 }
@@ -946,6 +1026,13 @@ impl Deserial for UpdatePayload {
             15u8 => Ok(UpdatePayload::PoolParametersCPV1(source.get()?)),
             16u8 => Ok(UpdatePayload::TimeParametersCPV1(source.get()?)),
             17u8 => Ok(UpdatePayload::MintDistributionCPV1(source.get()?)),
+            18u8 => Ok(UpdatePayload::TimeoutParametersCPV2(source.get()?)),
+            19u8 => Ok(UpdatePayload::MinBlockTimeCPV2(source.get()?)),
+            20u8 => Ok(UpdatePayload::BlockEnergyLimitCPV2(source.get()?)),
+            21u8 => Ok(UpdatePayload::GASRewardsCPV2(source.get()?)),
+            22u8 => Ok(UpdatePayload::FinalizationCommitteeParametersCPV2(
+                source.get()?,
+            )),
             tag => anyhow::bail!("Unknown update payload tag {}", tag),
         }
     }


### PR DESCRIPTION
## Purpose

Update types to support protocol version 6.
Depends on https://github.com/Concordium/concordium-contracts-common/pull/85.
Related to https://github.com/Concordium/concordium-rust-sdk/pull/92

## Changes

- Introduce `Ratio` struct for implementing serde and the serialization of the node.
- Extend enums `UpdatePayload` and `UpdateType` with variants introduced in protocol version 6.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
