### PR TITLE
Add helpers to extract build information from Wasm modules.

### DIFF
--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -25,7 +25,6 @@ jobs:
   rustfmt:
     name: Format
     runs-on: ubuntu-latest
-    working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -40,6 +39,7 @@ jobs:
 
       - name: Run cargo fmt
         uses: actions-rs/cargo@v1
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         with:
           command: fmt
           args: --all -- --check
@@ -47,7 +47,6 @@ jobs:
   rustdoc:
     name: Docs
     runs-on: ubuntu-latest
-    working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -60,13 +59,13 @@ jobs:
           override: true
 
       - name: Run cargo doc
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         run: |
           RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features --color=always
 
   clippy:
     name: Clippy on concordium-contracts-common
     runs-on: ubuntu-latest
-    working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
         features:
@@ -96,6 +95,7 @@ jobs:
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         with:
           command: clippy
           args: --manifest-path=concordium-contracts-common/Cargo.toml --target=${{ matrix.target }} --features=${{ matrix.features }} --no-default-features -- -D warnings
@@ -103,7 +103,6 @@ jobs:
   clippy-on-derive:
     name: Clippy on concordium-contracts-common-derive
     runs-on: ubuntu-latest
-    working-directory: ${{ env.WORKING_DIRECTORY }}
     strategy:
       matrix:
         features:
@@ -129,6 +128,7 @@ jobs:
 
       - name: Run cargo clippy
         uses: actions-rs/cargo@v1
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         with:
           command: clippy
           args: --manifest-path=concordium-contracts-common-derive/Cargo.toml --target=${{ matrix.target }} --no-default-features -- -D warnings
@@ -136,7 +136,6 @@ jobs:
   test:
     name: x86_64 tests
     runs-on: ubuntu-latest
-    working-directory: ${{ env.WORKING_DIRECTORY }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
@@ -150,6 +149,7 @@ jobs:
 
       - name: Run cargo test
         uses: actions-rs/cargo@v1
+        working-directory: ${{ env.WORKING_DIRECTORY }}
         with:
           command: test
           args: --workspace --all-features

--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -27,11 +27,6 @@ pub enum UpdateSignMarker {}
 pub enum StateMarker {}
 
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-/// Used as a phantom type to indicate a hash is a hash with no specific
-/// meaning.
-pub enum PureHashMarker {}
-
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 /// Used as a phantom type to indicate a hash is a leadership election
 /// nonce.
 pub enum ElectionNonceMarker {}
@@ -59,6 +54,3 @@ pub type UpdateSignHash = HashBytes<UpdateSignMarker>;
 pub type StateHash = HashBytes<StateMarker>;
 /// Hash that is a successor proof of an epoch finalization entry.
 pub type SuccessorProof = HashBytes<SuccessorProofMarker>;
-
-/// A Sha256 with no specific meaning.
-pub type Hash = HashBytes<PureHashMarker>;

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix incorrect serialization of policies in `OwnedPolicy::serial_for_smart_contract`.
   - The method is used internally in `concordium-smart-contract-testing` and the bug caused issues when checking sender policies.
 - Make `Timestamp::from_timestamp_millis` and `Timestamp::timestamp_millis` constant methods so they can be used when declaring constants.
+- Add a new type `Hash` for representing SHA2-256 hashes.
 
 ## concordium-contracts-common 8.0.0 (2023-08-21)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
@@ -76,6 +76,15 @@ pub enum ModuleReferenceMarker {}
 /// A reference to a smart contract module deployed on the chain.
 pub type ModuleReference = HashBytes<ModuleReferenceMarker>;
 
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+/// Used as a phantom type to indicate a hash is a hash with no specific
+/// meaning.
+pub enum PureHashMarker {}
+
+/// A Sha256 with no specific meaning.
+pub type Hash = HashBytes<PureHashMarker>;
+
 #[cfg(feature = "derive-serde")]
 #[derive(Debug, thiserror::Error)]
 /// Possible errors when converting from a string to any kind of hash.

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
@@ -76,7 +76,6 @@ pub enum ModuleReferenceMarker {}
 /// A reference to a smart contract module deployed on the chain.
 pub type ModuleReference = HashBytes<ModuleReferenceMarker>;
 
-
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
 /// Used as a phantom type to indicate a hash is a hash with no specific
 /// meaning.

--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased changes
 
+- Add `get_build_info` and `get_build_info_from_skeleton` utility functions for
+  extracting build information from a Wasm module.
+
 ## concordium-smart-contract-engine 3.0.0 (2023-08-21)
 
 - Functions that process V1 smart contract modules

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -648,7 +648,9 @@ pub fn get_build_info_from_skeleton(
     let mut build_context_section = None;
     for ucs in skeleton.custom.iter() {
         let cs = parse_custom(ucs)?;
-        if cs.name.as_ref() == BUILD_INFO_SECTION_NAME && build_context_section.replace(cs).is_some() {
+        if cs.name.as_ref() == BUILD_INFO_SECTION_NAME
+            && build_context_section.replace(cs).is_some()
+        {
             return Err(CustomSectionLookupError::Multiple);
         }
     }

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -1,12 +1,15 @@
-//! Various utilities for testing and extraction of schemas.
+//! Various utilities for testing and extraction of schemas and build
+//! information.
 
 use crate::ExecResult;
 use anyhow::{anyhow, bail, ensure, Context};
-use concordium_contracts_common::{from_bytes, schema, Cursor, Deserial};
+use concordium_contracts_common::{
+    self as concordium_std, from_bytes, hashes, schema, Cursor, Deserial,
+};
 use concordium_wasm::{
     artifact::{Artifact, ArtifactNamedImport, RunnableCode, TryFromImport},
     machine::{self, NoInterrupt, Value},
-    parse::{parse_custom, parse_skeleton},
+    parse::{parse_custom, parse_skeleton, Skeleton},
     types::{ExportDescription, Module, Name},
     utils,
     validate::{self, ValidationConfig},
@@ -582,6 +585,74 @@ pub fn get_embedded_schema_v1(bytes: &[u8]) -> ExecResult<schema::VersionedModul
     } else {
         bail!("No schema found in the module")
     }
+}
+
+/// The build information that will be embedded as a custom section to
+/// support reproducible builds.
+/// It is embedded serialized using the smart contract serialization format.
+#[derive(Debug, Clone, concordium_contracts_common::Serialize)]
+pub struct BuildInfo {
+    /// The SHA256 hash of the tar file used to build.
+    /// Note that this is the hash of the **tar** file alone, not of any
+    /// compressed version.
+    pub archive_hash:  hashes::Hash,
+    /// The link to where the source code will be located.
+    pub source_link:   Option<String>,
+    /// The build image that was used.
+    pub image:         String,
+    /// The exact command invocation inside the image that was used to produce
+    /// the contract.
+    pub build_command: Vec<String>,
+}
+
+#[derive(Debug, Clone, concordium_contracts_common::Serialize)]
+pub enum VersionedBuildInfo {
+    V0(BuildInfo),
+}
+
+/// Name of the custom section that contains the build information of the
+/// module.
+pub const BUILD_INFO_SECTION_NAME: &str = "concordium-build-info";
+
+#[derive(Debug, thiserror::Error)]
+pub enum CustomSectionLookupError {
+    #[error("Custom section with a provided name is not present.")]
+    Missing,
+    #[error("Multiple custom sections with the given name are present.")]
+    Multiple,
+    #[error("Parse error: {0}.")]
+    MalformedData(#[from] anyhow::Error),
+}
+
+impl CustomSectionLookupError {
+    /// Returns whether the value is of the [`Missing`](Self::Missing) variant.
+    pub fn is_missing(&self) -> bool { matches!(self, Self::Missing) }
+}
+
+/// Extract the embedded [`VersionedBuildContext`] from a Wasm module.
+pub fn get_build_info(bytes: &[u8]) -> Result<VersionedBuildInfo, CustomSectionLookupError> {
+    let skeleton = parse_skeleton(bytes)?;
+    get_build_info_from_skeleton(&skeleton)
+}
+
+/// Extract the embedded [`VersionedBuildContext`] from a [`Skeleton`].
+pub fn get_build_info_from_skeleton(
+    skeleton: &Skeleton,
+) -> Result<VersionedBuildInfo, CustomSectionLookupError> {
+    let mut build_context_section = None;
+    for ucs in skeleton.custom.iter() {
+        let cs = parse_custom(ucs)?;
+        if cs.name.as_ref() == BUILD_INFO_SECTION_NAME {
+            if build_context_section.replace(cs).is_some() {
+                return Err(CustomSectionLookupError::Multiple);
+            }
+        }
+    }
+    let Some(cs) = build_context_section else {
+        return Err(CustomSectionLookupError::Missing)
+    };
+    let info: VersionedBuildInfo = from_bytes(cs.contents).context("Failed parsing build info")?;
+    Ok(info)
 }
 
 #[cfg(test)]

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -648,10 +648,8 @@ pub fn get_build_info_from_skeleton(
     let mut build_context_section = None;
     for ucs in skeleton.custom.iter() {
         let cs = parse_custom(ucs)?;
-        if cs.name.as_ref() == BUILD_INFO_SECTION_NAME {
-            if build_context_section.replace(cs).is_some() {
-                return Err(CustomSectionLookupError::Multiple);
-            }
+        if cs.name.as_ref() == BUILD_INFO_SECTION_NAME && build_context_section.replace(cs).is_some() {
+            return Err(CustomSectionLookupError::Multiple);
         }
     }
     let Some(cs) = build_context_section else {

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -589,7 +589,6 @@ pub fn get_embedded_schema_v1(bytes: &[u8]) -> ExecResult<schema::VersionedModul
 
 /// The build information that will be embedded as a custom section to
 /// support reproducible builds.
-/// It is embedded serialized using the smart contract serialization format.
 #[derive(Debug, Clone, concordium_contracts_common::Serialize)]
 pub struct BuildInfo {
     /// The SHA256 hash of the tar file used to build.
@@ -605,6 +604,13 @@ pub struct BuildInfo {
     pub build_command: Vec<String>,
 }
 
+/// A versioned build information. This is the information that is embedded in a
+/// custom section. Currently there is one version, but the format supports
+/// future evolution.
+///
+/// The value is embedded in a custom section serialized using the smart
+/// contract serialization format
+/// ([`Serial`](concordium_contracts_common::Serial) trait).
 #[derive(Debug, Clone, concordium_contracts_common::Serialize)]
 pub enum VersionedBuildInfo {
     V0(BuildInfo),
@@ -629,13 +635,13 @@ impl CustomSectionLookupError {
     pub fn is_missing(&self) -> bool { matches!(self, Self::Missing) }
 }
 
-/// Extract the embedded [`VersionedBuildContext`] from a Wasm module.
+/// Extract the embedded [`VersionedBuildInfo`] from a Wasm module.
 pub fn get_build_info(bytes: &[u8]) -> Result<VersionedBuildInfo, CustomSectionLookupError> {
     let skeleton = parse_skeleton(bytes)?;
     get_build_info_from_skeleton(&skeleton)
 }
 
-/// Extract the embedded [`VersionedBuildContext`] from a [`Skeleton`].
+/// Extract the embedded [`VersionedBuildInfo`] from a [`Skeleton`].
 pub fn get_build_info_from_skeleton(
     skeleton: &Skeleton,
 ) -> Result<VersionedBuildInfo, CustomSectionLookupError> {


### PR DESCRIPTION
## Purpose

For the reproducible builds work we need to embed build information into the Wasm modules. This PR adds helpers for extract this information.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
