### PR TITLE
P6 protocol update

### DIFF
--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -347,6 +347,8 @@ data StateMigrationParameters (p1 :: ProtocolVersion) (p2 :: ProtocolVersion) wh
     StateMigrationParametersP3ToP4 :: P4.StateMigrationData -> StateMigrationParameters 'P3 'P4
     -- |The state is migrated from protocol version 'P4' to 'P5'.
     StateMigrationParametersP4ToP5 :: StateMigrationParameters 'P4 'P5
+    -- |The state is migrated from protocol version 'P5' to 'P6'.
+    StateMigrationParametersP5ToP6 :: StateMigrationParameters 'P5 'P6
 
 -- |Extract the genesis configuration from the genesis data.
 genesisConfiguration :: (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GenesisConfiguration

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -348,7 +348,7 @@ data StateMigrationParameters (p1 :: ProtocolVersion) (p2 :: ProtocolVersion) wh
     -- |The state is migrated from protocol version 'P4' to 'P5'.
     StateMigrationParametersP4ToP5 :: StateMigrationParameters 'P4 'P5
     -- |The state is migrated from protocol version 'P5' to 'P6'.
-    StateMigrationParametersP5ToP6 :: StateMigrationParameters 'P5 'P6
+    StateMigrationParametersP5ToP6 :: P6.StateMigrationData -> StateMigrationParameters 'P5 'P6
 
 -- |Extract the genesis configuration from the genesis data.
 genesisConfiguration :: (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GenesisConfiguration

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -382,3 +382,12 @@ genesisCoreParametersV1 ::
     BaseV1.CoreGenesisParametersV1
 genesisCoreParametersV1 = case protocolVersion @pv of
     SP6 -> \(GDP6 genData) -> P6.genesisCore genData
+
+-- |Extract the V1 core genesis parameters from the regenesis data.
+regenesisCoreParametersV1 ::
+    forall pv.
+    (IsProtocolVersion pv, IsConsensusV1 pv) =>
+    Regenesis pv ->
+    BaseV1.CoreGenesisParametersV1
+regenesisCoreParametersV1 = case protocolVersion @pv of
+    SP6 -> \(RGDP6 genData) -> BaseV1.genesisCore $ P6.genesisRegenesis genData

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -23,7 +23,9 @@ data ProtocolUpdateData = ProtocolUpdateData
       updateConsensusParameters :: !(ConsensusParameters 'ChainParametersV2),
       -- |The 'FinalizationCommitteeParameters' that the protocol should
       -- be instantiated with.
-      updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters
+      updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters,
+      -- |Duration of the epoch after the protocol update.
+      updateGenesisEpochDuration :: !Duration
     }
     deriving (Eq, Show)
 
@@ -31,9 +33,11 @@ instance Serialize ProtocolUpdateData where
     put ProtocolUpdateData{..} = do
         put updateConsensusParameters
         put updateFinalizationCommitteeParameters
+        put updateGenesisEpochDuration
     get = do
         updateConsensusParameters <- get
         updateFinalizationCommitteeParameters <- get
+        updateGenesisEpochDuration <- get
         return ProtocolUpdateData{..}
 
 -- |Parameters used to migrate state from 'P5' to 'P6'.

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE DerivingStrategies #-}
 
 -- |This module defines the genesis data format for the 'P6' protocol version.
 module Concordium.Genesis.Data.P6 where

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -43,6 +43,8 @@ data StateMigrationData = StateMigrationData
       migrationProtocolUpdateData :: !ProtocolUpdateData,
       -- |The time of the trigger block that caused
       -- this protocol update.
+      -- This is used for calculating the new 'SeedState' during
+      -- the migration P5->P6.
       migrationTriggerBlockTime :: !Timestamp
     }
     deriving (Eq, Show)

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -25,7 +25,7 @@ data ProtocolUpdateData = ProtocolUpdateData
       -- be instantiated with.
       updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters
     }
-    deriving stock (Eq, Show)
+    deriving (Eq, Show)
 
 instance Serialize ProtocolUpdateData where
     put ProtocolUpdateData{..} = do
@@ -45,7 +45,7 @@ data StateMigrationData = StateMigrationData
       -- this protocol update.
       migrationTriggerBlockTime :: !Timestamp
     }
-    deriving stock (Eq, Show)
+    deriving (Eq, Show)
 
 instance Serialize StateMigrationData where
     put StateMigrationData{..} = do
@@ -159,7 +159,7 @@ regenesisBlockHash GDP6Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} 
 regenesisBlockHash GDP6RegenesisFromP5{genesisRegenesis = BaseV1.RegenesisDataV1{..}, ..} = BlockHash . Hash.hashLazy . runPutLazy $ do
     put genesisSlot
     put P6
-    putWord8 2 -- regenesis variant
+    putWord8 2 -- migration from P5 variant
     put genesisCore
     put genesisFirstGenesis
     put genesisPreviousGenesis

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -76,10 +76,10 @@ data GenesisDataP6 = GDP6Initial
 -- There are two variants, one when migrating from 'P5' to 'P6'and
 -- one from 'P6' to 'P6'.
 data RegenesisP6
-    = GDP6Regenesis {genesisRegenesis :: BaseV1.RegenesisDataV1}
+    = GDP6Regenesis {genesisRegenesis :: !BaseV1.RegenesisDataV1}
     | GDP6RegenesisFromP5
-        { genesisRegenesis :: BaseV1.RegenesisDataV1,
-          genesisMigration :: StateMigrationData
+        { genesisRegenesis :: !BaseV1.RegenesisDataV1,
+          genesisMigration :: !StateMigrationData
         }
     deriving stock (Eq, Show)
 
@@ -159,7 +159,7 @@ regenesisBlockHash GDP6Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} 
 regenesisBlockHash GDP6RegenesisFromP5{genesisRegenesis = BaseV1.RegenesisDataV1{..}, ..} = BlockHash . Hash.hashLazy . runPutLazy $ do
     put genesisSlot
     put P6
-    putWord8 1 -- regenesis variant
+    putWord8 2 -- regenesis variant
     put genesisCore
     put genesisFirstGenesis
     put genesisPreviousGenesis

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -87,7 +87,7 @@ data RegenesisP6
         { genesisRegenesis :: !BaseV1.RegenesisDataV1,
           genesisMigration :: !StateMigrationData
         }
-    deriving stock (Eq, Show)
+    deriving (Eq, Show)
 
 -- |Deserialize genesis data in the V8 format.
 getGenesisDataV8 :: Get GenesisDataP6

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DerivingStrategies #-}
 
 -- |This module defines the genesis data format for the 'P6' protocol version.
 module Concordium.Genesis.Data.P6 where
@@ -14,18 +14,18 @@ import qualified Concordium.Crypto.SHA256 as Hash
 import qualified Concordium.Genesis.Data.Base as Base
 import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
 import Concordium.Types
-import qualified Concordium.Types.Parameters as Parameters
+import Concordium.Types.Parameters
 
 -- |Parameters data type for the 'P5' to 'P6' protocol update.
 -- This is provided as a parameter to the protocol update chain update instruction.
 data ProtocolUpdateData = ProtocolUpdateData
     { -- |The consensus parameters that the protocol should be instantiated with.
-      updateConsensusParameters :: !(Parameters.ConsensusParameters' 'Parameters.ConsensusParametersVersion1),
+      updateConsensusParameters :: !(ConsensusParameters 'ChainParametersV2),
       -- |The 'FinalizationCommitteeParameters' that the protocol should
       -- be instantiated with.
-      updateFinalizationCommitteeParameters :: !Parameters.FinalizationCommitteeParameters
+      updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters
     }
-    deriving (Eq, Show)
+    deriving stock (Eq, Show)
 
 instance Serialize ProtocolUpdateData where
     put ProtocolUpdateData{..} = do
@@ -40,8 +40,8 @@ instance Serialize ProtocolUpdateData where
 newtype StateMigrationData = StateMigrationData
     { migrationProtocolUpdateData :: ProtocolUpdateData
     }
-    deriving newtype (Eq, Show)
-    deriving (Serialize) via ProtocolUpdateData
+    deriving stock (Eq, Show)
+    deriving newtype Serialize
 
 -- |Initial genesis data for the P6 protocol version.
 data GenesisDataP6 = GDP6Initial

--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -37,11 +37,24 @@ instance Serialize ProtocolUpdateData where
         return ProtocolUpdateData{..}
 
 -- |Parameters used to migrate state from 'P5' to 'P6'.
-newtype StateMigrationData = StateMigrationData
-    { migrationProtocolUpdateData :: ProtocolUpdateData
+data StateMigrationData = StateMigrationData
+    { -- |Data provided by the protocol update to be used
+      -- in the migration.
+      migrationProtocolUpdateData :: !ProtocolUpdateData,
+      -- |The time of the trigger block that caused
+      -- this protocol update.
+      migrationTriggerBlockTime :: !Timestamp
     }
     deriving stock (Eq, Show)
-    deriving newtype Serialize
+
+instance Serialize StateMigrationData where
+    put StateMigrationData{..} = do
+        put migrationProtocolUpdateData
+        put migrationTriggerBlockTime
+    get = do
+        migrationProtocolUpdateData <- get
+        migrationTriggerBlockTime <- get
+        return StateMigrationData{..}
 
 -- |Initial genesis data for the P6 protocol version.
 data GenesisDataP6 = GDP6Initial

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -136,12 +136,13 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
                                 },
           _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
           _cpFinalizationCommitteeParameters = SomeParam finalizationCommitteeParameters,
+          -- We unwrap and wrap here in order to associate the correct cpv
+          -- with the time parameters.
           _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
           ..
         }
   where
     RewardParameters{..} = _cpRewardParameters
-    P6.ProtocolUpdateData{} = P6.migrationProtocolUpdateData migration
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
 
 -- |Apply a state migration to an 'AccountStake' structure.

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -125,15 +125,15 @@ migrateChainParameters m@(StateMigrationParametersP3ToP4 migration) ChainParamet
     RewardParameters{..} = _cpRewardParameters
     P4.ProtocolUpdateData{..} = P4.migrationProtocolUpdateData migration
 migrateChainParameters StateMigrationParametersP4ToP5 cps = cps
-migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParameters{..} =    
+migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParameters{..} =
     ChainParameters
         { _cpConsensusParameters = P6.updateConsensusParameters $ P6.migrationProtocolUpdateData migration,
-          _cpRewardParameters = RewardParameters
-                                {
-                                  _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
-                                  _rpGASRewards = migrateGASRewards m _rpGASRewards,
-                                  ..
-                                },
+          _cpRewardParameters =
+            RewardParameters
+                { _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
+                  _rpGASRewards = migrateGASRewards m _rpGASRewards,
+                  ..
+                },
           _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
           _cpFinalizationCommitteeParameters = SomeParam finalizationCommitteeParameters,
           -- We unwrap and wrap here in order to associate the correct cpv

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -80,6 +80,9 @@ migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
 migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
 
 -- |Apply a state migration to a 'GASRewards' structure.
+--
+-- This does nothing except for the P5->P6 protocol update,
+-- which removes the finalization proof reward.
 migrateGASRewards ::
     forall oldpv pv.
     StateMigrationParameters oldpv pv ->

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -6,6 +6,7 @@ module Concordium.Types.Migration where
 
 import Concordium.Genesis.Data
 import qualified Concordium.Genesis.Data.P4 as P4
+import qualified Concordium.Genesis.Data.P6 as P6
 import Concordium.Types
 import Concordium.Types.Accounts
 import Concordium.Types.Parameters
@@ -33,7 +34,7 @@ migrateAuthorizations (StateMigrationParametersP3ToP4 migration) Authorizations{
 migrateAuthorizations StateMigrationParametersP4ToP5 auths = auths
 -- Note that the authorization for the consensus parameters v0
 -- are carried over to consensus parameters v1.
-migrateAuthorizations StateMigrationParametersP5ToP6 auths = auths
+migrateAuthorizations StateMigrationParametersP5ToP6{} auths = auths
 
 -- |Apply a state migration to an 'UpdateKeysCollection' structure.
 --
@@ -60,7 +61,7 @@ migrateMintDistribution StateMigrationParametersP2P3 mint = mint
 migrateMintDistribution StateMigrationParametersP3ToP4{} MintDistribution{..} =
     MintDistribution{_mdMintPerSlot = CFalse, ..}
 migrateMintDistribution StateMigrationParametersP4ToP5 mint = mint
-migrateMintDistribution StateMigrationParametersP5ToP6 mint = mint
+migrateMintDistribution StateMigrationParametersP5ToP6{} mint = mint
 
 -- |Apply a state migration to a 'PoolParameters' structure.
 --
@@ -76,7 +77,7 @@ migratePoolParameters StateMigrationParametersP2P3 poolParams = poolParams
 migratePoolParameters (StateMigrationParametersP3ToP4 migration) _ =
     P4.updatePoolParameters (P4.migrationProtocolUpdateData migration)
 migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
-migratePoolParameters StateMigrationParametersP5ToP6 poolParams = poolParams
+migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
 
 -- |Apply a state migration to a 'GASRewards' structure.
 migrateGASRewards ::
@@ -89,12 +90,15 @@ migrateGASRewards StateMigrationParametersP1P2 gr = gr
 migrateGASRewards StateMigrationParametersP2P3 gr = gr
 migrateGASRewards StateMigrationParametersP3ToP4{} gr = gr
 migrateGASRewards StateMigrationParametersP4ToP5 gr = gr
-migrateGASRewards StateMigrationParametersP5ToP6 gr = gr{_gasFinalizationProof = CFalse}
+migrateGASRewards StateMigrationParametersP5ToP6{} GASRewards{..} = GASRewards{_gasFinalizationProof = CFalse, ..}
 
 -- |Apply a state migration to a 'ChainParameters' structure.
 --
 -- [P3 to P4]: the new cooldown, time and pool parameters are given by the migration parameters;
 --   the mint-per-slot rate is removed from the reward parameters.
+--
+-- [P5 to P6]: the new consensus, finalization committee parameters are given by the migration parameters;
+--   the GAS finalization proof reward is removed.
 migrateChainParameters ::
     forall oldpv pv.
     StateMigrationParameters oldpv pv ->
@@ -121,22 +125,24 @@ migrateChainParameters m@(StateMigrationParametersP3ToP4 migration) ChainParamet
     RewardParameters{..} = _cpRewardParameters
     P4.ProtocolUpdateData{..} = P4.migrationProtocolUpdateData migration
 migrateChainParameters StateMigrationParametersP4ToP5 cps = cps
-migrateChainParameters StateMigrationParametersP5ToP6 ChainParameters{..} =
+migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParameters{..} =    
     ChainParameters
-        { _cpConsensusParameters =
-            ConsensusParametersV1
-                { _cpTimeoutParameters =
-                    TimeoutParameters
-                        { _tpTimeoutBase = undefined,
-                          _tpTimeoutIncrease = undefined,
-                          _tpTimeoutDecrease = undefined
-                        },
-                  _cpMinBlockTime = undefined,
-                  _cpBlockEnergyLimit = undefined
-                },
-          _cpFinalizationCommitteeParameters = SomeParam undefined,
+        { _cpConsensusParameters = P6.updateConsensusParameters $ P6.migrationProtocolUpdateData migration,
+          _cpRewardParameters = RewardParameters
+                                {
+                                  _rpMintDistribution = migrateMintDistribution m _rpMintDistribution,
+                                  _rpGASRewards = migrateGASRewards m _rpGASRewards,
+                                  ..
+                                },
+          _cpPoolParameters = migratePoolParameters m _cpPoolParameters,
+          _cpFinalizationCommitteeParameters = SomeParam finalizationCommitteeParameters,
+          _cpTimeParameters = SomeParam $ unOParam _cpTimeParameters,
           ..
         }
+  where
+    RewardParameters{..} = _cpRewardParameters
+    P6.ProtocolUpdateData{..} = P6.migrationProtocolUpdateData migration
+    finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
 
 -- |Apply a state migration to an 'AccountStake' structure.
 --
@@ -177,7 +183,7 @@ migrateAccountStake StateMigrationParametersP4ToP5 =
                     { _delegationPendingChange = coercePendingChangeEffectiveV1 <$> _delegationPendingChange,
                       ..
                     }
-migrateAccountStake StateMigrationParametersP5ToP6 = id
+migrateAccountStake StateMigrationParametersP5ToP6{} = id
 
 -- |Migrate time of the effective change from V0 to V1 accounts. Currently this
 -- translates times relative to genesis to times relative to the unix epoch.
@@ -204,4 +210,4 @@ migrateStakePendingChange (StateMigrationParametersP3ToP4 migration) = \case
     ReduceStake amnt eff -> ReduceStake amnt (migratePendingChangeEffective migration eff)
     RemoveStake eff -> RemoveStake (migratePendingChangeEffective migration eff)
 migrateStakePendingChange StateMigrationParametersP4ToP5 = fmap coercePendingChangeEffectiveV1
-migrateStakePendingChange StateMigrationParametersP5ToP6 = fmap coercePendingChangeEffectiveV1
+migrateStakePendingChange StateMigrationParametersP5ToP6{} = id

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -141,7 +141,7 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
         }
   where
     RewardParameters{..} = _cpRewardParameters
-    P6.ProtocolUpdateData{..} = P6.migrationProtocolUpdateData migration
+    P6.ProtocolUpdateData{} = P6.migrationProtocolUpdateData migration
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
 
 -- |Apply a state migration to an 'AccountStake' structure.


### PR DESCRIPTION
## Purpose

Address https://github.com/Concordium/concordium-node/issues/856

## Changes

- Introduce migration parameters for P5->P6 protocol update. 
In particular `StateMigrationParametersP5ToP6` is added to the `StateMigrationParameters` which yields the  `StateMigrationData` for protocol 6.

The `StateMigrationData` holds onto the chain parameters that must be supplied for the protocol update P5->P6.

- Consensus parameters for the new chain parameters version V2. These parameters are related to the new consensus protocol.
- Finalization committee parameters. The parameters that determines size and required stake of the finalization committee used in CPV2.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


