### PR TITLE
Derive Serialize/Deserialize for CredentialStatus

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Add `Serialize` and `Deserialize` instances to `CredentialStatus` type.
+
 ## 3.0.0 (2023-08-21)
 
 - Remove the constant `MAX_ALLOWED_INVOKE_ENERGY` since it was no longer

--- a/rust-src/concordium_base/src/cis4_types.rs
+++ b/rust-src/concordium_base/src/cis4_types.rs
@@ -60,6 +60,8 @@ pub struct CredentialEntry {
 }
 
 #[derive(
+    serde::Serialize,
+    serde::Deserialize,
     contracts_common::Serialize,
     PartialOrd,
     Ord,
@@ -71,6 +73,7 @@ pub struct CredentialEntry {
     Debug,
     derive_more::Display,
 )]
+#[serde(rename_all = "camelCase")]
 /// The current status of a credential.
 pub enum CredentialStatus {
     /// The credential is active.


### PR DESCRIPTION
## Purpose

Concordia needs to send credential status through a JSON API, so `Serialize` and `Deserialize` need to be derived.

## Changes

Added the derive.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.