### PR TITLE
Add proof version and improve range proofs

### DIFF
--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -15,7 +15,7 @@ use concordium_base::{
     id::{
         self, account_holder,
         constants::{ArCurve, AttributeKind},
-        id_proof_types::{Statement, StatementWithContext, ProofVersion},
+        id_proof_types::{ProofVersion, Statement, StatementWithContext},
         pedersen_commitment::Value as PedersenValue,
         ps_sig,
         secret_sharing::Threshold,
@@ -1051,7 +1051,13 @@ fn prove_id_statement_aux(input: &str) -> anyhow::Result<String> {
     let id_object: IdentityObjectV1<Bls12, ArCurve, AttributeKind> = try_get(&v, "identityObject")?;
     let challenge: [u8; 32] = try_get(&v, "challenge")?;
     let proof = statement
-        .prove(&ProofVersion::Version1, &global, &challenge, &id_object.alist, &credential_context)
+        .prove(
+            &ProofVersion::Version1,
+            &global,
+            &challenge,
+            &id_object.alist,
+            &credential_context,
+        )
         .context("Could not produce proof.")?;
     let response = serde_json::json!({
         "idProof": common::Versioned::new(common::VERSION_0, proof),

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -15,7 +15,7 @@ use concordium_base::{
     id::{
         self, account_holder,
         constants::{ArCurve, AttributeKind},
-        id_proof_types::{Statement, StatementWithContext},
+        id_proof_types::{Statement, StatementWithContext, ProofVersion},
         pedersen_commitment::Value as PedersenValue,
         ps_sig,
         secret_sharing::Threshold,
@@ -1051,7 +1051,7 @@ fn prove_id_statement_aux(input: &str) -> anyhow::Result<String> {
     let id_object: IdentityObjectV1<Bls12, ArCurve, AttributeKind> = try_get(&v, "identityObject")?;
     let challenge: [u8; 32] = try_get(&v, "challenge")?;
     let proof = statement
-        .prove(&global, &challenge, &id_object.alist, &credential_context)
+        .prove(&ProofVersion::Version1, &global, &challenge, &id_object.alist, &credential_context)
         .context("Could not produce proof.")?;
     let response = serde_json::json!({
         "idProof": common::Versioned::new(common::VERSION_0, proof),

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -1052,7 +1052,7 @@ fn prove_id_statement_aux(input: &str) -> anyhow::Result<String> {
     let challenge: [u8; 32] = try_get(&v, "challenge")?;
     let proof = statement
         .prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &global,
             &challenge,
             &id_object.alist,

--- a/rust-src/concordium_base/benches/bulletproofs.rs
+++ b/rust-src/concordium_base/benches/bulletproofs.rs
@@ -6,6 +6,7 @@ extern crate criterion;
 use concordium_base::{
     bulletproofs::{inner_product_proof::*, range_proof::*, utils::Generators},
     curve_arithmetic::*,
+    id::id_proof_types::ProofVersion,
     pedersen_commitment::*,
     random_oracle::RandomOracle,
 };
@@ -71,6 +72,7 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     group.bench_function("Prove", move |b| {
         b.iter(|| {
             prove(
+                &ProofVersion::Version1,
                 &mut transcript,
                 rng,
                 n,
@@ -86,6 +88,7 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     let rng = &mut thread_rng();
     let mut transcript = RandomOracle::empty();
     let proof = prove(
+        &ProofVersion::Version1,
         &mut transcript,
         rng,
         n,
@@ -100,9 +103,16 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     group.bench_function("Verify Efficient", move |b| {
         b.iter(|| {
             let mut transcript = RandomOracle::empty();
-            assert!(
-                verify_efficient(&mut transcript, n, &commitments, &proof, &gens, &keys).is_ok()
-            );
+            assert!(verify_efficient(
+                &ProofVersion::Version1,
+                &mut transcript,
+                n,
+                &commitments,
+                &proof,
+                &gens,
+                &keys
+            )
+            .is_ok());
         })
     });
 }

--- a/rust-src/concordium_base/benches/bulletproofs.rs
+++ b/rust-src/concordium_base/benches/bulletproofs.rs
@@ -72,7 +72,7 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     group.bench_function("Prove", move |b| {
         b.iter(|| {
             prove(
-                &ProofVersion::Version1,
+                ProofVersion::Version1,
                 &mut transcript,
                 rng,
                 n,
@@ -88,7 +88,7 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
     let rng = &mut thread_rng();
     let mut transcript = RandomOracle::empty();
     let proof = prove(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         &mut transcript,
         rng,
         n,
@@ -104,7 +104,7 @@ pub fn prove_verify_benchmarks(c: &mut Criterion) {
         b.iter(|| {
             let mut transcript = RandomOracle::empty();
             assert!(verify_efficient(
-                &ProofVersion::Version1,
+                ProofVersion::Version1,
                 &mut transcript,
                 n,
                 &commitments,

--- a/rust-src/concordium_base/benches/set_proof_bench.rs
+++ b/rust-src/concordium_base/benches/set_proof_bench.rs
@@ -5,6 +5,7 @@ extern crate criterion;
 use concordium_base::{
     bulletproofs::{set_membership_proof, set_non_membership_proof, utils::Generators},
     curve_arithmetic::*,
+    id::id_proof_types::ProofVersion,
     pedersen_commitment::{CommitmentKey, Randomness},
     random_oracle::RandomOracle,
 };
@@ -68,6 +69,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
                 let rng = &mut thread_rng();
                 let mut transcript = RandomOracle::empty();
                 set_membership_proof::prove(
+                    &ProofVersion::Version1,
                     &mut transcript,
                     rng,
                     &the_set_p,
@@ -90,6 +92,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
                 let rng = &mut thread_rng();
                 let mut transcript = RandomOracle::empty();
                 set_non_membership_proof::prove(
+                    &ProofVersion::Version1,
                     &mut transcript,
                     rng,
                     &the_set_p,
@@ -105,6 +108,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
         // Generate valid proofs for verification
         let mut transcript = RandomOracle::empty();
         let snm_proof = set_non_membership_proof::prove(
+            &ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -116,8 +120,16 @@ pub fn bench_set_proofs(c: &mut Criterion) {
         assert!(snm_proof.is_ok());
         let snm_proof = snm_proof.unwrap();
         let mut transcript = RandomOracle::empty();
-        let sm_proof =
-            set_membership_proof::prove(&mut transcript, rng, &the_set, w, &gens, &v_keys, &w_rand);
+        let sm_proof = set_membership_proof::prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            w,
+            &gens,
+            &v_keys,
+            &w_rand,
+        );
         assert!(sm_proof.is_ok());
         let sm_proof = sm_proof.unwrap();
 
@@ -131,6 +143,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
             b.iter(|| {
                 let mut transcript = RandomOracle::empty();
                 set_membership_proof::verify(
+                    &ProofVersion::Version1,
                     &mut transcript,
                     &the_set_p,
                     &w_com_p,
@@ -152,6 +165,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
             b.iter(|| {
                 let mut transcript = RandomOracle::empty();
                 set_non_membership_proof::verify(
+                    &ProofVersion::Version1,
                     &mut transcript,
                     &the_set_p,
                     &v_com_p,

--- a/rust-src/concordium_base/benches/set_proof_bench.rs
+++ b/rust-src/concordium_base/benches/set_proof_bench.rs
@@ -69,7 +69,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
                 let rng = &mut thread_rng();
                 let mut transcript = RandomOracle::empty();
                 set_membership_proof::prove(
-                    &ProofVersion::Version1,
+                    ProofVersion::Version1,
                     &mut transcript,
                     rng,
                     &the_set_p,
@@ -92,7 +92,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
                 let rng = &mut thread_rng();
                 let mut transcript = RandomOracle::empty();
                 set_non_membership_proof::prove(
-                    &ProofVersion::Version1,
+                    ProofVersion::Version1,
                     &mut transcript,
                     rng,
                     &the_set_p,
@@ -108,7 +108,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
         // Generate valid proofs for verification
         let mut transcript = RandomOracle::empty();
         let snm_proof = set_non_membership_proof::prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -121,7 +121,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
         let snm_proof = snm_proof.unwrap();
         let mut transcript = RandomOracle::empty();
         let sm_proof = set_membership_proof::prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -143,7 +143,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
             b.iter(|| {
                 let mut transcript = RandomOracle::empty();
                 set_membership_proof::verify(
-                    &ProofVersion::Version1,
+                    ProofVersion::Version1,
                     &mut transcript,
                     &the_set_p,
                     &w_com_p,
@@ -165,7 +165,7 @@ pub fn bench_set_proofs(c: &mut Criterion) {
             b.iter(|| {
                 let mut transcript = RandomOracle::empty();
                 set_non_membership_proof::verify(
-                    &ProofVersion::Version1,
+                    ProofVersion::Version1,
                     &mut transcript,
                     &the_set_p,
                     &v_com_p,

--- a/rust-src/concordium_base/src/bulletproofs/range_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/range_proof.rs
@@ -79,7 +79,7 @@ fn two_n_vec<F: Field>(n: u8) -> Vec<F> {
 /// See the documentation of `prove` below for the meaning of arguments.
 #[allow(clippy::too_many_arguments)]
 pub fn prove_given_scalars<C: Curve, T: Rng>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     csprng: &mut T,
     n: u8,
@@ -123,7 +123,7 @@ pub fn prove_given_scalars<C: Curve, T: Rng>(
 #[allow(non_snake_case)]
 #[allow(clippy::too_many_arguments)]
 pub fn prove<C: Curve, T: Rng>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     csprng: &mut T,
     n: u8,
@@ -190,7 +190,7 @@ pub fn prove<C: Curve, T: Rng>(
         V_vec.push(V_j);
     }
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add n, generators and commitment keys to the transcript
         transcript.append_message(b"n", &n);
         transcript.append_message(b"G", &G);
@@ -490,7 +490,7 @@ pub enum VerificationError {
 #[allow(clippy::too_many_arguments)]
 #[allow(clippy::many_single_char_names)]
 pub fn verify_efficient<C: Curve>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     n: u8,
     commitments: &[Commitment<C>],
@@ -514,7 +514,7 @@ pub fn verify_efficient<C: Curve>(
         transcript.append_message(b"Vj", &V.0);
     }
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add n, generators and commitment keys to the transcript
         transcript.append_message(b"n", &n);
         transcript.append_message(b"G", &G);
@@ -692,7 +692,7 @@ pub fn prove_less_than_or_equal<C: Curve, T: Rng>(
     let mut randomness = **randomness_b;
     randomness.sub_assign(randomness_a);
     prove(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         transcript,
         csprng,
         n,
@@ -719,7 +719,7 @@ pub fn verify_less_than_or_equal<C: Curve>(
 ) -> bool {
     let commitment = Commitment(commitment_b.0.minus_point(&commitment_a.0));
     verify_efficient(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         transcript,
         n,
         &[commitment, *commitment_a],
@@ -919,7 +919,7 @@ mod tests {
         }
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             n,
@@ -933,7 +933,7 @@ mod tests {
         let proof = proof.unwrap();
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             n,
             &commitments,
@@ -945,7 +945,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             n,
@@ -959,7 +959,7 @@ mod tests {
         let proof = proof.unwrap();
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             n,
             &commitments,
@@ -1019,7 +1019,7 @@ mod tests {
         }
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             n,
@@ -1034,7 +1034,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             n,
             &commitments,
@@ -1046,7 +1046,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             n,
@@ -1061,7 +1061,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             n,
             &commitments,
@@ -1173,7 +1173,7 @@ mod tests {
         let proof = proof.unwrap();
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             n,
             &commitments,
@@ -1221,7 +1221,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             n,
@@ -1236,7 +1236,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let result = verify_efficient(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             n,
             &commitments,

--- a/rust-src/concordium_base/src/bulletproofs/set_membership_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/set_membership_proof.rs
@@ -87,7 +87,7 @@ fn a_L_a_R<F: Field>(v: &F, set_slice: &[F]) -> Option<(Vec<F>, Vec<F>)> {
 ///   `k` where k is the smallest power of two >= `|the_set|`
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in the bluepaper)
 /// - `v_rand` - the randomness used to commit to `v` using `v_keys`
-#[allow(non_snake_case)]
+#[allow(non_snake_case, clippy::too_many_arguments)]
 pub fn prove<C: Curve, R: Rng>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,

--- a/rust-src/concordium_base/src/bulletproofs/set_membership_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/set_membership_proof.rs
@@ -89,7 +89,7 @@ fn a_L_a_R<F: Field>(v: &F, set_slice: &[F]) -> Option<(Vec<F>, Vec<F>)> {
 /// - `v_rand` - the randomness used to commit to `v` using `v_keys`
 #[allow(non_snake_case, clippy::too_many_arguments)]
 pub fn prove<C: Curve, R: Rng>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     csprng: &mut R,
     the_set: &[C::Scalar],
@@ -122,7 +122,7 @@ pub fn prove<C: Curve, R: Rng>(
     // Select generators for vector commitments
     let (G, H): (Vec<_>, Vec<_>) = gens.G_H.iter().take(n).cloned().unzip();
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add generators and commitment keys to the transcript
         transcript.append_message(b"G", &G);
         transcript.append_message(b"H", &H);
@@ -369,7 +369,7 @@ pub enum VerificationError {
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in bluepaper)
 #[allow(non_snake_case)]
 pub fn verify<C: Curve>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     the_set: &[C::Scalar],
     V: &Commitment<C>,
@@ -394,7 +394,7 @@ pub fn verify<C: Curve>(
     transcript.append_message(b"V", &V.0);
     transcript.append_message(b"theSet", &set_vec);
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add generators and commitment keys to the transcript
         transcript.append_message(b"G", &G);
         transcript.append_message(b"H", &H);
@@ -609,7 +609,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -624,7 +624,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -637,7 +637,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -652,7 +652,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,
@@ -677,7 +677,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -692,7 +692,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -704,7 +704,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -719,7 +719,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,
@@ -742,7 +742,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -769,7 +769,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -786,7 +786,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -811,7 +811,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -828,7 +828,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &new_set,
             &v_com,
@@ -852,7 +852,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -870,7 +870,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -897,7 +897,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -913,7 +913,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -926,7 +926,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -942,7 +942,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,

--- a/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
@@ -3,6 +3,7 @@ use super::{inner_product_proof::*, utils::*};
 use crate::{
     common::*,
     curve_arithmetic::{multiexp, multiexp_table, multiexp_worker_given_table, Curve},
+    id::id_proof_types::ProofVersion,
     pedersen_commitment::*,
     random_oracle::RandomOracle,
 };
@@ -60,6 +61,7 @@ pub enum ProverError {
 /// - `v_rand` - the randomness used to commit to `v` using `v_keys`
 #[allow(non_snake_case)]
 pub fn prove<C: Curve, R: Rng>(
+    version: &ProofVersion,
     transcript: &mut RandomOracle,
     csprng: &mut R,
     the_set: &[C::Scalar],
@@ -107,6 +109,13 @@ pub fn prove<C: Curve, R: Rng>(
     );
     let G = &GH_B_tilde[0..n];
     let H = &GH_B_tilde[n..2 * n];
+
+    if let ProofVersion::Version2 = version {
+        // Explicitly add generators and commitment keys to the transcript
+        transcript.append_message(b"G", &G);
+        transcript.append_message(b"H", &H);
+        transcript.append_message(b"v_keys", v_keys);
+    }
 
     // Compute A_scalars, that is a_L, a_R and a_tilde
     let mut A_scalars = Vec::with_capacity(2 * n + 1);
@@ -332,6 +341,7 @@ pub enum VerificationError {
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in bluepaper)
 #[allow(non_snake_case)]
 pub fn verify<C: Curve>(
+    version: &ProofVersion,
     transcript: &mut RandomOracle,
     the_set: &[C::Scalar],
     V: &Commitment<C>,
@@ -355,6 +365,13 @@ pub fn verify<C: Curve>(
     // append commitment V to transcript
     transcript.append_message(b"V", &V.0);
     transcript.append_message(b"theSet", &set_vec);
+
+    if let ProofVersion::Version2 = version {
+        // Explicitly add generators and commitment keys to the transcript
+        transcript.append_message(b"G", &G);
+        transcript.append_message(b"H", &H);
+        transcript.append_message(b"v_keys", v_keys);
+    }
 
     // define the commitments A,S
     let A = proof.A;
@@ -502,11 +519,11 @@ mod tests {
 
     /// Generates commitment to v given commitment key and randomness
     fn get_v_com(
-        v: <SomeCurve as Curve>::Scalar,
-        v_keys: CommitmentKey<G1>,
-        v_rand: Randomness<G1>,
+        v: &<SomeCurve as Curve>::Scalar,
+        v_keys: &CommitmentKey<G1>,
+        v_rand: &Randomness<G1>,
     ) -> Commitment<G1> {
-        let v_value = Value::<SomeCurve>::new(v);
+        let v_value = Value::<SomeCurve>::new(*v);
 
         v_keys.hide(&v_value, &v_rand)
     }
@@ -520,18 +537,63 @@ mod tests {
         let v = SomeCurve::scalar_from_u64(4);
         let n = the_set.len();
         let (gens, v_keys, v_rand) = generate_helper_values(n);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
 
         // prove
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let proof = proof.unwrap();
 
         // verify
-        let v_com = get_v_com(v, v_keys, v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
-        assert!(result.is_ok());
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 1 proof should verify");
+
+        // prove
+        let mut transcript = RandomOracle::empty();
+        let proof = prove(
+            &ProofVersion::Version2,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
+        assert!(proof.is_ok());
+        let proof = proof.unwrap();
+
+        // verify
+        let mut transcript = RandomOracle::empty();
+        let result = verify(
+            &ProofVersion::Version2,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 2 proof should verify");
     }
 
     /// Test that sets with sizes not a power of two work
@@ -544,17 +606,61 @@ mod tests {
         let n = the_set.len();
         let k = n.next_power_of_two();
         let (gens, v_keys, v_rand) = generate_helper_values(k);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
 
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let proof = proof.unwrap();
 
         // verify
-        let v_com = get_v_com(v, v_keys, v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
-        assert!(result.is_ok());
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 1 proof should verify");
+
+        let mut transcript = RandomOracle::empty();
+        let proof = prove(
+            &ProofVersion::Version2,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
+        assert!(proof.is_ok());
+        let proof = proof.unwrap();
+
+        // verify
+        let mut transcript = RandomOracle::empty();
+        let result = verify(
+            &ProofVersion::Version2,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 2 proof should verify");
     }
 
     /// Test that proof fails if element is in the set
@@ -568,7 +674,16 @@ mod tests {
         let (gens, v_keys, v_rand) = generate_helper_values(n);
 
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(matches!(proof, Err(ProverError::CouldFindValueInSet)));
     }
 
@@ -586,15 +701,32 @@ mod tests {
 
         // prove
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let proof = proof.unwrap();
 
         // verify
         let v = SomeCurve::scalar_from_u64(42); // different v still in set
-        let v_com = get_v_com(v, v_keys, v_rand);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
         assert!(matches!(result, Err(VerificationError::InconsistentT0)));
     }
 
@@ -611,15 +743,32 @@ mod tests {
 
         // prove
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let proof = proof.unwrap();
 
         // verify
         let new_set = get_set_vector::<SomeCurve>(&[2, 7, 3, 5]);
-        let v_com = get_v_com(v, v_keys, v_rand);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &new_set, &v_com, &proof, &gens, &v_keys);
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &new_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
         assert!(matches!(result, Err(VerificationError::InconsistentT0)));
     }
 
@@ -635,16 +784,33 @@ mod tests {
 
         // prove
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let mut proof = proof.unwrap();
 
         proof.ip_proof.a.negate(); // tamper with IP proof
 
         // verify
-        let v_com = get_v_com(v, v_keys, v_rand);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
         assert!(matches!(
             result,
             Err(VerificationError::IPVerificationError)
@@ -660,17 +826,62 @@ mod tests {
         let v = SomeCurve::scalar_from_u64(4);
         let num_gens = 2112;
         let (gens, v_keys, v_rand) = generate_helper_values(num_gens);
+        let v_com = get_v_com(&v, &v_keys, &v_rand);
 
         // prove
         let mut transcript = RandomOracle::empty();
-        let proof = prove(&mut transcript, rng, &the_set, v, &gens, &v_keys, &v_rand);
+        let proof = prove(
+            &ProofVersion::Version1,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
         assert!(proof.is_ok());
         let proof = proof.unwrap();
 
         // verify
-        let v_com = get_v_com(v, v_keys, v_rand);
         let mut transcript = RandomOracle::empty();
-        let result = verify(&mut transcript, &the_set, &v_com, &proof, &gens, &v_keys);
-        assert!(result.is_ok());
+        let result = verify(
+            &ProofVersion::Version1,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 1 proof should verify");
+
+        // prove
+        let mut transcript = RandomOracle::empty();
+        let proof = prove(
+            &ProofVersion::Version2,
+            &mut transcript,
+            rng,
+            &the_set,
+            v,
+            &gens,
+            &v_keys,
+            &v_rand,
+        );
+        assert!(proof.is_ok());
+        let proof = proof.unwrap();
+
+        // verify
+        let mut transcript = RandomOracle::empty();
+        let result = verify(
+            &ProofVersion::Version2,
+            &mut transcript,
+            &the_set,
+            &v_com,
+            &proof,
+            &gens,
+            &v_keys,
+        );
+        assert!(result.is_ok(), "Version 2 proof should verify");
     }
 }

--- a/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
@@ -61,7 +61,7 @@ pub enum ProverError {
 /// - `v_rand` - the randomness used to commit to `v` using `v_keys`
 #[allow(non_snake_case, clippy::too_many_arguments)]
 pub fn prove<C: Curve, R: Rng>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     csprng: &mut R,
     the_set: &[C::Scalar],
@@ -110,7 +110,7 @@ pub fn prove<C: Curve, R: Rng>(
     let G = &GH_B_tilde[0..n];
     let H = &GH_B_tilde[n..2 * n];
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add generators and commitment keys to the transcript
         transcript.append_message(b"G", &G);
         transcript.append_message(b"H", &H);
@@ -341,7 +341,7 @@ pub enum VerificationError {
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in bluepaper)
 #[allow(non_snake_case)]
 pub fn verify<C: Curve>(
-    version: &ProofVersion,
+    version: ProofVersion,
     transcript: &mut RandomOracle,
     the_set: &[C::Scalar],
     V: &Commitment<C>,
@@ -366,7 +366,7 @@ pub fn verify<C: Curve>(
     transcript.append_message(b"V", &V.0);
     transcript.append_message(b"theSet", &set_vec);
 
-    if let ProofVersion::Version2 = version {
+    if version >= ProofVersion::Version2 {
         // Explicitly add generators and commitment keys to the transcript
         transcript.append_message(b"G", &G);
         transcript.append_message(b"H", &H);
@@ -542,7 +542,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -557,7 +557,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -570,7 +570,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -585,7 +585,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,
@@ -610,7 +610,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -625,7 +625,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -637,7 +637,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -652,7 +652,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,
@@ -675,7 +675,7 @@ mod tests {
 
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -702,7 +702,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -719,7 +719,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -744,7 +744,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -761,7 +761,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &new_set,
             &v_com,
@@ -785,7 +785,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -803,7 +803,7 @@ mod tests {
         let v_com = get_v_com(&v, &v_keys, &v_rand);
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -831,7 +831,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             rng,
             &the_set,
@@ -846,7 +846,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             &mut transcript,
             &the_set,
             &v_com,
@@ -859,7 +859,7 @@ mod tests {
         // prove
         let mut transcript = RandomOracle::empty();
         let proof = prove(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             rng,
             &the_set,
@@ -874,7 +874,7 @@ mod tests {
         // verify
         let mut transcript = RandomOracle::empty();
         let result = verify(
-            &ProofVersion::Version2,
+            ProofVersion::Version2,
             &mut transcript,
             &the_set,
             &v_com,

--- a/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
+++ b/rust-src/concordium_base/src/bulletproofs/set_non_membership_proof.rs
@@ -59,7 +59,7 @@ pub enum ProverError {
 ///   in bluepaper)
 /// - `v_keys` - commitment keys `B` and `B_tilde` (`g,h` in the bluepaper)
 /// - `v_rand` - the randomness used to commit to `v` using `v_keys`
-#[allow(non_snake_case)]
+#[allow(non_snake_case, clippy::too_many_arguments)]
 pub fn prove<C: Curve, R: Rng>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,

--- a/rust-src/concordium_base/src/encrypted_transfers/proofs/generate_proofs.rs
+++ b/rust-src/concordium_base/src/encrypted_transfers/proofs/generate_proofs.rs
@@ -268,7 +268,7 @@ pub fn gen_enc_trans<C: Curve, R: Rng>(
         .map(|x| PedersenRandomness::new(*(x.as_ref())))
         .collect();
     let bulletproof_a = bulletprove(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -280,7 +280,7 @@ pub fn gen_enc_trans<C: Curve, R: Rng>(
     )?;
 
     let bulletproof_s_prime = bulletprove(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -429,7 +429,7 @@ pub fn gen_sec_to_pub_trans<C: Curve, R: Rng>(
         .collect();
 
     let bulletproof_s_prime = bulletprove(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -545,7 +545,7 @@ pub fn verify_enc_trans<C: Curve>(
     };
 
     let first_bulletproof = verify_efficient(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         u8::from(CHUNK_SIZE),
         &commitments_a,
@@ -557,7 +557,7 @@ pub fn verify_enc_trans<C: Curve>(
         return Err(VerificationError::FirstBulletproofError(err));
     }
     let second_bulletproof = verify_efficient(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         u8::from(CHUNK_SIZE),
         &commitments_s_prime,
@@ -641,7 +641,7 @@ pub fn verify_sec_to_pub_trans<C: Curve>(
     let num_bits_in_chunk = (64 / num_chunks) as u8; // as is safe here because the number is < 64
 
     let bulletproof = verify_efficient(
-        &ProofVersion::Version1,
+        ProofVersion::Version1,
         ro,
         num_bits_in_chunk,
         &commitments_s_prime,

--- a/rust-src/concordium_base/src/encrypted_transfers/proofs/generate_proofs.rs
+++ b/rust-src/concordium_base/src/encrypted_transfers/proofs/generate_proofs.rs
@@ -11,6 +11,7 @@ use crate::{
     curve_arithmetic::{Curve, Value},
     elgamal::{Cipher, PublicKey, Randomness, SecretKey},
     id::{
+        id_proof_types::ProofVersion,
         sigma_protocols::{com_eq::*, common::*, dlog::*},
         types::GlobalContext,
     },
@@ -267,6 +268,7 @@ pub fn gen_enc_trans<C: Curve, R: Rng>(
         .map(|x| PedersenRandomness::new(*(x.as_ref())))
         .collect();
     let bulletproof_a = bulletprove(
+        &ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -278,6 +280,7 @@ pub fn gen_enc_trans<C: Curve, R: Rng>(
     )?;
 
     let bulletproof_s_prime = bulletprove(
+        &ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -426,6 +429,7 @@ pub fn gen_sec_to_pub_trans<C: Curve, R: Rng>(
         .collect();
 
     let bulletproof_s_prime = bulletprove(
+        &ProofVersion::Version1,
         ro,
         csprng,
         u8::from(CHUNK_SIZE),
@@ -541,6 +545,7 @@ pub fn verify_enc_trans<C: Curve>(
     };
 
     let first_bulletproof = verify_efficient(
+        &ProofVersion::Version1,
         ro,
         u8::from(CHUNK_SIZE),
         &commitments_a,
@@ -552,6 +557,7 @@ pub fn verify_enc_trans<C: Curve>(
         return Err(VerificationError::FirstBulletproofError(err));
     }
     let second_bulletproof = verify_efficient(
+        &ProofVersion::Version1,
         ro,
         u8::from(CHUNK_SIZE),
         &commitments_s_prime,
@@ -635,6 +641,7 @@ pub fn verify_sec_to_pub_trans<C: Curve>(
     let num_bits_in_chunk = (64 / num_chunks) as u8; // as is safe here because the number is < 64
 
     let bulletproof = verify_efficient(
+        &ProofVersion::Version1,
         ro,
         num_bits_in_chunk,
         &commitments_s_prime,

--- a/rust-src/concordium_base/src/id/account_holder.rs
+++ b/rust-src/concordium_base/src/id/account_holder.rs
@@ -452,7 +452,7 @@ fn generate_pio_common<'a, P: Pairing, C: Curve<Scalar = P::ScalarField>, R: ran
             .map(|x| PedersenRandomness::new(*x.as_ref()))
             .collect::<Vec<_>>();
         let bulletproof = bulletprove(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             transcript,
             csprng,
             u8::from(CHUNK_SIZE),

--- a/rust-src/concordium_base/src/id/account_holder.rs
+++ b/rust-src/concordium_base/src/id/account_holder.rs
@@ -1,6 +1,7 @@
 //! Functionality needed by the account holder, either when interacting with the
 //! identity provider, or when interacting with the chain.
 use super::{
+    id_proof_types::ProofVersion,
     secret_sharing::*,
     sigma_protocols::{
         com_enc_eq, com_eq, com_eq_different_groups, com_eq_sig, com_mult, common::*, dlog,
@@ -451,6 +452,7 @@ fn generate_pio_common<'a, P: Pairing, C: Curve<Scalar = P::ScalarField>, R: ran
             .map(|x| PedersenRandomness::new(*x.as_ref()))
             .collect::<Vec<_>>();
         let bulletproof = bulletprove(
+            &ProofVersion::Version1,
             transcript,
             csprng,
             u8::from(CHUNK_SIZE),

--- a/rust-src/concordium_base/src/id/id_proof_types.rs
+++ b/rust-src/concordium_base/src/id/id_proof_types.rs
@@ -18,6 +18,7 @@ use pairing::bls12_381::G1;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use std::{collections::BTreeSet, convert::TryFrom, marker::PhantomData, str::FromStr};
 
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Copy)]
 pub enum ProofVersion {
     Version1,
     Version2,

--- a/rust-src/concordium_base/src/id/id_proof_types.rs
+++ b/rust-src/concordium_base/src/id/id_proof_types.rs
@@ -18,6 +18,11 @@ use pairing::bls12_381::G1;
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use std::{collections::BTreeSet, convert::TryFrom, marker::PhantomData, str::FromStr};
 
+pub enum ProofVersion {
+    Version1,
+    Version2,
+}
+
 /// For the case where the verifier wants the user to show the value of an
 /// attribute and prove that it is indeed the value inside the on-chain
 /// commitment. Since the verifier does not know the attribute value before

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -264,7 +264,7 @@ pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     }
 }
 
-/// Helper function for producing a range proof.     
+/// Helper function for producing a range proof.
 #[allow(clippy::too_many_arguments)]
 fn prove_attribute_in_range_helper<C: Curve>(
     version: &ProofVersion,

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -85,6 +85,12 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 let x = attribute.to_field_element(); // This is public in the sense that the verifier should learn it
                 transcript.add_bytes(b"RevealAttributeDlogProof");
                 transcript.append_message(b"x", &x);
+                if let ProofVersion::Version2 = version {
+                    transcript.append_message(b"keys", &global.on_chain_commitment_key);
+                    let x_value: Value<C> = Value::new(x);
+                    let comm = global.on_chain_commitment_key.hide(&x_value, &randomness);
+                    transcript.append_message(b"C", &comm);
+                }
                 // This is the Dlog proof section 9.2.4 from the Bluepaper.
                 let h = global.on_chain_commitment_key.h;
                 let h_r = h.mul_by_scalar(&randomness);

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -215,6 +215,7 @@ pub fn prove_ownership_of_account(
 /// that lower <= attribute < upper.
 /// This is done by proving that attribute-upper+2^n and attribute-lower lie in
 /// [0, 2^n). For further details about this technique, see page 15 in <https://arxiv.org/pdf/1907.06381.pdf>.
+#[allow(clippy::too_many_arguments)]
 pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,
@@ -264,6 +265,7 @@ pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
 }
 
 /// Helper function for producing a range proof.
+#[allow(clippy::too_many_arguments)]
 fn prove_attribute_in_range_helper<C: Curve>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -34,6 +34,7 @@ use sha2::{Digest, Sha256};
 impl<C: Curve, AttributeType: Attribute<C::Scalar>> StatementWithContext<C, AttributeType> {
     pub fn prove(
         &self,
+        version: &ProofVersion,
         global: &GlobalContext<C>,
         challenge: &[u8],
         attribute_values: &impl HasAttributeValues<C::Scalar, AttributeTag, AttributeType>,
@@ -49,6 +50,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> StatementWithContext<C, Attr
         let mut csprng = rand::thread_rng();
         for atomic_statement in self.statement.statements.iter() {
             proofs.push(atomic_statement.prove(
+                version,
                 global,
                 &mut transcript,
                 &mut csprng,
@@ -65,6 +67,7 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
 {
     pub(crate) fn prove(
         &self,
+        version: &ProofVersion,
         global: &GlobalContext<C>,
         transcript: &mut RandomOracle,
         csprng: &mut impl rand::Rng,
@@ -104,6 +107,7 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 let attribute_vec: Vec<_> =
                     statement.set.iter().map(|x| x.to_field_element()).collect();
                 let proof = prove_set_membership(
+                    version,
                     transcript,
                     csprng,
                     &attribute_vec,
@@ -125,6 +129,7 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 let attribute_vec: Vec<_> =
                     statement.set.iter().map(|x| x.to_field_element()).collect();
                 let proof = prove_set_non_membership(
+                    version,
                     transcript,
                     csprng,
                     &attribute_vec,
@@ -143,6 +148,9 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                     .get_attribute_commitment_randomness(statement.attribute_tag)
                     .ok()?;
                 let proof = prove_attribute_in_range(
+                    version,
+                    transcript,
+                    csprng,
                     global.bulletproof_generators(),
                     &global.on_chain_commitment_key,
                     attribute,
@@ -208,6 +216,9 @@ pub fn prove_ownership_of_account(
 /// This is done by proving that attribute-upper+2^n and attribute-lower lie in
 /// [0, 2^n). For further details about this technique, see page 15 in <https://arxiv.org/pdf/1907.06381.pdf>.
 pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
+    version: &ProofVersion,
+    transcript: &mut RandomOracle,
+    csprng: &mut impl rand::Rng,
     gens: &Generators<C>,
     keys: &PedersenKey<C>,
     attribute: &AttributeType,
@@ -215,11 +226,55 @@ pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     upper: &AttributeType,
     r: &PedersenRandomness<C>,
 ) -> Option<RangeProof<C>> {
-    let mut transcript = RandomOracle::domain("attribute_range_proof");
-    let mut csprng = rand::thread_rng();
     let delta = attribute.to_field_element();
     let a = lower.to_field_element();
     let b = upper.to_field_element();
+    match version {
+        ProofVersion::Version1 => {
+            let mut transcript_v1 = RandomOracle::domain("attribute_range_proof");
+            prove_attribute_in_range_helper(
+                &ProofVersion::Version1,
+                &mut transcript_v1,
+                csprng,
+                gens,
+                keys,
+                delta,
+                a,
+                b,
+                r,
+            )
+        }
+        ProofVersion::Version2 => {
+            transcript.add_bytes(b"AttributeRangeProof");
+            transcript.append_message(b"a", &a);
+            transcript.append_message(b"b", &b);
+            prove_attribute_in_range_helper(
+                &ProofVersion::Version2,
+                transcript,
+                csprng,
+                gens,
+                keys,
+                delta,
+                a,
+                b,
+                r,
+            )
+        }
+    }
+}
+
+/// Helper function for producing a range proof.
+fn prove_attribute_in_range_helper<C: Curve>(
+    version: &ProofVersion,
+    transcript: &mut RandomOracle,
+    csprng: &mut impl rand::Rng,
+    gens: &Generators<C>,
+    keys: &PedersenKey<C>,
+    delta: C::Scalar,
+    a: C::Scalar,
+    b: C::Scalar,
+    r: &PedersenRandomness<C>,
+) -> Option<RangeProof<C>> {
     let mut scalar1 = delta;
     let two = C::scalar_from_u64(2);
     let two_n = two.pow([64]);
@@ -230,8 +285,9 @@ pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     let rand1 = r.clone();
     let rand2 = r.clone();
     prove_given_scalars(
-        &mut transcript,
-        &mut csprng,
+        version,
+        transcript,
+        csprng,
         64,
         2,
         &[scalar1, scalar2],

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -264,7 +264,7 @@ pub fn prove_attribute_in_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     }
 }
 
-/// Helper function for producing a range proof.
+/// Helper function for producing a range proof.     
 #[allow(clippy::too_many_arguments)]
 fn prove_attribute_in_range_helper<C: Curve>(
     version: &ProofVersion,

--- a/rust-src/concordium_base/src/id/id_verifier.rs
+++ b/rust-src/concordium_base/src/id/id_verifier.rs
@@ -57,7 +57,7 @@ pub fn verify_attribute<C: Curve, AttributeType: Attribute<C::Scalar>>(
 /// This is done by verifying that the attribute inside the commitment satisfies
 /// that `attribute-upper+2^n` and attribute-lower lie in `[0, 2^n)`.
 /// For further details about this technique, see page 15 in <https://arxiv.org/pdf/1907.06381.pdf>.
-
+#[allow(clippy::too_many_arguments)]
 pub fn verify_attribute_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,
@@ -102,6 +102,8 @@ pub fn verify_attribute_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     }
 }
 
+/// Helper functionf for verifying range proofs.
+#[allow(clippy::too_many_arguments)]
 fn verify_attribute_range_helper<C: Curve>(
     version: &ProofVersion,
     transcript: &mut RandomOracle,

--- a/rust-src/concordium_base/src/id/id_verifier.rs
+++ b/rust-src/concordium_base/src/id/id_verifier.rs
@@ -102,7 +102,7 @@ pub fn verify_attribute_range<C: Curve, AttributeType: Attribute<C::Scalar>>(
     }
 }
 
-/// Helper functionf for verifying range proofs.
+/// Helper function for verifying range proofs.
 #[allow(clippy::too_many_arguments)]
 fn verify_attribute_range_helper<C: Curve>(
     version: ProofVersion,
@@ -460,7 +460,7 @@ mod tests {
                 "Incorrect version 1 range proof."
             );
         } else {
-            panic!("Failed to produce proof.");
+            panic!("Failed to produce version 1 proof.");
         };
         let mut transcript = RandomOracle::domain("Test");
         let maybe_proof = prove_attribute_in_range(
@@ -490,7 +490,7 @@ mod tests {
                 "Incorrect version 2 range proof."
             );
         } else {
-            panic!("Failed to produce proof.");
+            panic!("Failed to produce version 2 proof.");
         };
     }
 

--- a/rust-src/concordium_base/src/id/identity_provider.rs
+++ b/rust-src/concordium_base/src/id/identity_provider.rs
@@ -1,6 +1,7 @@
 //! Functionality needed by the identity provider. This gathers together the
 //! primitives from the rest of the library into a convenient package.
 use super::{
+    id_proof_types::ProofVersion,
     secret_sharing::Threshold,
     sigma_protocols::{com_enc_eq, com_eq, com_eq_different_groups, common::*, dlog},
     types::*,
@@ -320,7 +321,17 @@ fn validate_request_common<P: Pairing, C: Curve<Scalar = P::ScalarField>>(
         let gens = &context.global_context.bulletproof_generators().take(32 * 8);
         let commitments = ciphers.iter().map(|x| Commitment(x.1)).collect::<Vec<_>>();
         transcript.append_message(b"encrypted_share", &ciphers);
-        if verify_efficient(transcript, 32, &commitments, proof, gens, &keys).is_err() {
+        if verify_efficient(
+            &ProofVersion::Version1,
+            transcript,
+            32,
+            &commitments,
+            proof,
+            gens,
+            &keys,
+        )
+        .is_err()
+        {
             return Err(Reason::IncorrectProof);
         }
     }

--- a/rust-src/concordium_base/src/id/identity_provider.rs
+++ b/rust-src/concordium_base/src/id/identity_provider.rs
@@ -322,7 +322,7 @@ fn validate_request_common<P: Pairing, C: Curve<Scalar = P::ScalarField>>(
         let commitments = ciphers.iter().map(|x| Commitment(x.1)).collect::<Vec<_>>();
         transcript.append_message(b"encrypted_share", &ciphers);
         if verify_efficient(
-            &ProofVersion::Version1,
+            ProofVersion::Version1,
             transcript,
             32,
             &commitments,

--- a/rust-src/concordium_base/src/id/sigma_protocols/com_lin.rs
+++ b/rust-src/concordium_base/src/id/sigma_protocols/com_lin.rs
@@ -408,7 +408,7 @@ mod tests {
         }
         let gens = crate::bulletproofs::utils::Generators { G_H };
         let proof = crate::bulletproofs::range_proof::prove_given_scalars(
-            &crate::id::id_proof_types::ProofVersion::Version1,
+            crate::id::id_proof_types::ProofVersion::Version1,
             &mut ro.split(),
             rng,
             n,
@@ -419,7 +419,7 @@ mod tests {
             &rs_copy,
         );
         assert!(crate::bulletproofs::range_proof::verify_efficient(
-            &crate::id::id_proof_types::ProofVersion::Version1,
+            crate::id::id_proof_types::ProofVersion::Version1,
             &mut ro,
             n,
             &cmms_copy,

--- a/rust-src/concordium_base/src/id/sigma_protocols/com_lin.rs
+++ b/rust-src/concordium_base/src/id/sigma_protocols/com_lin.rs
@@ -408,6 +408,7 @@ mod tests {
         }
         let gens = crate::bulletproofs::utils::Generators { G_H };
         let proof = crate::bulletproofs::range_proof::prove_given_scalars(
+            &crate::id::id_proof_types::ProofVersion::Version1,
             &mut ro.split(),
             rng,
             n,
@@ -418,6 +419,7 @@ mod tests {
             &rs_copy,
         );
         assert!(crate::bulletproofs::range_proof::verify_efficient(
+            &crate::id::id_proof_types::ProofVersion::Version1,
             &mut ro,
             n,
             &cmms_copy,

--- a/rust-src/concordium_base/src/id/types.rs
+++ b/rust-src/concordium_base/src/id/types.rs
@@ -2470,19 +2470,6 @@ pub enum AccountCredentialValues<C: Curve, AttributeType: Attribute<C::Scalar>> 
     },
 }
 
-pub trait HasAttributeCommitmentKey<C: Curve, TagType = AttributeTag> {
-    type ErrorType: 'static + Send + Sync + std::error::Error;
-
-    fn get_attribute_commitment_key(
-        &self,
-        attribute_tag: TagType,
-    ) -> Result<PedersenKey<C>, Self::ErrorType>;
-}
-
-pub trait HasBulletproofsGenerators<C: Curve> {
-    fn generators(&self) -> Generators<C>;
-}
-
 pub trait HasAttributeRandomness<C: Curve, TagType = AttributeTag> {
     type ErrorType: 'static + Send + Sync + std::error::Error;
 

--- a/rust-src/concordium_base/src/id/types.rs
+++ b/rust-src/concordium_base/src/id/types.rs
@@ -2470,6 +2470,19 @@ pub enum AccountCredentialValues<C: Curve, AttributeType: Attribute<C::Scalar>> 
     },
 }
 
+pub trait HasAttributeCommitmentKey<C: Curve, TagType = AttributeTag> {
+    type ErrorType: 'static + Send + Sync + std::error::Error;
+
+    fn get_attribute_commitment_key(
+        &self,
+        attribute_tag: TagType,
+    ) -> Result<PedersenKey<C>, Self::ErrorType>;
+}
+
+pub trait HasBulletproofsGenerators<C: Curve> {
+    fn generators(&self) -> Generators<C>;
+}
+
 pub trait HasAttributeRandomness<C: Curve, TagType = AttributeTag> {
     type ErrorType: 'static + Send + Sync + std::error::Error;
 

--- a/rust-src/concordium_base/src/web3id/mod.rs
+++ b/rust-src/concordium_base/src/web3id/mod.rs
@@ -1210,7 +1210,7 @@ fn verify_single_credential<C: Curve, AttributeType: Attribute<C::Scalar>>(
         ) => {
             for (statement, proof) in proofs.iter() {
                 if !statement.verify(
-                    &ProofVersion::Version2,
+                    ProofVersion::Version2,
                     global,
                     transcript,
                     commitments,
@@ -1238,7 +1238,7 @@ fn verify_single_credential<C: Curve, AttributeType: Attribute<C::Scalar>>(
             }
             for (statement, proof) in proofs.iter() {
                 if !statement.verify(
-                    &ProofVersion::Version2,
+                    ProofVersion::Version2,
                     global,
                     transcript,
                     &commitments.commitments,
@@ -1279,7 +1279,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
                 for statement in statement {
                     let proof = statement
                         .prove(
-                            &ProofVersion::Version2,
+                            ProofVersion::Version2,
                             global,
                             ro,
                             csprng,
@@ -1350,7 +1350,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
                 for statement in statement {
                     let proof = statement
                         .prove(
-                            &ProofVersion::Version2,
+                            ProofVersion::Version2,
                             global,
                             ro,
                             csprng,

--- a/rust-src/concordium_base/src/web3id/mod.rs
+++ b/rust-src/concordium_base/src/web3id/mod.rs
@@ -14,7 +14,7 @@ use crate::{
     curve_arithmetic::Curve,
     id::{
         constants::{ArCurve, AttributeKind},
-        id_proof_types::{AtomicProof, AtomicStatement},
+        id_proof_types::{AtomicProof, AtomicStatement, ProofVersion},
         types::{Attribute, AttributeTag, GlobalContext, IpIdentity},
     },
     pedersen_commitment,
@@ -1209,7 +1209,13 @@ fn verify_single_credential<C: Curve, AttributeType: Attribute<C::Scalar>>(
             CredentialsInputs::Account { commitments },
         ) => {
             for (statement, proof) in proofs.iter() {
-                if !statement.verify(global, transcript, commitments, proof) {
+                if !statement.verify(
+                    &ProofVersion::Version2,
+                    global,
+                    transcript,
+                    commitments,
+                    proof,
+                ) {
                     return false;
                 }
             }
@@ -1231,7 +1237,13 @@ fn verify_single_credential<C: Curve, AttributeType: Attribute<C::Scalar>>(
                 return false;
             }
             for (statement, proof) in proofs.iter() {
-                if !statement.verify(global, transcript, &commitments.commitments, proof) {
+                if !statement.verify(
+                    &ProofVersion::Version2,
+                    global,
+                    transcript,
+                    &commitments.commitments,
+                    proof,
+                ) {
                     return false;
                 }
             }
@@ -1266,7 +1278,14 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
             ) => {
                 for statement in statement {
                     let proof = statement
-                        .prove(global, ro, csprng, values, randomness)
+                        .prove(
+                            &ProofVersion::Version2,
+                            global,
+                            ro,
+                            csprng,
+                            values,
+                            randomness,
+                        )
                         .ok_or(ProofError::MissingAttribute)?;
                     proofs.push((statement, proof));
                 }
@@ -1330,7 +1349,14 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> CredentialStatement<C, Attri
                 };
                 for statement in statement {
                     let proof = statement
-                        .prove(global, ro, csprng, values, randomness)
+                        .prove(
+                            &ProofVersion::Version2,
+                            global,
+                            ro,
+                            csprng,
+                            values,
+                            randomness,
+                        )
                         .ok_or(ProofError::MissingAttribute)?;
                     proofs.push((statement, proof));
                 }


### PR DESCRIPTION
## Purpose
Introduce a new proof version in which
https://github.com/Concordium/concordium-base/issues/379 is addressed. In the new proof version bulletproofs and set (non-)membership proofs will add public information explicitly into the transcript.

## Changes

* New enum type `ProofVersion` introduced.
* Prover and verifier functions now takes a proof version
* For Web3ID we only use Version 2
* In Version 2, all public information related to the proven statement are added to the transcript. This includes the concrete bulletproof generaters used and the commitment keys. For ranges [0, 2^n) (i.e. the core bulletproofs), n is also added to the transcript. For general ranges [a,b), a and b are added to the transcript. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

