### PR TITLE
Remove the unneeded "Base" associated type.

### DIFF
--- a/rust-src/concordium_base/src/curve_arithmetic/bls12_381_instance.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/bls12_381_instance.rs
@@ -4,8 +4,8 @@ use ff::{Field, PrimeField};
 use group::{CurveAffine, CurveProjective, EncodedPoint};
 use pairing::{
     bls12_381::{
-        Bls12, Fq, Fr, FrRepr, G1Affine, G1Compressed, G1Prepared, G2Affine, G2Compressed,
-        G2Prepared, G1, G2,
+        Bls12, Fr, FrRepr, G1Affine, G1Compressed, G1Prepared, G2Affine, G2Compressed, G2Prepared,
+        G1, G2,
     },
     Engine, PairingCurveAffine,
 };
@@ -30,7 +30,6 @@ fn scalar_from_bytes_helper<A: AsRef<[u8]>>(bytes: A) -> Fr {
 }
 
 impl Curve for G2 {
-    type Base = Fq;
     type Compressed = G2Compressed;
     type Scalar = Fr;
 
@@ -114,7 +113,6 @@ impl Curve for G2 {
 }
 
 impl Curve for G1 {
-    type Base = Fq;
     type Compressed = G1Compressed;
     type Scalar = Fr;
 
@@ -198,7 +196,6 @@ impl Curve for G1 {
 }
 
 impl Curve for G1Affine {
-    type Base = Fq;
     type Compressed = G1Compressed;
     type Scalar = Fr;
 
@@ -279,7 +276,6 @@ impl Curve for G1Affine {
 }
 
 impl Curve for G2Affine {
-    type Base = Fq;
     type Compressed = G2Compressed;
     type Scalar = Fr;
 

--- a/rust-src/concordium_base/src/curve_arithmetic/mod.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/mod.rs
@@ -28,8 +28,6 @@ pub trait Curve:
     Serialize + Copy + Clone + Sized + Send + Sync + Debug + PartialEq + Eq + 'static {
     /// The prime field of the group order size.
     type Scalar: PrimeField + Field + Serialize;
-    /// The base field of the curve. In general larger than the Scalar field.
-    type Base: Field;
     /// A compressed representation of curve points used for compact
     /// serialization.
     type Compressed;
@@ -96,10 +94,10 @@ pub trait Curve:
 pub trait Pairing: Sized + 'static + Clone {
     type ScalarField: PrimeField + Serialize;
     /// The first group of the pairing.
-    type G1: Curve<Base = Self::BaseField, Scalar = Self::ScalarField>;
+    type G1: Curve<Scalar = Self::ScalarField>;
     /// The second group, must have the same order as [Pairing::G1]. Both G1 and
     /// G2 must be of prime order size.
-    type G2: Curve<Base = Self::BaseField, Scalar = Self::ScalarField>;
+    type G2: Curve<Scalar = Self::ScalarField>;
     /// An auxiliary type that is used as an input to the pairing function.
     type G1Prepared;
     /// An auxiliary type that is used as an input to the pairing function.


### PR DESCRIPTION
## Purpose

Remove the unneeded Base field. It's redefined in the Pairing trait.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.