### PR TITLE
mobile_wallet: Use conventional naming for transaction types

### DIFF
--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -250,6 +250,7 @@ enum SpecifiedEnergy {
 
 #[derive(common::SerdeDeserialize)]
 #[serde(tag = "type", content = "payload")]
+#[serde(rename_all = "camelCase")]
 enum JSONPayload {
     InitContract {
         #[serde(flatten)]


### PR DESCRIPTION
## Purpose

The dApp lib `@concordium/wallet-connectors` was changed to use lower case transaction type in https://github.com/Concordium/concordium-dapp-libraries/pull/42 to match the convention set by wallet-proxy and the internal types ([iOS](https://github.com/Concordium/concordium-reference-wallet-ios/blob/7200500f64084b8c0ce64ccc701f092859a3c6c1/ConcordiumWallet/Model/TransferType.swift)) of the mobile wallets.

This PR aligns the change with the crypto library to use the same type names.

## Changes

Make the mobile wallet crypto library use the conventional type names (in camelCase).

Part of https://concordium.atlassian.net/browse/CBW-1360.