### PR TITLE
Add support for ergonomic use of Arc and Rc over signer.

### DIFF
--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -1343,6 +1343,32 @@ pub trait ExactSizeTransactionSigner: TransactionSigner {
     fn num_keys(&self) -> u32;
 }
 
+impl<S: TransactionSigner> TransactionSigner for std::sync::Arc<S> {
+    fn sign_transaction_hash(
+        &self,
+        hash_to_sign: &hashes::TransactionSignHash,
+    ) -> TransactionSignature {
+        self.as_ref().sign_transaction_hash(hash_to_sign)
+    }
+}
+
+impl<S: ExactSizeTransactionSigner> ExactSizeTransactionSigner for std::sync::Arc<S> {
+    fn num_keys(&self) -> u32 { self.as_ref().num_keys() }
+}
+
+impl<S: TransactionSigner> TransactionSigner for std::rc::Rc<S> {
+    fn sign_transaction_hash(
+        &self,
+        hash_to_sign: &hashes::TransactionSignHash,
+    ) -> TransactionSignature {
+        self.as_ref().sign_transaction_hash(hash_to_sign)
+    }
+}
+
+impl<S: ExactSizeTransactionSigner> ExactSizeTransactionSigner for std::rc::Rc<S> {
+    fn num_keys(&self) -> u32 { self.as_ref().num_keys() }
+}
+
 /// This signs with the first `threshold` credentials and for each
 /// credential with the first threshold keys for that credential.
 impl TransactionSigner for AccountKeys {


### PR DESCRIPTION
## Purpose

It is common to wrap WalletAccount into an Arc or Rc to clone it. If a method then requires an `&impl ExactSizedTransactionSigner` and we have an `Arc<WalletAccount>` we have to do the ugly reborrow `&*signer` to get the correct type.

Implementing these traits means that we can just write &signer instead.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
