### PR TITLE
Fix policy serialization and mark methods as `const`

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 - Fix `Display` trait on `VersionedModuleSchema` when module contained multiple contracts to render all of them.
+- Fix incorrect serialization of policies in `OwnedPolicy::serial_for_smart_contract`.
+  - The method is used internally in `concordium-smart-contract-testing` and the bug caused issues when checking sender policies.
+- Make `Timestamp::from_timestamp_millis` and `Timestamp::timestamp_millis` constant methods so they can be used when declaring constants.
 
 ## concordium-contracts-common 8.0.0 (2023-08-21)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -672,7 +672,7 @@ impl quickcheck::Arbitrary for Timestamp {
 impl Timestamp {
     /// Construct timestamp from milliseconds since unix epoch.
     #[inline(always)]
-    pub fn from_timestamp_millis(milliseconds: u64) -> Self {
+    pub const fn from_timestamp_millis(milliseconds: u64) -> Self {
         Self {
             milliseconds,
         }
@@ -680,7 +680,7 @@ impl Timestamp {
 
     /// Milliseconds since the UNIX epoch.
     #[inline(always)]
-    pub fn timestamp_millis(&self) -> u64 { self.milliseconds }
+    pub const fn timestamp_millis(&self) -> u64 { self.milliseconds }
 
     /// Add duration to the timestamp. Returns `None` if the resulting timestamp
     /// is not representable, i.e., too far in the future.

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -2097,7 +2097,7 @@ impl OwnedPolicy {
     /// Serialize the policy for consumption by smart contract execution engine.
     ///
     /// This entails the following serialization scheme:
-    /// - `1`:             u8            specifying a single policy.
+    /// - `1`:             u16           specifying a single policy.
     /// - `len`:           u16           length of the inner payload
     /// - `inner payload`: `len` bytes   the serialized `OwnedPolicy`
     #[doc(hidden)]
@@ -2108,7 +2108,7 @@ impl OwnedPolicy {
         // Serialize to an inner vector.
         let inner = to_bytes(self);
         // Specify that there is only one policy.
-        out.write_u8(1)?;
+        out.write_u16(1)?;
         // Write length of the inner.
         (inner.len() as u16).serial(out)?;
         // Write the inner buffer.


### PR DESCRIPTION
## Purpose

Fix a bug in the serialization of the policies. The bug caused issues when using policies in your tests with the `concordium-smart-contract-testing` library.
Also marks some methods as const so they can be used to make constants.

## Changes

- Serialize the number of policies using two bytes rather than one, which matches what the node does.
- Mark `Timestamp::from_timestamp_millis` and `Timestamp::timestamp_millis` as const

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.