### PR TITLE
Fix VersionedModuleSchema Display given multiple contracts

### DIFF
--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -152,4 +152,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased changes
+- Fixed `Display` trait on `VersionedModuleSchema` when module contained multiple contracts to render all of them.
+- Add `--all-features` to contracts common CI test execution.
 
 ## concordium-contracts-common 8.0.0 (2023-08-21)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## Unreleased changes
 - Fixed `Display` trait on `VersionedModuleSchema` when module contained multiple contracts to render all of them.
-- Add `--all-features` to contracts common CI test execution.
 
 ## concordium-contracts-common 8.0.0 (2023-08-21)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
@@ -1027,7 +1027,7 @@ fn display_json_template_indented(
 ///     contracts: map,
 /// });
 ///
-/// let display = "Contract:                     MyContract
+/// let display = "Contract:  MyContract
 ///   Init:
 ///     Parameter:
 ///       \"<AccountAddress>\"
@@ -1054,7 +1054,7 @@ impl Display for VersionedModuleSchema {
         match self {
             VersionedModuleSchema::V0(module_v0) => {
                 for (contract_name, contract_schema) in module_v0.contracts.iter() {
-                    out = format!("Contract: {:>11}\n", contract_name);
+                    out = format!("{}Contract: {:>11}\n", out, contract_name);
                     // State
                     if let Some(type_schema) = &contract_schema.state {
                         out = format!("{}{:>2}State:\n", out, "");
@@ -1094,7 +1094,7 @@ impl Display for VersionedModuleSchema {
             }
             VersionedModuleSchema::V1(module_v1) => {
                 for (contract_name, contract_schema) in module_v1.contracts.iter() {
-                    out = format!("Contract: {:>11}\n", contract_name);
+                    out = format!("{}Contract: {:>11}\n", out, contract_name);
                     // Init Function
                     if let Some(schema) = &contract_schema.init {
                         out = format!("{}{:>2}Init:\n", out, "");
@@ -1151,7 +1151,7 @@ impl Display for VersionedModuleSchema {
             }
             VersionedModuleSchema::V2(module_v2) => {
                 for (contract_name, contract_schema) in module_v2.contracts.iter() {
-                    out = format!("Contract: {:>11}\n", contract_name);
+                    out = format!("{}Contract: {:>11}\n", out, contract_name);
                     // Init Function
                     if let Some(FunctionV2 {
                         parameter,
@@ -1240,7 +1240,7 @@ impl Display for VersionedModuleSchema {
             }
             VersionedModuleSchema::V3(module_v3) => {
                 for (contract_name, contract_schema) in module_v3.contracts.iter() {
-                    out = format!("Contract: {:>11}\n", contract_name);
+                    out = format!("{}Contract: {:>11}\n", out, contract_name);
 
                     // Init Function
                     if let Some(FunctionV2 {
@@ -1602,6 +1602,79 @@ mod tests {
     use super::*;
     use std::collections::BTreeMap;
 
+    #[test]
+    fn test_schema_template_display_module_version_v3_multiple_contracts() {
+        let mut receive_function_map = BTreeMap::new();
+        receive_function_map.insert(String::from("MyFunction"), FunctionV2 {
+            parameter:    Some(Type::AccountAddress),
+            error:        Some(Type::AccountAddress),
+            return_value: Some(Type::AccountAddress),
+        });
+
+        let mut map = BTreeMap::new();
+
+        map.insert(String::from("MyContract"), ContractV3 {
+            init:    Some(FunctionV2 {
+                parameter:    Some(Type::AccountAddress),
+                error:        Some(Type::AccountAddress),
+                return_value: Some(Type::AccountAddress),
+            }),
+            receive: receive_function_map.clone(),
+            event:   Some(Type::AccountAddress),
+        });
+        map.insert(String::from("MySecondContract"), ContractV3 {
+            init:    Some(FunctionV2 {
+                parameter:    Some(Type::AccountAddress),
+                error:        Some(Type::AccountAddress),
+                return_value: Some(Type::AccountAddress),
+            }),
+            receive: receive_function_map,
+            event:   Some(Type::AccountAddress),
+        });
+
+        let schema = VersionedModuleSchema::V3(ModuleV3 {
+            contracts: map,
+        });
+
+        let display = "Contract:  MyContract
+  Init:
+    Parameter:
+      \"<AccountAddress>\"
+    Error:
+      \"<AccountAddress>\"
+    Return value:
+      \"<AccountAddress>\"
+  Methods:
+    - \"MyFunction\"
+      Parameter:
+        \"<AccountAddress>\"
+      Error:
+        \"<AccountAddress>\"
+      Return value:
+        \"<AccountAddress>\"
+  Event:
+    \"<AccountAddress>\"
+Contract: MySecondContract
+  Init:
+    Parameter:
+      \"<AccountAddress>\"
+    Error:
+      \"<AccountAddress>\"
+    Return value:
+      \"<AccountAddress>\"
+  Methods:
+    - \"MyFunction\"
+      Parameter:
+        \"<AccountAddress>\"
+      Error:
+        \"<AccountAddress>\"
+      Return value:
+        \"<AccountAddress>\"
+  Event:
+    \"<AccountAddress>\"\n";
+              assert_eq!(display, format!("{}", schema));
+    }
+
     /// Tests schema template display of `VersionedModuleSchema::V3`
     #[test]
     fn test_schema_template_display_module_version_v3() {
@@ -1628,7 +1701,7 @@ mod tests {
             contracts: map,
         });
 
-        let display = "Contract:                     MyContract
+        let display = "Contract:  MyContract
   Init:
     Parameter:
       \"<AccountAddress>\"
@@ -1675,7 +1748,7 @@ mod tests {
             contracts: map,
         });
 
-        let display = "Contract:                     MyContract
+        let display = "Contract:  MyContract
   Init:
     Parameter:
       \"<AccountAddress>\"
@@ -1718,7 +1791,7 @@ mod tests {
             contracts: map,
         });
 
-        let display = "Contract:                     MyContract
+        let display = "Contract:  MyContract
   Init:
     Parameter:
       \"<AccountAddress>\"
@@ -1752,7 +1825,7 @@ mod tests {
             contracts: map,
         });
 
-        let display = "Contract:                     MyContract
+        let display = "Contract:  MyContract
   State:
     \"<AccountAddress>\"
   Init:

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
@@ -1672,7 +1672,7 @@ Contract: MySecondContract
         \"<AccountAddress>\"
   Event:
     \"<AccountAddress>\"\n";
-              assert_eq!(display, format!("{}", schema));
+        assert_eq!(display, format!("{}", schema));
     }
 
     /// Tests schema template display of `VersionedModuleSchema::V3`


### PR DESCRIPTION
## Purpose

When invoking `Display` on a `VersionedModuleSchema` with multiple contracts only the last contract was shown. This because contracts wasn’t appended to final output string in loop.

Also fix test since they didn’t run green. From the PR where they where added, and from this comment, https://github.com/Concordium/concordium-contracts-common/pull/99#discussion_r1250555893, I can see that at some time in the development the indention was set to 30. If I change the indention to 30 the test runs green. Hence I guess the test has been forgotten to run after the indention was changed from 30 -> 11.

## Changes
- Changed loop to append contracts to final string
- Fix test which wasn’t running green.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.