### PR TITLE
Fix cargo doc warnings and add lints

### DIFF
--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths:
-      - 'smart-contracts/contracts-common/**/*.rs'
-      - 'smart-contracts/contracts-common/**/*.toml'
+      - "smart-contracts/contracts-common/**/*.rs"
+      - "smart-contracts/contracts-common/**/*.toml"
   pull_request:
     branches:
       - main
     paths:
-      - 'smart-contracts/contracts-common/**/*.rs'
-      - 'smart-contracts/contracts-common/**/*.toml'
+      - "smart-contracts/contracts-common/**/*.rs"
+      - "smart-contracts/contracts-common/**/*.toml"
 
 name: Clippy & fmt
 
@@ -43,6 +43,25 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  rustdoc:
+    name: Docs
+    runs-on: ubuntu-latest
+    working-directory: ${{ env.WORKING_DIRECTORY }}
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ env.RUST_VERSION }}
+          override: true
+
+      - name: Run cargo doc
+        run: |
+          RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --color=always
 
   clippy:
     name: Clippy on concordium-contracts-common

--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -5,14 +5,14 @@ on:
     branches:
       - main
     paths:
-      - "smart-contracts/contracts-common/**/*.rs"
-      - "smart-contracts/contracts-common/**/*.toml"
+      - 'smart-contracts/contracts-common/**/*.rs'
+      - 'smart-contracts/contracts-common/**/*.toml'
   pull_request:
     branches:
       - main
     paths:
-      - "smart-contracts/contracts-common/**/*.rs"
-      - "smart-contracts/contracts-common/**/*.toml"
+      - 'smart-contracts/contracts-common/**/*.rs'
+      - 'smart-contracts/contracts-common/**/*.toml'
 
 name: Clippy & fmt
 

--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -17,7 +17,7 @@
 # The dependencies between the steps are described in inline comments below
 # along with a few suggestions for improving parallelization.
 
-name: Check format, build and run tests for Haskell and Rust sources
+name: Check format, docs, build and run tests for Haskell and Rust sources
 
 on:
   pull_request:
@@ -81,6 +81,39 @@ jobs:
         cargo fmt --manifest-path idiss/Cargo.toml -- --check
         cargo fmt --manifest-path mobile_wallet/Cargo.toml -- --check
         cargo fmt --manifest-path identity-provider-service/Cargo.toml -- --check
+
+  rustdoc:
+    runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
+      
+    strategy:
+      matrix:
+        plan:
+        - rust: 1.68
+        crates:
+        - rust-src
+        - rust-bins
+        - idiss
+        - mobile_wallet
+        - identity-provider-service
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: ${{ matrix.plan.rust }}
+        override: true
+
+    - name: Run cargo doc
+      working-directory: ${{ matrix.crates }}
+      run: |
+        RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --color=always
 
   fourmolu:
     runs-on: ubuntu-latest

--- a/rust-bins/src/bin/keygen-genesis.rs
+++ b/rust-bins/src/bin/keygen-genesis.rs
@@ -192,7 +192,7 @@ pub fn generate_ps_pk(n: u32, bytes: &[u8]) -> ps_sig::PublicKey<Bls12> {
     }
 }
 
-/// Implements a slight modification of https://tools.ietf.org/id/draft-irtf-cfrg-vrf-07.html#rfc.section.5.4.1.1
+/// Implements a slight modification of <https://tools.ietf.org/id/draft-irtf-cfrg-vrf-07.html#rfc.section.5.4.1.1>.
 /// The difference is that this one does not concatenate the input
 /// to Sha512 with the single octet values 0 and 1, and neither does it
 /// concatenate with a public key.

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -649,7 +649,7 @@ pub fn generate_ps_sk(
     })
 }
 
-/// This function is an implementation of the procedure described in https://github.com/satoshilabs/slips/blob/master/slip-0010.md
+/// This function is an implementation of the procedure described in <https://github.com/satoshilabs/slips/blob/master/slip-0010.md>
 /// It produces 32 random bytes given a seed, which is exactly a secret key for
 /// the ed25519_dalek.
 pub fn keygen_ed(seed: &[u8]) -> [u8; 32] {
@@ -676,7 +676,8 @@ pub fn generate_ed_sk(
 mod tests {
     use super::*;
 
-    /// Checking with the two test vectors mentioned in https://github.com/satoshilabs/slips/blob/master/slip-0010.md
+    /// Checking with the two test vectors mentioned in
+    /// <https://github.com/satoshilabs/slips/blob/master/slip-0010.md>.
     #[test]
     pub fn testvector_ed() {
         let seed1 = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
@@ -692,7 +693,7 @@ mod tests {
     }
 
     /// Test correct generation of BIP39 sentences.
-    /// Values are taken from https://github.com/trezor/python-mnemonic/blob/master/vectors.json
+    /// Values are taken from <https://github.com/trezor/python-mnemonic/blob/master/vectors.json>.
     #[test]
     pub fn test_bip39_generation() {
         let bip39_vec: Vec<_> = bip39_words().collect();

--- a/rust-bins/src/bin/keygen.rs
+++ b/rust-bins/src/bin/keygen.rs
@@ -649,7 +649,7 @@ pub fn generate_ps_sk(
     })
 }
 
-/// This function is an implementation of the procedure described in <https://github.com/satoshilabs/slips/blob/master/slip-0010.md>
+/// This function is an implementation of the procedure described in <https://github.com/satoshilabs/slips/blob/master/slip-0010.md>.
 /// It produces 32 random bytes given a seed, which is exactly a secret key for
 /// the ed25519_dalek.
 pub fn keygen_ed(seed: &[u8]) -> [u8; 32] {

--- a/rust-bins/src/lib.rs
+++ b/rust-bins/src/lib.rs
@@ -416,7 +416,7 @@ pub fn verify_bip39(word_vec: &[String], bip_word_map: &HashMap<&str, usize>) ->
 /// Convert given byte array to valid BIP39 sentence.
 /// Bytes must contain {16, 20, 24, 28, 32} bytes corresponding to
 /// {128, 160, 192, 224, 256} bits.
-/// This uses the method described at https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+/// This uses the method described at <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>.
 pub fn bytes_to_bip39(bytes: &[u8], bip_word_list: &[&str]) -> Result<Vec<String>, String> {
     let ent_len = 8 * bytes.len(); // input is called entropy in BIP39
     match ent_len {

--- a/rust-src/ed25519_hd_key_derivation/src/lib.rs
+++ b/rust-src/ed25519_hd_key_derivation/src/lib.rs
@@ -127,7 +127,8 @@ pub fn parse_path(path: &str) -> Result<Vec<u32>, DeriveError> {
     Ok(parsed_path)
 }
 
-/// Derives hierarchical deterministic keys for ed25519 according to the SLIP0010 (https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
+/// Derives hierarchical deterministic keys for ed25519 according to the
+/// SLIP0010 (<https://github.com/satoshilabs/slips/blob/master/slip-0010.md>)
 /// specification.
 ///
 /// # Arguments
@@ -147,7 +148,8 @@ pub fn derive(path: &str, seed: &[u8]) -> Result<HdKeys, DeriveError> {
     derive_from_parsed_path(&parsed_path, seed)
 }
 
-/// Derives hierarchical deterministic keys for ed25519 according to the SLIP0010 (https://github.com/satoshilabs/slips/blob/master/slip-0010.md)
+/// Derives hierarchical deterministic keys for ed25519 according to the
+/// SLIP0010 (<https://github.com/satoshilabs/slips/blob/master/slip-0010.md>)
 /// specification.
 ///
 /// # Arguments

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -42,12 +42,12 @@ fn bls_key_bytes_from_seed(key_seed: [u8; 32]) -> <ArCurve as Curve>::Scalar {
 }
 
 /// Convert 24 BIP-39 words to a 64 bytes seed.
-/// As described in https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki,
+/// As described in <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>,
 /// but with an empty passphrase.
 pub fn words_to_seed(words: &str) -> [u8; 64] { words_to_seed_with_passphrase(words, "") }
 
 /// Convert 24 BIP-39 words to a 64 bytes seed.
-/// As described in https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki
+/// As described in <https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki>.
 pub fn words_to_seed_with_passphrase(words: &str, passphrase: &str) -> [u8; 64] {
     let mut salt_string: String = "mnemonic".to_owned();
     salt_string.push_str(passphrase);


### PR DESCRIPTION
## Purpose

Fixes the warnings when running `cargo doc` and adds a lint to the Github actions.

## Changes

Fixes a comment and adds the lint.

Note: `cargo doc` still throws warnings in `smart-contracts/wasm-chain-integration` when run without `--features display-state`. I wanted to add `#[cfg_attr(docsrs, cfg(feature = "display-state"))]`, but the `ptree` crate which is needed for compilation of the feature-gated function is only enabled when `display-state` is enabled.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.