### PR TITLE
Reuse epoch duration from previous protocol.

### DIFF
--- a/haskell-src/Concordium/Genesis/Data/P6.hs
+++ b/haskell-src/Concordium/Genesis/Data/P6.hs
@@ -23,9 +23,7 @@ data ProtocolUpdateData = ProtocolUpdateData
       updateConsensusParameters :: !(ConsensusParameters 'ChainParametersV2),
       -- |The 'FinalizationCommitteeParameters' that the protocol should
       -- be instantiated with.
-      updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters,
-      -- |Duration of the epoch after the protocol update.
-      updateGenesisEpochDuration :: !Duration
+      updateFinalizationCommitteeParameters :: !FinalizationCommitteeParameters
     }
     deriving (Eq, Show)
 
@@ -33,11 +31,9 @@ instance Serialize ProtocolUpdateData where
     put ProtocolUpdateData{..} = do
         put updateConsensusParameters
         put updateFinalizationCommitteeParameters
-        put updateGenesisEpochDuration
     get = do
         updateConsensusParameters <- get
         updateFinalizationCommitteeParameters <- get
-        updateGenesisEpochDuration <- get
         return ProtocolUpdateData{..}
 
 -- |Parameters used to migrate state from 'P5' to 'P6'.


### PR DESCRIPTION
## Purpose

Reuse the existing epoch duration instead of setting it via the protocol update payload.

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
