### PR TITLE
Force character encoding of the form to be utf8.

### DIFF
--- a/identity-provider-service/html/attribute_form.html
+++ b/identity-provider-service/html/attribute_form.html
@@ -6,6 +6,7 @@ world scenario the attributes will be derived from the identity verification pro
 <html>
 <head>
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta charset="utf-8">
 
   <style>
    input[type=text], input[type=number], input[type=month], select {
@@ -51,7 +52,7 @@ world scenario the attributes will be derived from the identity verification pro
 <body>
   <div>
     <h1>Concordium Identity Verification</h1>
-    <form action="/api/submit" method="post">
+    <form action="/api/submit" method="post" accept-charset="utf-8">
 
         <input type="hidden" id="idcredpub" name="id_cred_pub" value="$id_cred_pub$">
         <input type="hidden" id="endpointversion" name="endpoint_version" value="$endpoint_version$">


### PR DESCRIPTION
## Purpose

All our encoding assumes UTF8 strings, so to use special characters as names we need the verifier's form to have UTF8 encoding, otherwise special characters can get garbled.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
