### PR TITLE
Revise web3id proofs.

### DIFF
--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -1196,16 +1196,16 @@ fn get_verifiable_credential_keys_aux(input: &str) -> anyhow::Result<String> {
     let v: Value = from_str(input)?;
     let wallet = parse_wallet_input(&v)?;
     let verifiable_credential_index = try_get(&v, "verifiableCredentialIndex")?;
+    let issuer = try_get(&v, "issuer")?;
 
-    let signing_key = wallet.get_verifiable_credential_signing_key(verifiable_credential_index)?;
-    let public_key = wallet.get_verifiable_credential_public_key(verifiable_credential_index)?;
-    let encryption_key =
-        wallet.get_verifiable_credential_encryption_key(verifiable_credential_index)?;
+    let signing_key =
+        wallet.get_verifiable_credential_signing_key(issuer, verifiable_credential_index)?;
+    let public_key =
+        wallet.get_verifiable_credential_public_key(issuer, verifiable_credential_index)?;
 
     let response = serde_json::json!({
         "signKey": hex::encode(signing_key),
         "verifyKey": hex::encode(public_key),
-        "encryptionKey": hex::encode(encryption_key)
     });
     Ok(to_string(&response)?)
 }

--- a/rust-src/concordium_base/src/cis4_types.rs
+++ b/rust-src/concordium_base/src/cis4_types.rs
@@ -15,6 +15,8 @@ pub struct CredentialType {
     pub credential_type: String,
 }
 
+// TODO: make field above private, add TryFrom/Into instances
+
 /// A schema reference is a schema URL pointing to the JSON
 /// schema for a verifiable credential.
 #[derive(
@@ -100,11 +102,11 @@ pub struct RevocationKeyWithNonce {
 #[derive(contracts_common::Serialize, Debug, Clone)]
 pub struct RegistryMetadata {
     /// A reference to the issuer's metadata.
-    issuer_metadata:   MetadataUrl,
+    pub issuer_metadata:   MetadataUrl,
     /// The type of credentials used.
-    credential_type:   CredentialType,
+    pub credential_type:   CredentialType,
     /// A reference to the JSON schema corresponding to this type.
-    credential_schema: SchemaRef,
+    pub credential_schema: SchemaRef,
 }
 
 #[doc(hidden)]

--- a/rust-src/concordium_base/src/cis4_types.rs
+++ b/rust-src/concordium_base/src/cis4_types.rs
@@ -107,6 +107,7 @@ pub struct RevocationKeyWithNonce {
 #[doc(hidden)]
 pub enum IssuerKeyRole {}
 
+/// Public key of an issuer.
 pub type IssuerKey = Ed25519PublicKey<IssuerKeyRole>;
 
 /// Data for events of registering and updating a credential.

--- a/rust-src/concordium_base/src/cis4_types.rs
+++ b/rust-src/concordium_base/src/cis4_types.rs
@@ -33,19 +33,11 @@ pub struct CredentialInfo {
     pub holder_id:        CredentialHolderId,
     /// Whether the holder is allowed to revoke the credential or not.
     pub holder_revocable: bool,
-    /// A vector Pedersen commitment to the attributes of the verifiable
-    /// credential.
-    #[concordium(size_length = 2)]
-    #[serde(with = "crate::internal::byte_array_hex")]
-    pub commitment:       Vec<u8>,
     /// The date from which the credential is considered valid.
     pub valid_from:       contracts_common::Timestamp,
     /// After this date, the credential becomes expired. `None` corresponds to a
     /// credential that cannot expire.
     pub valid_until:      Option<contracts_common::Timestamp>,
-    /// A type of the credential that is used to identify which schema the
-    /// credential is based on.
-    pub credential_type:  CredentialType,
     /// Metadata URL of the credential.
     pub metadata_url:     MetadataUrl,
 }
@@ -104,6 +96,17 @@ pub struct RevocationKeyWithNonce {
     pub nonce: u64,
 }
 
+/// A response type for the registry metadata request.
+#[derive(contracts_common::Serialize, Debug, Clone)]
+pub struct RegistryMetadata {
+    /// A reference to the issuer's metadata.
+    issuer_metadata:   MetadataUrl,
+    /// The type of credentials used.
+    credential_type:   CredentialType,
+    /// A reference to the JSON schema corresponding to this type.
+    credential_schema: SchemaRef,
+}
+
 #[doc(hidden)]
 pub enum IssuerKeyRole {}
 
@@ -145,15 +148,6 @@ pub struct RevokeCredentialEvent {
     /// An optional text clarifying the revocation reasons.
     /// The issuer can use this field to comment on the revocation, so the
     /// holder can observe it in the wallet.
-    reason:    Option<Reason>,
-}
-
-/// An untagged restoration event.
-#[derive(contracts_common::Serialize, Debug, Clone)]
-pub struct RestoreCredentialEvent {
-    /// A public key of the credential's holder.
-    holder_id: CredentialHolderId,
-    /// An optional text clarifying the restoring reasons.
     reason:    Option<Reason>,
 }
 

--- a/rust-src/concordium_base/src/web3id/mod.rs
+++ b/rust-src/concordium_base/src/web3id/mod.rs
@@ -10,14 +10,14 @@ pub mod did;
 // - Documentation.
 use crate::{
     base::CredentialRegistrationID,
+    cis4_types::IssuerKey,
     curve_arithmetic::Curve,
     id::{
         constants::{ArCurve, AttributeKind},
         id_proof_types::{AtomicProof, AtomicStatement},
-        sigma_protocols::{self, vcom_eq::VecComEq},
         types::{Attribute, AttributeTag, GlobalContext, IpIdentity},
     },
-    pedersen_commitment::{self, VecCommitmentKey},
+    pedersen_commitment,
     random_oracle::RandomOracle,
 };
 use concordium_contracts_common::{hashes::HashBytes, ContractAddress};
@@ -29,6 +29,9 @@ use std::{
     marker::PhantomData,
     str::FromStr,
 };
+
+/// Domain separation string used when the issuer signs the commitments.
+pub const COMMITMENT_SIGNATURE_DOMAIN_STRING: &[u8] = b"WEB3ID:COMMITMENTS";
 
 /// Domain separation string used when signing the revoke transaction
 /// using the credential secret key.
@@ -207,9 +210,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialProof<C, Attribute
                 contract,
                 ty: _,
                 issuance_date,
-                additional_commitments: _,
-                max_base_used: _,
-                glueing_proof: _,
+                commitments: _,
                 proofs: _,
             } => ProofMetadata {
                 created:       *created,
@@ -278,36 +279,92 @@ pub enum CredentialProof<C: Curve, AttributeType: Attribute<C::Scalar>> {
     },
     Web3Id {
         /// Creation timestamp of the proof.
-        created:                chrono::DateTime<chrono::Utc>,
+        created:       chrono::DateTime<chrono::Utc>,
         /// Owner of the credential, a public key.
-        owner:                  CredentialHolderId,
-        network:                Network,
+        owner:         CredentialHolderId,
+        network:       Network,
         /// Reference to a specific smart contract instance.
-        contract:               ContractAddress,
+        contract:      ContractAddress,
         /// The credential type. This is chosen by the provider to provide
         /// some information about what the credential is about.
-        ty:                     BTreeSet<String>,
+        ty:            BTreeSet<String>,
         /// Issuance date of the credential that the proof is about.
         /// This is an unfortunate name to conform to the standard, but the
         /// meaning here really is `validFrom` for the credential.
-        issuance_date:          chrono::DateTime<chrono::Utc>,
-        /// Additional commitments produced as part of the proof. These are
-        /// commitments for the values in the statement.
-        additional_commitments: BTreeMap<u8, pedersen_commitment::Commitment<C>>,
-        /// The maximum index that is used in the vector commitment. This is
-        /// needed since the vector commitment key is part of the
-        /// context when constructing the proof, so it matters exactly
-        /// what the key is, even if the rest (algebraic part) of the proof
-        /// works equally well with the full key.
-        max_base_used:          u8,
-        /// The proof that the individual commitments that are part of
-        /// `additional-commitments` above are commitments to the same
-        /// values as those found inside the vector commitment that is part of
-        /// the credential.
-        glueing_proof: sigma_protocols::common::SigmaProof<sigma_protocols::vcom_eq::Witness<C>>,
+        issuance_date: chrono::DateTime<chrono::Utc>,
+        /// Commitments that the user has. These are all the commitments that
+        /// are part of the credential, indexed by the attribute tag.
+        commitments:   SignedCommitments<C>,
         /// Individual proofs for statements.
-        proofs:                 Vec<StatementWithProof<C, AttributeType>>,
+        proofs:        Vec<StatementWithProof<C, AttributeType>>,
     },
+}
+
+/// Commitments signed by the issuer.
+#[derive(serde::Serialize, serde::Deserialize, Clone, Debug, crate::common::Serialize)]
+#[serde(bound = "C: Curve")]
+pub struct SignedCommitments<C: Curve> {
+    #[serde(
+        serialize_with = "crate::common::base16_encode",
+        deserialize_with = "crate::common::base16_decode"
+    )]
+    signature:   ed25519_dalek::Signature,
+    commitments: BTreeMap<u8, pedersen_commitment::Commitment<C>>,
+}
+
+impl<C: Curve> SignedCommitments<C> {
+    /// Verify signatures on the commitments.
+    pub fn verify_signature(&self, owner: &CredentialHolderId, issuer_pk: &IssuerKey) -> bool {
+        use crate::common::Serial;
+        let mut data = COMMITMENT_SIGNATURE_DOMAIN_STRING.to_vec();
+        owner.serial(&mut data);
+        self.commitments.serial(&mut data);
+        issuer_pk.public_key.verify(&data, &self.signature).is_ok()
+    }
+
+    /// Sign commitments for the owner.
+    pub fn from_commitments(
+        commitments: BTreeMap<u8, pedersen_commitment::Commitment<C>>,
+        owner: &CredentialHolderId,
+        signer: &impl Web3IdSigner,
+    ) -> Self {
+        use crate::common::Serial;
+        let mut data = COMMITMENT_SIGNATURE_DOMAIN_STRING.to_vec();
+        owner.serial(&mut data);
+        commitments.serial(&mut data);
+        Self {
+            signature: signer.sign(&data),
+            commitments,
+        }
+    }
+
+    pub fn from_secrets<AttributeType: Attribute<C::Scalar>>(
+        global: &GlobalContext<C>,
+        values: &BTreeMap<u8, AttributeType>,
+        randomness: &BTreeMap<u8, pedersen_commitment::Randomness<C>>,
+        owner: &CredentialHolderId,
+        signer: &impl Web3IdSigner,
+    ) -> Option<Self> {
+        // TODO: This is a bit inefficient. We don't need the intermediate map, we can
+        // just serialize directly.
+
+        // TODO: It would be better to use different commitment keys for different tags.
+        let cmm_key = &global.on_chain_commitment_key;
+        let mut commitments = BTreeMap::new();
+        for ((vi, value), (ri, randomness)) in values.iter().zip(randomness.iter()) {
+            if vi != ri {
+                return None;
+            }
+            commitments.insert(
+                *ri,
+                cmm_key.hide(
+                    &pedersen_commitment::Value::<C>::new(value.to_field_element()),
+                    randomness,
+                ),
+            );
+        }
+        Some(Self::from_commitments(commitments, owner, signer))
+    }
 }
 
 impl<C: Curve, AttributeType: Attribute<C::Scalar> + serde::Serialize> serde::Serialize
@@ -347,9 +404,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar> + serde::Serialize> serde::Se
                 contract,
                 ty,
                 issuance_date,
-                additional_commitments,
-                max_base_used,
-                glueing_proof,
+                commitments,
                 proofs,
                 owner,
             } => {
@@ -363,9 +418,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar> + serde::Serialize> serde::Se
                         "proof": {
                             "type": "ConcordiumZKProofV3",
                             "created": created,
-                            "additionalCommitments": additional_commitments,
-                            "maxBaseUsed": max_base_used,
-                            "glueingProof": glueing_proof,
+                            "commitments": commitments,
                             "proofValue": proofs.iter().map(|x| &x.1).collect::<Vec<_>>(),
                         }
                     }
@@ -477,12 +530,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar> + serde::de::DeserializeOwned
                     &mut proof, "created",
                 )?)?;
 
-                let additional_commitments =
-                    serde_json::from_value(get_field(&mut proof, "additionalCommitments")?)?;
-
-                let max_base_used = serde_json::from_value(get_field(&mut proof, "maxBaseUsed")?)?;
-
-                let glueing_proof = serde_json::from_value(get_field(&mut proof, "glueingProof")?)?;
+                let commitments = serde_json::from_value(get_field(&mut proof, "commitments")?)?;
 
                 let proof_value: Vec<_> =
                     serde_json::from_value(get_field(&mut proof, "proofValue")?)?;
@@ -496,9 +544,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar> + serde::de::DeserializeOwned
                     network: issuer.network,
                     contract: address,
                     issuance_date,
-                    additional_commitments,
-                    max_base_used,
-                    glueing_proof,
+                    commitments,
                     proofs,
                     ty,
                 })
@@ -533,11 +579,9 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> crate::common::Serial
                 created,
                 network,
                 contract,
-                additional_commitments,
-                glueing_proof,
+                commitments,
                 proofs,
                 issuance_date,
-                max_base_used,
                 owner,
                 ty,
             } => {
@@ -554,9 +598,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> crate::common::Serial
                 contract.serial(out);
                 owner.serial(out);
                 issuance_date.timestamp_millis().serial(out);
-                additional_commitments.serial(out);
-                max_base_used.serial(out);
-                glueing_proof.serial(out);
+                commitments.serial(out);
                 proofs.serial(out)
             }
         }
@@ -797,7 +839,8 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Presentation<C, AttributeTyp
         };
 
         // Compute the data that the linking proof signed.
-        let to_sign = message_to_sign(self.presentation_context, &self.verifiable_credential);
+        let to_sign =
+            linking_proof_message_to_sign(self.presentation_context, &self.verifiable_credential);
 
         let mut linking_proof_iter = self.linking_proof.proof_value.iter();
 
@@ -987,16 +1030,19 @@ pub enum CommitmentInputs<'a, C: Curve, AttributeType, Web3IdSigner> {
     },
     /// Inputs are for a credential issued by Web3ID issuer.
     Web3Issuer {
+        signature:     ed25519_dalek::Signature,
         /// Issuance date of the credential that the proof is about.
         /// This is an unfortunate name to conform to the standard, but the
         /// meaning here really is `validFrom` for the credential.
         issuance_date: chrono::DateTime<chrono::Utc>,
         /// The signer that will sign the presentation.
         signer:        &'a Web3IdSigner,
-        /// Values that are committed to.
+        /// All the values the user has and are required in the proofs.
         values:        &'a BTreeMap<u8, AttributeType>,
-        /// The randomness for the vector commitment.
-        randomness:    pedersen_commitment::Randomness<C>,
+        /// The randomness to go along with commitments in `values`. This has to
+        /// have the same keys as the `values` field, but it is more
+        /// convenient if it is a separate map itself.
+        randomness:    &'a BTreeMap<u8, pedersen_commitment::Randomness<C>>,
     },
 }
 
@@ -1021,7 +1067,16 @@ pub enum OwnedCommitmentInputs<C: Curve, AttributeType, Web3IdSigner> {
         signer:        Web3IdSigner,
         #[serde_as(as = "BTreeMap<serde_with::DisplayFromStr, _>")]
         values:        BTreeMap<u8, AttributeType>,
-        randomness:    pedersen_commitment::Randomness<C>,
+        /// The randomness to go along with commitments in `values`. This has to
+        /// have the same keys as the `values` field, but it is more
+        /// convenient if it is a separate map itself.
+        #[serde_as(as = "BTreeMap<serde_with::DisplayFromStr, _>")]
+        randomness:    BTreeMap<u8, pedersen_commitment::Randomness<C>>,
+        #[serde(
+            serialize_with = "crate::common::base16_encode",
+            deserialize_with = "crate::common::base16_decode"
+        )]
+        signature:     ed25519_dalek::Signature,
     },
 }
 
@@ -1049,11 +1104,13 @@ impl<'a, C: Curve, AttributeType, Web3IdSigner>
                 signer,
                 values,
                 randomness,
+                signature,
             } => CommitmentInputs::Web3Issuer {
                 issuance_date: *issuance_date,
                 signer,
                 values,
-                randomness: randomness.clone(),
+                randomness,
+                signature: *signature,
             },
         }
     }
@@ -1068,8 +1125,8 @@ pub enum ProofError {
     MissingAttribute,
     #[error("No attributes were provided.")]
     NoAttributes,
-    #[error("Cannot construct the vector commitment. This indicates a configuration error.")]
-    CannotCommit,
+    #[error("Inconsistent values and randomness. Cannot construct commitments.")]
+    InconsistentValuesAndRandomness,
     #[error("Cannot construct gluing proof.")]
     UnableToProve,
     #[error("The number of commitment inputs and statements is inconsistent.")]
@@ -1108,36 +1165,22 @@ fn verify_single_credential<C: Curve, AttributeType: Attribute<C::Scalar>>(
             CredentialProof::Web3Id {
                 network: _proof_network,
                 contract: _proof_contract,
-                additional_commitments,
-                glueing_proof,
+                commitments,
                 proofs,
                 created: _,
                 issuance_date: _,
-                max_base_used,
-                owner: _,
+                owner,
                 ty: _,
             },
-            CredentialsInputs::Web3 { commitment, .. },
+            CredentialsInputs::Web3 { issuer_pk },
         ) => {
-            let (&rand_base, _, base) = global.vector_commitment_base();
-            // TODO: This cloning here is a tiny bit wasteful.
-            let gis = base.take((max_base_used + 1).into()).copied().collect();
-
-            let verifier = VecComEq {
-                comm: *commitment,
-                comms: additional_commitments.clone(),
-                gis,
-                h: rand_base,
-                g_bar: global.on_chain_commitment_key.g,
-                h_bar: global.on_chain_commitment_key.h,
-            };
+            if !commitments.verify_signature(owner, issuer_pk) {
+                return false;
+            }
             for (statement, proof) in proofs.iter() {
-                if !statement.verify(global, transcript, additional_commitments, proof) {
+                if !statement.verify(global, transcript, &commitments.commitments, proof) {
                     return false;
                 }
-            }
-            if !sigma_protocols::common::verify(transcript, &verifier, glueing_proof) {
-                return false;
             }
         }
         _ => return false, // mismatch in data
@@ -1193,6 +1236,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
                     ty,
                 },
                 CommitmentInputs::Web3Issuer {
+                    signature,
                     values,
                     randomness,
                     signer,
@@ -1202,77 +1246,49 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
                 if credential != signer.id().into() {
                     return Err(ProofError::InconsistentIds);
                 }
-                let (&rand_base, base_size, base) = global.vector_commitment_base();
-                // First construct individual commitments.
-
-                // Get the last (maximum) key in the map.
-                let vec_key = values.iter().rev().next().ok_or(ProofError::NoAttributes)?;
-                if usize::from(*vec_key.0) >= base_size {
-                    return Err(ProofError::TooManyAttributes);
+                if values.len() != randomness.len() {
+                    return Err(ProofError::InconsistentValuesAndRandomness);
                 }
-                // TODO: It is wasteful to use the entire commitment key here
-                // But if we don't then we have to record how much of it we used
-                // so that the verifier can use the same.
-                let gis = base.take((*vec_key.0 + 1).into()).copied().collect();
-                let vec_comm_key = VecCommitmentKey {
-                    gs: gis,
-                    h:  rand_base,
-                };
-                let committed_values = {
-                    let mut out = Vec::new();
-                    for (tag, value) in values.iter() {
-                        while out.len() < usize::from(*tag) {
-                            out.push(C::scalar_from_u64(0));
-                        }
-                        out.push(value.to_field_element());
+
+                // We use the same commitment key to commit to values for all the different
+                // attributes. TODO: This is not ideal, but is probably fine
+                // since the tags are signed as well, so you cannot switch one
+                // commitment for another. We could instead use bulletproof generators, that
+                // would be cleaner.
+                let cmm_key = &global.on_chain_commitment_key;
+
+                let mut commitments = BTreeMap::new();
+                for ((vi, value), (ri, randomness)) in values.iter().zip(randomness.iter()) {
+                    if vi != ri {
+                        return Err(ProofError::InconsistentValuesAndRandomness);
                     }
-                    out
-                };
-                let comm = vec_comm_key
-                    .hide(&committed_values, &randomness)
-                    .ok_or(ProofError::CannotCommit)?;
-                let comm_key = &global.on_chain_commitment_key;
-                let mut ris = BTreeMap::new();
-                let individual = statement
-                    .iter()
-                    .map(|x| {
-                        let attr = x.attribute();
-                        let value = values.get(&attr).ok_or(ProofError::MissingAttribute)?;
-                        let (ind_comm, randomness) = comm_key.commit(
+                    commitments.insert(
+                        *ri,
+                        cmm_key.hide(
                             &pedersen_commitment::Value::<C>::new(value.to_field_element()),
-                            csprng,
-                        );
-                        ris.insert(attr, randomness.as_value());
-                        Ok::<_, ProofError>((attr, ind_comm))
-                    })
-                    .collect::<Result<BTreeMap<_, _>, _>>()?;
-                let prover = VecComEq {
-                    comm,
-                    comms: individual,
-                    gis: vec_comm_key.gs,
-                    h: rand_base,
-                    g_bar: global.on_chain_commitment_key.g,
-                    h_bar: global.on_chain_commitment_key.h,
+                            randomness,
+                        ),
+                    );
+                }
+                // TODO: For better user experience/debugging we could check the signature here.
+                let commitments = SignedCommitments {
+                    signature,
+                    commitments,
                 };
                 for statement in statement {
                     let proof = statement
-                        .prove(global, ro, csprng, values, &ris)
+                        .prove(global, ro, csprng, values, randomness)
                         .ok_or(ProofError::MissingAttribute)?;
                     proofs.push((statement, proof));
                 }
-                let secrets = (committed_values, randomness.as_value(), ris);
-                let glueing_proof = sigma_protocols::common::prove(ro, &prover, secrets, csprng)
-                    .ok_or(ProofError::UnableToProve)?;
                 let created = chrono::Utc::now();
                 Ok(CredentialProof::Web3Id {
-                    additional_commitments: prover.comms,
-                    glueing_proof,
+                    commitments,
                     proofs,
                     network,
                     contract,
                     created,
                     issuance_date,
-                    max_base_used: *vec_key.0,
                     owner: signer.id().into(),
                     ty,
                 })
@@ -1282,7 +1298,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
     }
 }
 
-fn message_to_sign<C: Curve, AttributeType: Attribute<C::Scalar>>(
+fn linking_proof_message_to_sign<C: Curve, AttributeType: Attribute<C::Scalar>>(
     challenge: Challenge,
     proofs: &[CredentialProof<C, AttributeType>],
 ) -> Vec<u8> {
@@ -1323,7 +1339,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Request<C, AttributeType> {
             let proof = cred_statement.prove(params, &mut transcript, &mut csprng, attributes)?;
             proofs.push(proof);
         }
-        let to_sign = message_to_sign(self.challenge, &proofs);
+        let to_sign = linking_proof_message_to_sign(self.challenge, &proofs);
         // Linking proof
         let mut proof_value = Vec::new();
         for signer in signers {
@@ -1343,7 +1359,9 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> Request<C, AttributeType> {
 }
 
 /// Public inputs to the verification function. These are the public commitments
-/// that are contained in the credentials.
+/// that are contained in the credentials for identity credentials, and the
+/// issuer's public key for Web3ID credentials which do not store commitments on
+/// the chain.
 pub enum CredentialsInputs<C: Curve> {
     Account {
         // All the commitments of the credential.
@@ -1352,7 +1370,8 @@ pub enum CredentialsInputs<C: Curve> {
         commitments: BTreeMap<AttributeTag, pedersen_commitment::Commitment<C>>,
     },
     Web3 {
-        commitment: pedersen_commitment::Commitment<C>,
+        /// The public key of the issuer.
+        issuer_pk: IssuerKey,
     },
 }
 
@@ -1456,6 +1475,8 @@ mod tests {
         let challenge = Challenge::new(rng.gen());
         let signer_1 = ed25519_dalek::Keypair::generate(&mut rng);
         let signer_2 = ed25519_dalek::Keypair::generate(&mut rng);
+        let issuer_1 = ed25519_dalek::Keypair::generate(&mut rng);
+        let issuer_2 = ed25519_dalek::Keypair::generate(&mut rng);
         let credential_statements = vec![
             CredentialStatement::Web3Id {
                 ty:         [
@@ -1537,23 +1558,58 @@ mod tests {
         let mut values_1 = BTreeMap::new();
         values_1.insert(17, Web3IdAttribute::Numeric(137));
         values_1.insert(23, Web3IdAttribute::String(AttributeKind("ff".into())));
-        let randomness_1 = pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng);
+        let mut randomness_1 = BTreeMap::new();
+        randomness_1.insert(
+            17,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        randomness_1.insert(
+            23,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        let commitments_1 = SignedCommitments::from_secrets(
+            &params,
+            &values_1,
+            &randomness_1,
+            &CredentialHolderId::new(signer_1.public),
+            &issuer_1,
+        )
+        .unwrap();
+
         let secrets_1 = CommitmentInputs::Web3Issuer {
             issuance_date: chrono::Utc::now(),
             signer:        &signer_1,
             values:        &values_1,
-            randomness:    randomness_1.clone(),
+            randomness:    &randomness_1,
+            signature:     commitments_1.signature,
         };
 
         let mut values_2 = BTreeMap::new();
         values_2.insert(0, Web3IdAttribute::Numeric(137));
         values_2.insert(1, Web3IdAttribute::String(AttributeKind("xkcd".into())));
-        let randomness_2 = pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng);
+        let mut randomness_2 = BTreeMap::new();
+        randomness_2.insert(
+            0,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        randomness_2.insert(
+            1,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        let commitments_2 = SignedCommitments::from_secrets(
+            &params,
+            &values_2,
+            &randomness_2,
+            &CredentialHolderId::new(signer_2.public),
+            &issuer_2,
+        )
+        .unwrap();
         let secrets_2 = CommitmentInputs::Web3Issuer {
             issuance_date: chrono::Utc::now(),
             signer:        &signer_2,
             values:        &values_2,
-            randomness:    randomness_2.clone(),
+            randomness:    &randomness_2,
+            signature:     commitments_2.signature,
         };
         let attrs = [secrets_1, secrets_2];
         let proof = request
@@ -1561,54 +1617,12 @@ mod tests {
             .prove(&params, attrs.into_iter())
             .context("Cannot prove")?;
 
-        let commitment_1 = {
-            let (&rand_base, _, base) = params.vector_commitment_base();
-            let gis = base.take(24).copied().collect();
-            let vec_comm_key = VecCommitmentKey {
-                gs: gis,
-                h:  rand_base,
-            };
-            let committed_values = {
-                let mut out = Vec::new();
-                for (tag, value) in values_1.iter() {
-                    while out.len() < usize::from(*tag) {
-                        out.push(ArCurve::scalar_from_u64(0));
-                    }
-                    out.push(value.to_field_element());
-                }
-                out
-            };
-            vec_comm_key
-                .hide(&committed_values, &randomness_1)
-                .context("Unable to commit in the test.")?
-        };
-        let commitment_2 = {
-            let (&rand_base, _, base) = params.vector_commitment_base();
-            let gis = base.take(2).copied().collect();
-            let vec_comm_key = VecCommitmentKey {
-                gs: gis,
-                h:  rand_base,
-            };
-            let committed_values = {
-                let mut out = Vec::new();
-                for (tag, value) in values_2.iter() {
-                    while out.len() < usize::from(*tag) {
-                        out.push(ArCurve::scalar_from_u64(0));
-                    }
-                    out.push(value.to_field_element());
-                }
-                out
-            };
-            vec_comm_key
-                .hide(&committed_values, &randomness_2)
-                .context("Unable to commit in the test.")?
-        };
         let public = vec![
             CredentialsInputs::Web3 {
-                commitment: commitment_1,
+                issuer_pk: issuer_1.public.into(),
             },
             CredentialsInputs::Web3 {
-                commitment: commitment_2,
+                issuer_pk: issuer_2.public.into(),
             },
         ];
         anyhow::ensure!(
@@ -1644,6 +1658,7 @@ mod tests {
         let cred_id_exp = ArCurve::generate_scalar(&mut rng);
         let cred_id = CredentialRegistrationID::from_exponent(&params, cred_id_exp);
         let signer_1 = ed25519_dalek::Keypair::generate(&mut rng);
+        let issuer_1 = ed25519_dalek::Keypair::generate(&mut rng);
         let credential_statements = vec![
             CredentialStatement::Web3Id {
                 ty:         [
@@ -1716,12 +1731,29 @@ mod tests {
         let mut values_1 = BTreeMap::new();
         values_1.insert(17, Web3IdAttribute::Numeric(137));
         values_1.insert(23, Web3IdAttribute::String(AttributeKind("ff".into())));
-        let randomness_1 = pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng);
+        let mut randomness_1 = BTreeMap::new();
+        randomness_1.insert(
+            17,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        randomness_1.insert(
+            23,
+            pedersen_commitment::Randomness::<ArCurve>::generate(&mut rng),
+        );
+        let signed_commitments_1 = SignedCommitments::from_secrets(
+            &params,
+            &values_1,
+            &randomness_1,
+            &CredentialHolderId::new(signer_1.public),
+            &issuer_1,
+        )
+        .unwrap();
         let secrets_1 = CommitmentInputs::Web3Issuer {
             issuance_date: chrono::Utc::now(),
             signer:        &signer_1,
             values:        &values_1,
-            randomness:    randomness_1.clone(),
+            randomness:    &randomness_1,
+            signature:     signed_commitments_1.signature,
         };
 
         let mut values_2 = BTreeMap::new();
@@ -1746,27 +1778,6 @@ mod tests {
             .prove(&params, attrs.into_iter())
             .context("Cannot prove")?;
 
-        let commitment_1 = {
-            let (&rand_base, _, base) = params.vector_commitment_base();
-            let gis = base.take(24).copied().collect();
-            let vec_comm_key = VecCommitmentKey {
-                gs: gis,
-                h:  rand_base,
-            };
-            let committed_values = {
-                let mut out = Vec::new();
-                for (tag, value) in values_1.iter() {
-                    while out.len() < usize::from(*tag) {
-                        out.push(ArCurve::scalar_from_u64(0));
-                    }
-                    out.push(value.to_field_element());
-                }
-                out
-            };
-            vec_comm_key
-                .hide(&committed_values, &randomness_1)
-                .context("Unable to commit in the test.")?
-        };
         let commitments_2 = {
             let key = params.on_chain_commitment_key;
             let mut comms = BTreeMap::new();
@@ -1786,7 +1797,7 @@ mod tests {
 
         let public = vec![
             CredentialsInputs::Web3 {
-                commitment: commitment_1,
+                issuer_pk: issuer_1.public.into(),
             },
             CredentialsInputs::Account {
                 commitments: commitments_2,

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -1,5 +1,6 @@
 use concordium_base::{
     common::{base16_decode, base16_encode, SerdeDeserialize, SerdeSerialize},
+    contracts_common::ContractAddress,
     id::{
         constants::{ArCurve, IpPairing},
         curve_arithmetic::Curve,
@@ -230,9 +231,24 @@ impl ConcordiumHdWallet {
     /// which is necessary for it to be submitted to the storage contract.
     pub fn get_verifiable_credential_signing_key(
         &self,
+        issuer: ContractAddress,
         verifiable_credential_index: u32,
     ) -> Result<SecretKey, DeriveError> {
-        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 0])?;
+        let [i1, i2, i3, i4] = split_u64_into_chunks(issuer.index);
+        let [si1, si2, si3, si4] = split_u64_into_chunks(issuer.subindex);
+        let path = self.make_verifiable_credential_path(&[
+            0,
+            i1,
+            i2,
+            i3,
+            i4,
+            si1,
+            si2,
+            si3,
+            si4,
+            verifiable_credential_index,
+            0,
+        ])?;
         let keys = derive_from_parsed_path(&path, &self.seed)?;
         Ok(SecretKey::from_bytes(&keys.private_key)
             .expect("The byte array has correct length, so this cannot fail."))
@@ -246,24 +262,28 @@ impl ConcordiumHdWallet {
     /// [`get_verifiable_credential_signing_key`](Self::get_verifiable_credential_signing_key)
     pub fn get_verifiable_credential_public_key(
         &self,
+        issuer: ContractAddress,
         verifiable_credential_index: u32,
     ) -> Result<PublicKey, DeriveError> {
         let signing_key =
-            self.get_verifiable_credential_signing_key(verifiable_credential_index)?;
+            self.get_verifiable_credential_signing_key(issuer, verifiable_credential_index)?;
         let public_key = PublicKey::from(&signing_key);
         Ok(public_key)
     }
+}
 
-    /// Get the encryption key for the verifiable credential with the given
-    /// index. The encryption key is used as the key when encrypting the
-    /// verifiable credential before it is stored in the storage contract.
-    pub fn get_verifiable_credential_encryption_key(
-        &self,
-        verifiable_credential_index: u32,
-    ) -> Result<[u8; 32], DeriveError> {
-        let path = self.make_verifiable_credential_path(&[0, verifiable_credential_index, 1])?;
-        Ok(derive_from_parsed_path(&path, &self.seed)?.private_key)
-    }
+fn split_u64_into_chunks(x: u64) -> [u32; 4] {
+    let [b0, b1, b2, b3, b4, b5, b6, b7] = x.to_be_bytes();
+    let x0 = [b0, b1];
+    let x1 = [b2, b3];
+    let x2 = [b4, b5];
+    let x3 = [b6, b7];
+    [
+        u16::from_be_bytes(x0).into(),
+        u16::from_be_bytes(x1).into(),
+        u16::from_be_bytes(x2).into(),
+        u16::from_be_bytes(x3).into(),
+    ]
 }
 
 /// The [`ConcordiumHdWallet`] together indices that uniquely determine the
@@ -571,22 +591,22 @@ mod tests {
     #[test]
     pub fn mainnet_verifiable_credential_signing_key() {
         let signing_key = create_wallet(Net::Mainnet, TEST_SEED_1)
-            .get_verifiable_credential_signing_key(1)
+            .get_verifiable_credential_signing_key(ContractAddress::new(1, 2), 1)
             .unwrap();
         assert_eq!(
             hex::encode(&signing_key),
-            "875df27dc69b0ebcb3b362b00fdc95ad50353819087fa75d39ef0aa3f9a8104a"
+            "670d904509ce09372deb784e702d4951d4e24437ad3879188d71ae6db51f3301"
         );
     }
 
     #[test]
     pub fn mainnet_verifiable_credential_public_key() {
         let public_key = create_wallet(Net::Mainnet, TEST_SEED_1)
-            .get_verifiable_credential_public_key(341)
+            .get_verifiable_credential_public_key(ContractAddress::new(3, 1232), 341)
             .unwrap();
         assert_eq!(
             hex::encode(public_key),
-            "49efcf3adcfc87864cba5095dbf669fd9fa4529bba3fcecb3b1c0c12285530c8"
+            "16afdb3cb3568b5ad8f9a0fa3c741b065642de8c53e58f7920bf449e63ff2bf9"
         );
     }
 
@@ -594,8 +614,12 @@ mod tests {
     pub fn mainnet_verifiable_credential_signing_key_matches_public_key() {
         let wallet = create_wallet(Net::Mainnet, TEST_SEED_1);
 
-        let public_key = wallet.get_verifiable_credential_public_key(0).unwrap();
-        let signing_key = wallet.get_verifiable_credential_signing_key(0).unwrap();
+        let public_key = wallet
+            .get_verifiable_credential_public_key(ContractAddress::new(1337, 0), 0)
+            .unwrap();
+        let signing_key = wallet
+            .get_verifiable_credential_signing_key(ContractAddress::new(1337, 0), 0)
+            .unwrap();
         let expanded_sk = ExpandedSecretKey::from(&signing_key);
 
         let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
@@ -608,35 +632,24 @@ mod tests {
     }
 
     #[test]
-    pub fn mainnet_verifiable_credential_encryption_key() {
-        let wallet = create_wallet(Net::Mainnet, TEST_SEED_1);
-        let encryption_key = wallet.get_verifiable_credential_encryption_key(97).unwrap();
-
-        assert_eq!(
-            hex::encode(encryption_key),
-            "30be8892d89599867fca90dcd841ac62cc07ea0ea521e8708eb8ae143c093210"
-        );
-    }
-
-    #[test]
     pub fn testnet_verifiable_credential_signing_key() {
         let signing_key = create_wallet(Net::Testnet, TEST_SEED_1)
-            .get_verifiable_credential_signing_key(1)
+            .get_verifiable_credential_signing_key(ContractAddress::new(13, 0), 1)
             .unwrap();
         assert_eq!(
             hex::encode(&signing_key),
-            "c53e2259d321b55637952951ea56bcae336404765b85c3ba78ca22a9d06bb40f"
+            "c75a161b97a1e204d9f31202308958e541e14f0b14903bd220df883bd06702bb"
         );
     }
 
     #[test]
     pub fn testnet_verifiable_credential_public_key() {
         let public_key = create_wallet(Net::Testnet, TEST_SEED_1)
-            .get_verifiable_credential_public_key(341)
+            .get_verifiable_credential_public_key(ContractAddress::new(17, 0), 341)
             .unwrap();
         assert_eq!(
             hex::encode(public_key),
-            "20a5ce34364e1f1ce619fdfb12daa806e5e86ef44971f3c9cf1ec6b8b58e27d3"
+            "c52a30475bac88da9e65471cf9cf59f99dcce22ce31de580b3066597746b394a"
         );
     }
 
@@ -644,8 +657,12 @@ mod tests {
     pub fn testnet_verifiable_credential_signing_key_matches_public_key() {
         let wallet = create_wallet(Net::Testnet, TEST_SEED_1);
 
-        let public_key = wallet.get_verifiable_credential_public_key(0).unwrap();
-        let signing_key = wallet.get_verifiable_credential_signing_key(0).unwrap();
+        let public_key = wallet
+            .get_verifiable_credential_public_key(ContractAddress::new(13, 0), 0)
+            .unwrap();
+        let signing_key = wallet
+            .get_verifiable_credential_signing_key(ContractAddress::new(13, 0), 0)
+            .unwrap();
         let expanded_sk = ExpandedSecretKey::from(&signing_key);
 
         let data_to_sign = hex::decode("abcd1234abcd5678").unwrap();
@@ -654,17 +671,6 @@ mod tests {
         public_key.verify(&data_to_sign, &signature).expect(
             "The public key should be able to verify the signature, otherwise the keys do not \
              match.",
-        );
-    }
-
-    #[test]
-    pub fn testnet_verifiable_credential_encryption_key() {
-        let wallet = create_wallet(Net::Testnet, TEST_SEED_1);
-        let encryption_key = wallet.get_verifiable_credential_encryption_key(97).unwrap();
-
-        assert_eq!(
-            hex::encode(encryption_key),
-            "f263c915c8000b5164e3fc1d84ce80a451eef2b32f9749a4d0d390844bb1673e"
         );
     }
 }


### PR DESCRIPTION
## Purpose

Revise web3id proofs since we are no longer storing commitments on the chain.

## Changes

- Commitments are now sent as part of the proof.
- The signature on the commitments is checked as part of proof verification.
- Change the derivation path for holder keys to include the contract address.
- Remove generating encryption key from the seed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
