### PR TITLE
Add timestamp to web3id credential types.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -277,7 +277,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.0",
  "bs58",
@@ -297,7 +297,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/idiss/Cargo.lock
+++ b/idiss/Cargo.lock
@@ -302,7 +302,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64",
  "bs58",
@@ -322,7 +322,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -312,7 +312,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.0",
  "bs58",
@@ -332,7 +332,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "base64 0.21.2",
  "bs58",
@@ -374,7 +374,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -13,6 +13,10 @@
 - Update notation of sigma protocols to better match the literature and the bluepaper.
 - Move all sigma protocols to a common sigma-protocol crate.
 - Move all range proof helper functions to `range_proofs`.
+- Add a new module `web3id` that defines types related to Web3ID and implements
+  proving and verification functions.
+- Add a new module `cis4_types` that defines the interface types for CIS4
+  compatible contracts.
 
 ## 2.0.0 (2023-06-16)
 

--- a/rust-src/concordium_base/Cargo.toml
+++ b/rust-src/concordium_base/Cargo.toml
@@ -57,7 +57,7 @@ crate-type = ["rlib", "staticlib", "cdylib"]
 
 # Local dependencies
 [dependencies.concordium-contracts-common]
-version = "7.0"
+version = "8.0"
 path = "../../concordium-contracts-common/concordium-contracts-common"
 features = ["derive-serde"]
 

--- a/rust-src/concordium_base/src/common/impls.rs
+++ b/rust-src/concordium_base/src/common/impls.rs
@@ -11,6 +11,17 @@ use std::convert::TryFrom;
 
 use super::serialize::*;
 
+impl Serial for concordium_contracts_common::Timestamp {
+    fn serial<B: Buffer>(&self, out: &mut B) { self.timestamp_millis().serial(out) }
+}
+
+impl Deserial for concordium_contracts_common::Timestamp {
+    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> {
+        let millis: u64 = source.get()?;
+        Ok(Self::from_timestamp_millis(millis))
+    }
+}
+
 impl Deserial for Fr {
     fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Fr> {
         let mut frrepr: FrRepr = FrRepr([0u64; 4]);

--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.1.0"
+version = "8.0.0"
 dependencies = [
  "arbitrary",
  "base64",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -45,7 +45,7 @@ path = "../wasm-transform"
 version = "2"
 
 [dependencies.concordium-contracts-common]
-version = "7.0"
+version = "8.0"
 path = "../../concordium-contracts-common/concordium-contracts-common"
 features = ["derive-serde"]
 

--- a/smart-contracts/wasm-test/Cargo.lock
+++ b/smart-contracts/wasm-test/Cargo.lock
@@ -115,7 +115,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common"
-version = "7.0.0"
+version = "8.0.0"
 dependencies = [
  "base64",
  "bs58",
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "concordium-contracts-common-derive"
-version = "3.0.0"
+version = "4.0.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/smart-contracts/wasm-transform/Cargo.toml
+++ b/smart-contracts/wasm-transform/Cargo.toml
@@ -21,7 +21,7 @@ derive_more = "0.99"
 
 
 [dependencies.concordium-contracts-common]
-version = "7"
+version = "8"
 path = "../../concordium-contracts-common/concordium-contracts-common"
 features = ["derive-serde"]
 


### PR DESCRIPTION
## Purpose

Add a new timestamp type to web3id attributes.

The JSON serialization of this value is an object
```json
{
    "type": "date-time",
    "timestamp": "2016-09-01T10:11:12Z"
}
```

## Changes

Add new variant to Web3IdAttribute.
Bump contracts-common (this is why all the lock files are updated).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.