### PR TITLE
Add getting event schema from module schema

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased changes
+- Add event schema getter on `VersionedModuleSchema`.
 - Fix `Display` trait on `VersionedModuleSchema` when module contained multiple contracts to render all of them.
 - Fix incorrect serialization of policies in `OwnedPolicy::serial_for_smart_contract`.
   - The method is used internally in `concordium-smart-contract-testing` and the bug caused issues when checking sender policies.

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased changes
-- Add event schema getter on `VersionedModuleSchema`.
+- Add contract event schema getter on `VersionedModuleSchema`.
 - Fix `Display` trait on `VersionedModuleSchema` when module contained multiple contracts to render all of them.
 - Fix incorrect serialization of policies in `OwnedPolicy::serial_for_smart_contract`.
   - The method is used internally in `concordium-smart-contract-testing` and the bug caused issues when checking sender policies.

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1058,7 +1058,9 @@ mod impls {
         #[error("Return values not supported for this module version")]
         ReturnValueNotSupported,
         #[error("Event schema not found in contract schema")]
-        NoErrorInEvents,
+        NoEventInContract,
+        #[error("Events not supported for this module version")]
+        EventNotSupported,
     }
 
     impl From<ParseError> for VersionedSchemaError {
@@ -1222,11 +1224,11 @@ mod impls {
             let versioned_contract_schema = get_versioned_contract_schema(self, contract_name)?;
 
             let param_event = match versioned_contract_schema {
-                VersionedContractSchema::V0(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
-                VersionedContractSchema::V1(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
-                VersionedContractSchema::V2(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
+                VersionedContractSchema::V0(_) => Err(VersionedSchemaError::EventNotSupported)?,
+                VersionedContractSchema::V1(_) => Err(VersionedSchemaError::EventNotSupported)?,
+                VersionedContractSchema::V2(_) => Err(VersionedSchemaError::EventNotSupported)?,
                 VersionedContractSchema::V3(contract_schema) => {
-                    contract_schema.event.ok_or(VersionedSchemaError::NoErrorInEvents)
+                    contract_schema.event.ok_or(VersionedSchemaError::NoEventInContract)
                 }
             };
             param_event

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1358,12 +1358,19 @@ mod impls {
 
         #[test]
         fn test_getting_get_event_schema() {
-            let module_bytes = hex::decode("ffff03010000000c00000054657374436f6e7472616374000000000001150200000003000000466f6f020300000042617202").unwrap();
-            let module_schema = VersionedModuleSchema::new(&module_bytes, &None).unwrap();
+            let events = Type::Enum(vec![("Foo".to_string(), Fields::None), ("Bar".to_string(), Fields::None)]);
+            let module_schema = VersionedModuleSchema::V3(
+                ModuleV3 { 
+                    contracts: BTreeMap::from([("TestContract".into(), ContractV3 {
+                        init: None,
+                        receive: BTreeMap::new(),
+                        event: Some(events.clone())
+                    })])
+             });
             let extracted_type = module_schema
                 .get_event_schema("TestContract")
                 .unwrap();
-            assert_eq!(extracted_type, Type::Enum(vec![("Foo".to_string(), Fields::None), ("Bar".to_string(), Fields::None)]))
+            assert_eq!(extracted_type, events)
         }
 
         #[test]

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1218,19 +1218,16 @@ mod impls {
         }
 
         // Returns a event schema from a versioned module schema
-        pub fn get_event_schema(
-            &self,
-            contract_name: &str
-        ) -> Result<Type, VersionedSchemaError> {
+        pub fn get_event_schema(&self, contract_name: &str) -> Result<Type, VersionedSchemaError> {
             let versioned_contract_schema = get_versioned_contract_schema(self, contract_name)?;
 
             let param_event = match versioned_contract_schema {
                 VersionedContractSchema::V0(_) => Err(VersionedSchemaError::NoEventInContract)?,
                 VersionedContractSchema::V1(_) => Err(VersionedSchemaError::NoEventInContract)?,
                 VersionedContractSchema::V2(_) => Err(VersionedSchemaError::NoEventInContract)?,
-                VersionedContractSchema::V3(contract_schema) => Ok(contract_schema
-                    .event
-                    .ok_or(VersionedSchemaError::NoEventInContract)?)
+                VersionedContractSchema::V3(contract_schema) => {
+                    Ok(contract_schema.event.ok_or(VersionedSchemaError::NoEventInContract)?)
+                }
             };
             param_event
         }
@@ -1358,18 +1355,21 @@ mod impls {
 
         #[test]
         fn test_getting_get_event_schema() {
-            let events = Type::Enum(vec![("Foo".to_string(), Fields::None), ("Bar".to_string(), Fields::None)]);
-            let module_schema = VersionedModuleSchema::V3(
-                ModuleV3 { 
-                    contracts: BTreeMap::from([("TestContract".into(), ContractV3 {
+            let events = Type::Enum(vec![
+                ("Foo".to_string(), Fields::None),
+                ("Bar".to_string(), Fields::None),
+            ]);
+            let module_schema = VersionedModuleSchema::V3(ModuleV3 {
+                contracts: BTreeMap::from([(
+                    "TestContract".into(),
+                    ContractV3 {
                         init: None,
                         receive: BTreeMap::new(),
-                        event: Some(events.clone())
-                    })])
-             });
-            let extracted_type = module_schema
-                .get_event_schema("TestContract")
-                .unwrap();
+                        event: Some(events.clone()),
+                    },
+                )]),
+            });
+            let extracted_type = module_schema.get_event_schema("TestContract").unwrap();
             assert_eq!(extracted_type, events)
         }
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1217,7 +1217,7 @@ mod impls {
             Ok(param_schema)
         }
 
-        // Returns a event schema from a versioned module schema
+        // Returns an event schema from a versioned module schema
         pub fn get_event_schema(&self, contract_name: &str) -> Result<Type, VersionedSchemaError> {
             let versioned_contract_schema = get_versioned_contract_schema(self, contract_name)?;
 
@@ -1226,7 +1226,7 @@ mod impls {
                 VersionedContractSchema::V1(_) => Err(VersionedSchemaError::NoEventInContract)?,
                 VersionedContractSchema::V2(_) => Err(VersionedSchemaError::NoEventInContract)?,
                 VersionedContractSchema::V3(contract_schema) => {
-                    Ok(contract_schema.event.ok_or(VersionedSchemaError::NoEventInContract)?)
+                    contract_schema.event.ok_or(VersionedSchemaError::NoEventInContract)
                 }
             };
             param_event

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1360,14 +1360,11 @@ mod impls {
                 ("Bar".to_string(), Fields::None),
             ]);
             let module_schema = VersionedModuleSchema::V3(ModuleV3 {
-                contracts: BTreeMap::from([(
-                    "TestContract".into(),
-                    ContractV3 {
-                        init: None,
-                        receive: BTreeMap::new(),
-                        event: Some(events.clone()),
-                    },
-                )]),
+                contracts: BTreeMap::from([("TestContract".into(), ContractV3 {
+                    init:    None,
+                    receive: BTreeMap::new(),
+                    event:   Some(events.clone()),
+                })]),
             });
             let extracted_type = module_schema.get_event_schema("TestContract").unwrap();
             assert_eq!(extracted_type, events)

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1351,7 +1351,7 @@ mod impls {
         fn test_getting_init_param_schema() {
             let extracted_type = module_schema().get_init_param_schema("TestContract").unwrap();
             assert_eq!(extracted_type, Type::U8)
-        }        
+        }
 
         #[test]
         fn test_getting_get_event_schema() {

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1058,7 +1058,7 @@ mod impls {
         #[error("Return values not supported for this module version")]
         ReturnValueNotSupported,
         #[error("Event schema not found in contract schema")]
-        NoEventInContract,
+        NoErrorInEvents,
     }
 
     impl From<ParseError> for VersionedSchemaError {
@@ -1222,11 +1222,11 @@ mod impls {
             let versioned_contract_schema = get_versioned_contract_schema(self, contract_name)?;
 
             let param_event = match versioned_contract_schema {
-                VersionedContractSchema::V0(_) => Err(VersionedSchemaError::NoEventInContract)?,
-                VersionedContractSchema::V1(_) => Err(VersionedSchemaError::NoEventInContract)?,
-                VersionedContractSchema::V2(_) => Err(VersionedSchemaError::NoEventInContract)?,
+                VersionedContractSchema::V0(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
+                VersionedContractSchema::V1(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
+                VersionedContractSchema::V2(_) => Err(VersionedSchemaError::ErrorNotSupported)?,
                 VersionedContractSchema::V3(contract_schema) => {
-                    contract_schema.event.ok_or(VersionedSchemaError::NoEventInContract)
+                    contract_schema.event.ok_or(VersionedSchemaError::NoErrorInEvents)
                 }
             };
             param_event


### PR DESCRIPTION
## Purpose

To deserialize events one need to be able to extract the event schema from the module schema. This PR extend `VersionedModuleSchema` with a getter.

## Changes

Extend `VersionedModuleSchema` with a getter to event schema.

## Checklist

- [x] My code follows the style of this project.
- [] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.