### PR TITLE
Fix identity-provider-service url

### DIFF
--- a/identity-provider-service/CHANGELOG.md
+++ b/identity-provider-service/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.6
+
+- Changed the submitCredential url. 
+
 ## 0.5.5
 - Added improved error handling, so that the wallet can handle some of the errors
 

--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -952,7 +952,7 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "identity-provider-service"
-version = "0.5.5"
+version = "0.5.6"
 dependencies = [
  "anyhow",
  "chrono",

--- a/identity-provider-service/Cargo.toml
+++ b/identity-provider-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "identity-provider-service"
-version = "0.5.5"
+version = "0.5.6"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/identity-provider-service/src/bin/main.rs
+++ b/identity-provider-service/src/bin/main.rs
@@ -245,7 +245,7 @@ impl ServerConfig {
             "Unsupported anonymity revokers version."
         );
         let mut submit_credential_url = config.wallet_proxy_base.clone();
-        submit_credential_url.set_path("v0/submitCredential/");
+        submit_credential_url.set_path("v0/submitCredential");
         Ok(ServerConfig {
             ip_data,
             global: versioned_global.value,


### PR DESCRIPTION
## Purpose

Change the identity provider service's `submitCredential` url to work with our wallet-proxy setup.

## Changes

 - Remove a "/".
 - Bump the version.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

