### PR TITLE
Add `parse` helper method to `ContractEvent`

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased changes
 
 - Fix `Display` implementation of `Web3IdAttribute::Timestamp` attribute.
+- Add helper method `parse` to `ContractEvent` for deserializing into types that implement `concordium_contracts_common::Deserial`.
 
 ## 3.0.1 (2023-08-28)
 

--- a/rust-src/concordium_base/src/smart_contracts.rs
+++ b/rust-src/concordium_base/src/smart_contracts.rs
@@ -223,8 +223,8 @@ impl std::fmt::Display for ContractEvent {
 }
 
 impl ContractEvent {
-    /// Try to parse the event into a type that implement
-    /// [`concordium_contracts_common::Deserial`].
+    /// Try to parse the event into a type that implements
+    /// [`Deserial`](concordium_contracts_common::Deserial).
     ///
     /// Ensures that all the bytes in the event data are read.
     pub fn parse<T: concordium_contracts_common::Deserial>(

--- a/rust-src/concordium_base/src/smart_contracts.rs
+++ b/rust-src/concordium_base/src/smart_contracts.rs
@@ -221,3 +221,23 @@ impl std::fmt::Display for ContractEvent {
         Ok(())
     }
 }
+
+impl ContractEvent {
+    /// Try to parse the event into a type that implement
+    /// [`concordium_contracts_common::Deserial`].
+    ///
+    /// Ensures that all the bytes in the event data are read.
+    pub fn parse<T: concordium_contracts_common::Deserial>(
+        &self,
+    ) -> concordium_contracts_common::ParseResult<T> {
+        use concordium_contracts_common::{Cursor, Get, ParseError};
+        let mut cursor = Cursor::new(self.as_ref());
+        let res = cursor.get()?;
+        // Check that all bytes have been read, as leftover bytes usually indicate
+        // errors.
+        if cursor.offset != self.as_ref().len() {
+            return Err(ParseError::default());
+        }
+        Ok(res)
+    }
+}


### PR DESCRIPTION
## Purpose

Add `parse` helper method to `ContractEvent`

## Changes

- Add the method

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.