### PR TITLE
Remove the (de)`compressed` functions from the Curve trait.

### DIFF
--- a/rust-src/concordium_base/src/curve_arithmetic/bls12_381_instance.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/bls12_381_instance.rs
@@ -30,7 +30,6 @@ fn scalar_from_bytes_helper<A: AsRef<[u8]>>(bytes: A) -> Fr {
 }
 
 impl Curve for G2 {
-    type Compressed = G2Compressed;
     type Scalar = Fr;
 
     const GROUP_ELEMENT_LENGTH: usize = 96;
@@ -73,22 +72,6 @@ impl Curve for G2 {
         p
     }
 
-    fn compress(&self) -> Self::Compressed { self.into_affine().into_compressed() }
-
-    fn decompress(c: &Self::Compressed) -> Result<G2, CurveDecodingError> {
-        match c.into_affine() {
-            Ok(t) => Ok(t.into_projective()),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
-    fn decompress_unchecked(c: &Self::Compressed) -> Result<Self, CurveDecodingError> {
-        match c.into_affine_unchecked() {
-            Ok(t) => Ok(t.into_projective()),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
     #[inline(always)]
     fn scalar_from_u64(n: u64) -> Self::Scalar {
         Fr::from_repr(FrRepr::from(n)).expect("Every u64 is representable.")
@@ -113,7 +96,6 @@ impl Curve for G2 {
 }
 
 impl Curve for G1 {
-    type Compressed = G1Compressed;
     type Scalar = Fr;
 
     const GROUP_ELEMENT_LENGTH: usize = 48;
@@ -156,22 +138,6 @@ impl Curve for G1 {
         p
     }
 
-    fn compress(&self) -> Self::Compressed { self.into_affine().into_compressed() }
-
-    fn decompress(c: &Self::Compressed) -> Result<G1, CurveDecodingError> {
-        match c.into_affine() {
-            Ok(t) => Ok(t.into_projective()),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
-    fn decompress_unchecked(c: &Self::Compressed) -> Result<Self, CurveDecodingError> {
-        match c.into_affine_unchecked() {
-            Ok(t) => Ok(t.into_projective()),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
     #[inline(always)]
     fn scalar_from_u64(n: u64) -> Self::Scalar {
         Fr::from_repr(FrRepr::from(n)).expect("Every u64 is representable.")
@@ -196,7 +162,6 @@ impl Curve for G1 {
 }
 
 impl Curve for G1Affine {
-    type Compressed = G1Compressed;
     type Scalar = Fr;
 
     const GROUP_ELEMENT_LENGTH: usize = 48;
@@ -237,22 +202,6 @@ impl Curve for G1Affine {
         self.mul(s).into_affine()
     }
 
-    fn compress(&self) -> Self::Compressed { self.into_compressed() }
-
-    fn decompress(c: &Self::Compressed) -> Result<G1Affine, CurveDecodingError> {
-        match c.into_affine() {
-            Ok(t) => Ok(t),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
-    fn decompress_unchecked(c: &Self::Compressed) -> Result<Self, CurveDecodingError> {
-        match c.into_affine_unchecked() {
-            Ok(t) => Ok(t),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
     fn scalar_from_u64(n: u64) -> Self::Scalar {
         Fr::from_repr(FrRepr::from(n)).expect("Every u64 is representable.")
     }
@@ -276,7 +225,6 @@ impl Curve for G1Affine {
 }
 
 impl Curve for G2Affine {
-    type Compressed = G2Compressed;
     type Scalar = Fr;
 
     const GROUP_ELEMENT_LENGTH: usize = 96;
@@ -315,22 +263,6 @@ impl Curve for G2Affine {
     fn mul_by_scalar(&self, scalar: &Self::Scalar) -> Self {
         let s = *scalar;
         self.mul(s).into_affine()
-    }
-
-    fn compress(&self) -> Self::Compressed { self.into_compressed() }
-
-    fn decompress(c: &Self::Compressed) -> Result<G2Affine, CurveDecodingError> {
-        match c.into_affine() {
-            Ok(t) => Ok(t),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
-    }
-
-    fn decompress_unchecked(c: &Self::Compressed) -> Result<Self, CurveDecodingError> {
-        match c.into_affine_unchecked() {
-            Ok(t) => Ok(t),
-            Err(_) => Err(CurveDecodingError::NotOnCurve),
-        }
     }
 
     fn scalar_from_u64(n: u64) -> Self::Scalar {

--- a/rust-src/concordium_base/src/curve_arithmetic/mod.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/mod.rs
@@ -28,9 +28,6 @@ pub trait Curve:
     Serialize + Copy + Clone + Sized + Send + Sync + Debug + PartialEq + Eq + 'static {
     /// The prime field of the group order size.
     type Scalar: PrimeField + Field + Serialize;
-    /// A compressed representation of curve points used for compact
-    /// serialization.
-    type Compressed;
     /// Size in bytes of elements of the [Curve::Scalar] field.
     const SCALAR_LENGTH: usize;
     /// Size in bytes of group elements when serialized.
@@ -57,10 +54,6 @@ pub trait Curve:
     /// Exponentiation by a scalar, i.e., compute n * x for a group element x
     /// and integer n.
     fn mul_by_scalar(&self, scalar: &Self::Scalar) -> Self;
-    #[must_use]
-    fn compress(&self) -> Self::Compressed;
-    fn decompress(c: &Self::Compressed) -> Result<Self, CurveDecodingError>;
-    fn decompress_unchecked(c: &Self::Compressed) -> Result<Self, CurveDecodingError>;
     /// Deserialize a value from a byte source, but do not check that it is in
     /// the group itself. This can be cheaper if the source of the value is
     /// trusted, but it must not be used on untrusted sources.


### PR DESCRIPTION
## Purpose

They are not used, and their functionality is hidden behind serialization.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
