### PR TITLE
Check denominator when deserializing TimeoutParameters

### DIFF
--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -1512,12 +1512,14 @@ instance Serialize TimeoutParameters where
         -- Get the timeout increase ratio.
         tiNum <- get
         tiDen <- get
+        when (tiDen == 0) $ fail "timeoutIncrease denominator must be non zero."
         let _tpTimeoutIncrease = tiNum % tiDen
         unless (_tpTimeoutIncrease > 1) $ fail "timeoutIncrease must be greater than 1."
         unless (gcd tiNum tiDen == 1) $ fail "timeoutIncrease numerator and denominator are not coprime."
         -- Get the timeout decrease ratio.
         tdNum <- get
         tdDen <- get
+        when (tdDen == 0) $ fail "timeoutDecrease denominator must be non zero."
         let _tpTimeoutDecrease = tdNum % tdDen
         unless (_tpTimeoutDecrease > 0) $ fail "timeoutDecrease must be greater than 0."
         unless (_tpTimeoutDecrease < 1) $ fail "timeoutDecrease must be less than 1."


### PR DESCRIPTION
## Purpose

Partly fixes https://github.com/Concordium/concordium-base/issues/327 by checking the denominators when deserializing the `TimeoutParameters`.


## Changes

Introduced two checks that make sure that we fail properly if the provided denominator of either the `timeoutIncrease` or `timeoutDecrease` are zero.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

