### PR TITLE
Add helpers to WasmModule.

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -356,7 +356,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bs58",

--- a/idiss/Cargo.lock
+++ b/idiss/Cargo.lock
@@ -341,7 +341,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bs58",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -278,7 +278,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "anyhow",
  "bs58",

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -379,7 +379,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 dependencies = [
  "aes",
  "anyhow",

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Add helpers `from_file` and `from_slice` to construct a `WasmModule`.
+
 ## 3.1.0 (2023-10-18)
 
 - Fix `Display` implementation of `Web3IdAttribute::Timestamp` attribute.

--- a/rust-src/concordium_base/Cargo.toml
+++ b/rust-src/concordium_base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_base"
-version = "3.1.0"
+version = "3.1.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.65"


### PR DESCRIPTION
## Purpose

Helper functions for reading modules.

It is often necessary to read a versioned module from a file, both in deploy scripts and in tools we have. This simplifies the repetitive task.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
