### PR TITLE
get verifiable credential backup encryption key

### DIFF
--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -1137,7 +1137,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -901,7 +901,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key_derivation"
-version = "1.2.0"
+version = "1.3.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE"


### PR DESCRIPTION

## Purpose

Add `get_verifiable_credential_backup_encryption_key` to `ConcordiumHdWallet` struct in the `key_derivation` module.

## Changes

- Added the method.
- Added some tests for it.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
