### PR TITLE
user_cli tool bugfix: Could not accept the account flag

### DIFF
--- a/rust-bins/CHANGELOG.md
+++ b/rust-bins/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## 2.0.1
+- Fixed bug where the user_cli tool was unable to accept the `account` flag as it conflicted with the `expiry` flag that was always set due to a default value being provided.

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "misc_tools"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/rust-bins/Cargo.toml
+++ b/rust-bins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misc_tools"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/rust-bins/src/bin/user_cli.rs
+++ b/rust-bins/src/bin/user_cli.rs
@@ -150,8 +150,6 @@ struct CreateCredential {
     #[structopt(
         long = "message-expiry",
         help = "Expiry time of the credential message. In seconds from __now__.",
-        required_unless = "account",
-        conflicts_with = "account",
         default_value = "900"
     )]
     expiry:      u64,
@@ -200,8 +198,6 @@ struct CreateCredentialV1 {
     #[structopt(
         long = "message-expiry",
         help = "Expiry time of the credential message. In seconds from __now__.",
-        required_unless = "account",
-        conflicts_with = "account",
         default_value = "900"
     )]
     expiry:             u64,


### PR DESCRIPTION
## Purpose

The user_cli tool was unable to accept the `account` flag as it conflicted with the `expiry flag` that was always set due to a default value being provided.

## Changes

I removed the mutual exclusivity of the flags. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.