### PR TITLE
Revise credentials

### DIFF
--- a/rust-src/concordium_base/src/common/serialize.rs
+++ b/rust-src/concordium_base/src/common/serialize.rs
@@ -495,7 +495,7 @@ impl Deserial for String {
             while remaining > 0 {
                 let to_read = std::cmp::min(remaining, MAX_PREALLOCATED_CAPACITY);
                 source.read_exact(&mut chunk[..to_read])?;
-                data.extend_from_slice(&mut chunk[..to_read]);
+                data.extend_from_slice(&chunk[..to_read]);
                 remaining -= to_read;
             }
             let s = String::from_utf8(data)?;

--- a/rust-src/concordium_base/src/common/serialize.rs
+++ b/rust-src/concordium_base/src/common/serialize.rs
@@ -959,3 +959,14 @@ fn test_set_serialization() {
         assert_eq!(set, deserialized);
     }
 }
+
+#[test]
+fn test_string_serialization() {
+    use rand::Rng;
+    for _ in 0..1000 {
+        let n: usize = rand::thread_rng().gen_range(0, 2 * MAX_PREALLOCATED_CAPACITY);
+        let s: String = String::from_utf8(vec!['a' as u8; n]).unwrap();
+        let deserialized = super::serialize_deserialize(&s).expect("Deserialization succeeds.");
+        assert_eq!(s, deserialized);
+    }
+}

--- a/rust-src/concordium_base/src/common/serialize.rs
+++ b/rust-src/concordium_base/src/common/serialize.rs
@@ -495,7 +495,7 @@ impl Deserial for String {
             while remaining > 0 {
                 let to_read = std::cmp::min(remaining, MAX_PREALLOCATED_CAPACITY);
                 source.read_exact(&mut chunk[..to_read])?;
-                data.append(&mut chunk);
+                data.extend_from_slice(&mut chunk[..to_read]);
                 remaining -= to_read;
             }
             let s = String::from_utf8(data)?;

--- a/rust-src/concordium_base/src/id/account_holder.rs
+++ b/rust-src/concordium_base/src/id/account_holder.rs
@@ -1134,7 +1134,7 @@ pub fn compute_commitments<C: Curve, AttributeType: Attribute<C::Scalar>, R: Rng
         // We can just commit with randomness 0.
         if !policy.policy_vec.contains_key(&i) {
             let value = Value::<C>::new(val.to_field_element());
-            let attr_rand = secret_data.get_attribute_commitment_randomness(i)?;
+            let attr_rand = secret_data.get_attribute_commitment_randomness(&i)?;
             let cmm = commitment_key.hide(&value, &attr_rand);
             cmm_attributes.insert(i, cmm);
             attributes_rand.insert(i, attr_rand);

--- a/rust-src/concordium_base/src/id/id_prover.rs
+++ b/rust-src/concordium_base/src/id/id_prover.rs
@@ -60,7 +60,7 @@ impl<C: Curve, AttributeType: Attribute<C::Scalar>> StatementWithContext<C, Attr
     }
 }
 
-impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribute<C::Scalar>>
+impl<C: Curve, TagType: crate::common::Serialize, AttributeType: Attribute<C::Scalar>>
     AtomicStatement<C, TagType, AttributeType>
 {
     pub(crate) fn prove(
@@ -74,10 +74,10 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
         match self {
             AtomicStatement::RevealAttribute { statement } => {
                 let attribute = attribute_values
-                    .get_attribute_value(statement.attribute_tag)?
+                    .get_attribute_value(&statement.attribute_tag)?
                     .clone();
                 let randomness = attribute_randomness
-                    .get_attribute_commitment_randomness(statement.attribute_tag)
+                    .get_attribute_commitment_randomness(&statement.attribute_tag)
                     .ok()?;
                 let x = attribute.to_field_element(); // This is public in the sense that the verifier should learn it
                 transcript.add_bytes(b"RevealAttributeDlogProof");
@@ -96,9 +96,9 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 Some(AtomicProof::RevealAttribute { attribute, proof })
             }
             AtomicStatement::AttributeInSet { statement } => {
-                let attribute = attribute_values.get_attribute_value(statement.attribute_tag)?;
+                let attribute = attribute_values.get_attribute_value(&statement.attribute_tag)?;
                 let randomness = attribute_randomness
-                    .get_attribute_commitment_randomness(statement.attribute_tag)
+                    .get_attribute_commitment_randomness(&statement.attribute_tag)
                     .ok()?;
                 let attribute_scalar = attribute.to_field_element();
                 let attribute_vec: Vec<_> =
@@ -117,9 +117,9 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 Some(proof)
             }
             AtomicStatement::AttributeNotInSet { statement } => {
-                let attribute = attribute_values.get_attribute_value(statement.attribute_tag)?;
+                let attribute = attribute_values.get_attribute_value(&statement.attribute_tag)?;
                 let randomness = attribute_randomness
-                    .get_attribute_commitment_randomness(statement.attribute_tag)
+                    .get_attribute_commitment_randomness(&statement.attribute_tag)
                     .ok()?;
                 let attribute_scalar = attribute.to_field_element();
                 let attribute_vec: Vec<_> =
@@ -138,9 +138,9 @@ impl<C: Curve, TagType: crate::common::Serialize + Copy, AttributeType: Attribut
                 Some(proof)
             }
             AtomicStatement::AttributeInRange { statement } => {
-                let attribute = attribute_values.get_attribute_value(statement.attribute_tag)?;
+                let attribute = attribute_values.get_attribute_value(&statement.attribute_tag)?;
                 let randomness = attribute_randomness
-                    .get_attribute_commitment_randomness(statement.attribute_tag)
+                    .get_attribute_commitment_randomness(&statement.attribute_tag)
                     .ok()?;
                 let proof = prove_attribute_in_range(
                     global.bulletproof_generators(),

--- a/rust-src/concordium_base/src/id/id_verifier.rs
+++ b/rust-src/concordium_base/src/id/id_verifier.rs
@@ -385,9 +385,9 @@ mod tests {
 
         fn get_attribute_commitment_randomness(
             &self,
-            attribute_tag: AttributeTag,
+            attribute_tag: &AttributeTag,
         ) -> Result<PedersenRandomness<G1>, Self::ErrorType> {
-            match self.randomness.get(&attribute_tag) {
+            match self.randomness.get(attribute_tag) {
                 Some(r) => Ok(r.clone()),
                 _ => {
                     let mut csprng = rand::thread_rng();

--- a/rust-src/concordium_base/src/web3id/did.rs
+++ b/rust-src/concordium_base/src/web3id/did.rs
@@ -1,10 +1,6 @@
 //! Definition of Concordium DIDs and their parser.
 
-use crate::{
-    base::CredentialRegistrationID,
-    common::{base16_decode_string, Deserial},
-    id::types::IpIdentity,
-};
+use crate::{base::CredentialRegistrationID, common::base16_decode_string, id::types::IpIdentity};
 use concordium_contracts_common::{
     AccountAddress, ContractAddress, EntrypointName, OwnedEntrypointName, OwnedParameter,
 };
@@ -97,7 +93,10 @@ pub enum IdentifierType {
 }
 
 impl IdentifierType {
-    pub fn extract_contract<D: Deserial>(
+    /// If `self` is the [`ContractData`](Self::ContractData) variant then
+    /// check if the entrypoint is as specified, and attempt to parse the
+    /// parameter into the provided type.
+    pub fn extract_contract<D: concordium_contracts_common::Deserial>(
         &self,
         ep: EntrypointName,
     ) -> Option<(ContractAddress, D)> {
@@ -111,10 +110,12 @@ impl IdentifierType {
         if entrypoint.as_entrypoint_name() != ep {
             return None;
         }
-        let d = crate::common::from_bytes(&mut std::io::Cursor::new(parameter.as_ref())).ok()?;
+        let d = concordium_contracts_common::from_bytes(parameter.as_ref()).ok()?;
         Some((*address, d))
     }
 
+    /// If `self` is the [`PublicKey`](Self::PublicKey) variant then extract the
+    /// public key, otherwise return [`None`].
     pub fn extract_public_key(&self) -> Option<ed25519_dalek::PublicKey> {
         let IdentifierType::PublicKey {
             key,

--- a/rust-src/concordium_base/src/web3id/mod.rs
+++ b/rust-src/concordium_base/src/web3id/mod.rs
@@ -1043,22 +1043,6 @@ pub enum CommitmentInputs<'a, C: Curve, AttributeType, Web3IdSigner> {
     },
 }
 
-#[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
-#[serde(transparent)]
-pub struct CredentialSchema {
-    schema: serde_json::Value,
-}
-
-impl CredentialSchema {
-    pub fn attribute_tag(&self, attribute: &str) -> Option<u8> {
-        let value = self.schema.pointer(&format!(
-            "/properties/credentialSubject/properties/{attribute}/index"
-        ))?;
-        let num = value.as_u64()?;
-        num.try_into().ok()
-    }
-}
-
 #[derive(Clone, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
 #[serde(bound(
     deserialize = "AttributeType: DeserializeOwned, C: Curve",

--- a/rust-src/concordium_base/src/web3id/mod.rs
+++ b/rust-src/concordium_base/src/web3id/mod.rs
@@ -1064,16 +1064,25 @@ impl CredentialSchema {
 pub struct Web3IdCredential<C: Curve, AttributeType> {
     /// The credential holder's public key.
     pub holder_id:         CredentialHolderId,
+    /// The network to which the credential applies.
     pub network:           Network,
+    /// The address of the credential registry where the credential is tracked.
     pub registry:          ContractAddress,
+    /// Credential type describing what kind of a credential it is.
     pub credential_type:   BTreeSet<String>,
+    /// Link to the credential schema.
     pub credential_schema: String,
+    /// The issuer's public key.
     pub issuer_key:        IssuerKey,
+    /// Start of the validity of the credential.
     pub valid_from:        chrono::DateTime<chrono::Utc>,
     /// After this date, the credential becomes expired. `None` corresponds to a
     /// credential that cannot expire.
     pub valid_until:       Option<chrono::DateTime<chrono::Utc>>,
+    /// Names of attribute tags. The names are used in JSON serialization of
+    /// this credential.
     pub attribute_names:   BTreeMap<u8, String>,
+    /// The values of different attributes, indexed by attribute tags.
     pub values:            BTreeMap<u8, AttributeType>,
     /// The randomness to go along with commitments in `values`. This has to
     /// have the same keys as the `values` field, but it is more

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -321,13 +321,13 @@ impl HasAttributeRandomness<ArCurve> for CredentialContext {
 
     fn get_attribute_commitment_randomness(
         &self,
-        attribute_tag: AttributeTag,
+        attribute_tag: &AttributeTag,
     ) -> Result<CommitmentRandomness<ArCurve>, Self::ErrorType> {
         self.wallet.get_attribute_commitment_randomness(
             self.identity_provider_index.0,
             self.identity_index,
             self.credential_index.into(),
-            attribute_tag,
+            *attribute_tag,
         )
     }
 }


### PR DESCRIPTION
## Purpose

Revise credentials

## Changes

- The issuer now additionally signs the contract address.
- The JSON format of Web3IdCredential now follows W3C "standard".
- There are no more attribute tags (u8). String names are used in proofs and inputs now for Web3Id stuff.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.