### PR TITLE
New consensus multiversion runner integration

### DIFF
--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -4,6 +4,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |
 --    This module defines the protocol versioned variants of genesis and regenesis
@@ -35,6 +36,7 @@ import Data.Word
 import Concordium.Common.Version
 import Concordium.Genesis.Account
 import Concordium.Genesis.Data.Base
+import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
 import qualified Concordium.Genesis.Data.P1 as P1
 import qualified Concordium.Genesis.Data.P2 as P2
 import qualified Concordium.Genesis.Data.P3 as P3
@@ -367,3 +369,12 @@ regenesisConfiguration regenData =
           _gcFirstGenesis = firstGenesisBlockHash regenData,
           _gcCurrentHash = regenesisBlockHash regenData
         }
+
+-- |Extract the V1 core genesis parameters from the genesis data.
+genesisCoreParametersV1 ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    GenesisData pv ->
+    BaseV1.CoreGenesisParametersV1
+genesisCoreParametersV1 = case protocolVersion @pv of
+    SP6 -> \(GDP6 genData) -> P6.genesisCore genData

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -4,6 +4,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeApplications #-}
 {-# LANGUAGE TypeFamilies #-}
+-- We suppress redundant constraint warnings since GHC does not detect when a constraint is used
+-- for pattern matching. (See: https://gitlab.haskell.org/ghc/ghc/-/issues/20896)
 {-# OPTIONS_GHC -Wno-redundant-constraints #-}
 
 -- |

--- a/haskell-src/Concordium/Genesis/Data/BaseV1.hs
+++ b/haskell-src/Concordium/Genesis/Data/BaseV1.hs
@@ -33,7 +33,7 @@ instance Serialize CoreGenesisParametersV1 where
         genesisEpochDuration <- get
         gstNumerator <- get
         gstDenominator <- get
-        unless (gstDenominator == 0) $ fail "genesisSignatureThreshold: zero denominator"
+        when (gstDenominator == 0) $ fail "genesisSignatureThreshold: zero denominator"
         unless (gstNumerator <= gstDenominator) $ fail "genesisSignatureThreshold > 1"
         -- Ratios of fixed size (unsigned) integers can be subject to arithmetic overflow on basic
         -- operations. This >=2/3 check is implemented so as to avoid overflow.

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -76,6 +76,7 @@ module Concordium.Types.Accounts (
     AccountInfo (..),
     AccountStakingInfo (..),
     toAccountStakingInfo,
+    toAccountStakingInfoP4,
 
     -- * Account structure version
     AccountStructureVersion (..),
@@ -575,6 +576,16 @@ toAccountStakingInfo _ (AccountStakeDelegate AccountDelegationV1{..}) =
   where
     pcTime :: AVSupportsDelegation av => PendingChangeEffective av -> UTCTime
     pcTime (PendingChangeEffectiveV1 t) = timestampToUTCTime t
+
+-- |Convert an 'AccountStake' to an 'AccountStakingInfo' in protocol versions from 'P4' onwards.
+toAccountStakingInfoP4 ::
+    forall av.
+    (IsAccountVersion av, AVSupportsDelegation av) =>
+    AccountStake av ->
+    AccountStakingInfo
+toAccountStakingInfoP4 =
+    toAccountStakingInfo
+        (error "Epoch conversion is not used for account staking info in this protocol version")
 
 pendingChangeToJSON :: KeyValue kv => StakePendingChange' UTCTime -> [kv]
 pendingChangeToJSON NoChange = []


### PR DESCRIPTION
## Purpose

Changes to base to support the multiversion runner integration for new consensus.

## Changes

- Project `CoreGenesisParametersV1` from genesis data for consensus version 1.
- Specialised `toAccountStakingInfoP4 ` that does not require epoch conversion from P4 onwards.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
