### PR TITLE
Support block height as block identifier in gRPC v2 block queries

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1613,6 +1613,7 @@ instance ToProto QueryTypes.BlockInfo where
         ProtoFields.transactionsEnergyCost .= toProto biTransactionEnergyCost
         ProtoFields.transactionsSize .= fromIntegral biTransactionsSize
         ProtoFields.stateHash .= toProto biBlockStateHash
+        ProtoFields.protocolVersion .= toProto biProtocolVersion
 
 instance ToProto QueryTypes.PoolStatus where
     type Output QueryTypes.PoolStatus = Either Proto.PoolInfoResponse Proto.PassiveDelegationInfo
@@ -2097,6 +2098,16 @@ instance ToProto BlockHashInput where
         Best -> Proto.make $ ProtoFields.best .= Proto.defMessage
         LastFinal -> Proto.make $ ProtoFields.lastFinal .= Proto.defMessage
         Given bh -> Proto.make $ ProtoFields.given .= toProto bh
+        AtHeight (Absolute{..}) -> Proto.make $ ProtoFields.absoluteHeight .= toProto aBlockHeight
+        AtHeight (Relative{..}) ->
+            Proto.make $
+                ProtoFields.relativeHeight
+                    .= Proto.make
+                        ( do
+                            ProtoFields.genesisIndex .= toProto rGenesisIndex
+                            ProtoFields.height .= toProto rBlockHeight
+                            ProtoFields.restrict .= rRestrict
+                        )
 
 instance ToProto BlockHeightInput where
     type Output BlockHeightInput = Proto.BlocksAtHeightRequest

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -187,7 +187,9 @@ data BlockInfo = BlockInfo
       -- |The size of the transactions
       biTransactionsSize :: !Int,
       -- |The hash of the block state
-      biBlockStateHash :: !StateHash
+      biBlockStateHash :: !StateHash,
+      -- |Protocol version that the block belongs to.
+      biProtocolVersion :: !ProtocolVersion
     }
     deriving (Show)
 
@@ -945,8 +947,9 @@ data PeerInfo = PeerInfo
 -- just need the recent state can use @LastFinal@ or @Best@ to get the
 -- result without first establishing what the last final or best block
 -- is.
-data BlockHashInput = Best | LastFinal | Given !BlockHash
-    deriving (Read)
+data BlockHashInput = Best | LastFinal | Given !BlockHash | AtHeight !BlockHeightInput
+
+--  deriving (Read)
 
 -- |Input for @getBlocksAtHeight@.
 data BlockHeightInput


### PR DESCRIPTION
## Purpose

Related to https://github.com/Concordium/concordium-node/issues/837.
Should be merged with https://github.com/Concordium/concordium-grpc-api/pull/36 and https://github.com/Concordium/concordium-node/pull/838.

## Changes

- Update grpc api submodule and types for the node accordingly.
