### PR TITLE
Fix `Display` on `Timestamp`

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Fix `Display` implementation on `Timestamp` such that errors isn't returned but instead it default to a `u64` string. Also updated `FromStr` on `Timestamp` such that it can be mapped from a `u64`.
+- Fix `Display` implementation on `Timestamp` such that errors isn't returned but instead it defaults to an `u64` string. Also updated `FromStr` on `Timestamp` such that it can be mapped from an `u64`.
 
 ## concordium-contracts-common 8.1.0 (2023-10-18)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add `TryFrom<Timestamp> for String` such that possible errors can be matched.
+- Fix `Display` implementation on `Timestamp` such that errors isn't returned but instead it default to a `u64` string. Also updated `FromStr` on `Timestamp` such that it can be mapped from a `u64`.
 
 ## concordium-contracts-common 8.1.0 (2023-10-18)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Add `TryFrom<Timestamp> for String` such that possible errors can be matched.
+
 ## concordium-contracts-common 8.1.0 (2023-10-18)
 
 - Add contract event schema getter on `VersionedModuleSchema`.

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
@@ -2740,7 +2740,9 @@ impl Type {
                             .into(),
                     )
                 })?;
-                Ok(Value::String(timestamp.to_string()))
+                let datetime: String = String::try_from(timestamp)
+                    .map_err(|error: TimestampOverflow| ToJsonError::DeserialError { position, schema: Type::Timestamp, reason: error.to_string(), data: ToJsonErrorData::from(to_bytes(&timestamp)) })?;
+                Ok(Value::String(datetime))
             }
             Type::Duration => {
                 let duration = Duration::deserial(source).map_err(|_| {

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
@@ -2740,8 +2740,15 @@ impl Type {
                             .into(),
                     )
                 })?;
-                let datetime: String = String::try_from(timestamp)
-                    .map_err(|error: TimestampOverflow| ToJsonError::DeserialError { position, schema: Type::Timestamp, reason: error.to_string(), data: ToJsonErrorData::from(to_bytes(&timestamp)) })?;
+                let datetime: String =
+                    String::try_from(timestamp).map_err(|error: TimestampOverflow| {
+                        ToJsonError::DeserialError {
+                            position,
+                            schema: Type::Timestamp,
+                            reason: error.to_string(),
+                            data: ToJsonErrorData::from(to_bytes(&timestamp)),
+                        }
+                    })?;
                 Ok(Value::String(datetime))
             }
             Type::Duration => {

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema_json.rs
@@ -2740,16 +2740,7 @@ impl Type {
                             .into(),
                     )
                 })?;
-                let datetime: String =
-                    String::try_from(timestamp).map_err(|error: TimestampOverflow| {
-                        ToJsonError::DeserialError {
-                            position,
-                            schema: Type::Timestamp,
-                            reason: error.to_string(),
-                            data: ToJsonErrorData::from(to_bytes(&timestamp)),
-                        }
-                    })?;
-                Ok(Value::String(datetime))
+                Ok(Value::String(timestamp.to_string()))
             }
             Type::Duration => {
                 let duration = Duration::deserial(source).map_err(|_| {

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -778,8 +778,8 @@ impl fmt::Display for ParseTimestampError {
 impl std::error::Error for ParseTimestampError {}
 
 #[cfg(feature = "derive-serde")]
-/// The FromStr parses a string representing either an [`u64`] of milliseconds or
-/// the time according to RFC3339.
+/// The FromStr parses a string representing either an [`u64`] of milliseconds
+/// or the time according to RFC3339.
 impl str::FromStr for Timestamp {
     type Err = ParseTimestampError;
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -747,7 +747,7 @@ impl TryFrom<Timestamp> for String {
     type Error = TimestampOverflow;
 
     fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
-        if let Ok(utc)=  <chrono::DateTime<chrono::Utc>>::try_from(value) {
+        if let Ok(utc) =  <chrono::DateTime<chrono::Utc>>::try_from(value) {
             Ok(utc.to_rfc3339())
         } else {
             Err(TimestampOverflow)
@@ -811,8 +811,7 @@ impl str::FromStr for Timestamp {
 /// format in the UTC time zone.
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let date: String = String::try_from(*self)
-            .map_err(|_| fmt::Error)?;
+        let date: String = String::try_from(*self).map_err(|_| fmt::Error)?;
         write!(f, "{}", date)
     }
 }

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -802,10 +802,10 @@ impl str::FromStr for Timestamp {
 }
 
 #[cfg(feature = "derive-serde")]
-/// The display implementation tries to display the timestamp according to
-/// RFC3339 format in the UTC time zone.
-/// If parsing to a [`chrono::DateTime<Utc>`] fails [`Timestamp`] milliseconds,
-/// [`u64`], is returned directly as a string.
+/// This display implementation attempts to format the timestamp as per
+/// the RFC3339 standard, using the UTC time zone.
+/// If parsing the timestamp into a [`chrono::DateTime<Utc>`] fails, it
+/// simply returns the timestamp in milliseconds as a string.
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use chrono::offset::TimeZone;

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -2846,12 +2846,14 @@ mod test {
     use std::str::FromStr;
 
     #[test]
+    #[cfg(feature = "derive-serde")]
     fn test_string_from_timestamp_returns_error_when_to_far_in_future() {
         let timestamp = Timestamp::from_timestamp_millis(100000001683508889);
         assert!(matches!(String::try_from(timestamp), Err(TimestampOverflow)))
     }
 
     #[test]
+    #[cfg(feature = "derive-serde")]
     fn test_string_from_timestamp() {
         let timestamp = Timestamp::from_timestamp_millis(42);
         let expected = "1970-01-01T00:00:00.042+00:00".to_string();

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -747,7 +747,7 @@ impl TryFrom<Timestamp> for String {
     type Error = TimestampOverflow;
 
     fn try_from(value: Timestamp) -> Result<Self, Self::Error> {
-        if let Ok(utc) =  <chrono::DateTime<chrono::Utc>>::try_from(value) {
+        if let Ok(utc) = <chrono::DateTime<chrono::Utc>>::try_from(value) {
             Ok(utc.to_rfc3339())
         } else {
             Err(TimestampOverflow)

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -784,8 +784,7 @@ impl str::FromStr for Timestamp {
     type Err = ParseTimestampError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let try_parse_u64 =
-            s.parse::<u64>().map(|milliseconds| Timestamp::from_timestamp_millis(milliseconds));
+        let try_parse_u64 = s.parse::<u64>().map(Timestamp::from_timestamp_millis);
 
         if let Ok(parsed_u64) = try_parse_u64 {
             return Ok(parsed_u64);

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -784,8 +784,8 @@ impl str::FromStr for Timestamp {
     type Err = ParseTimestampError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let try_parse_u64 = s.parse::<u64>()
-            .map(|milliseconds| Timestamp::from_timestamp_millis(milliseconds));
+        let try_parse_u64 =
+            s.parse::<u64>().map(|milliseconds| Timestamp::from_timestamp_millis(milliseconds));
 
         if let Ok(parsed_u64) = try_parse_u64 {
             return Ok(parsed_u64);
@@ -802,10 +802,10 @@ impl str::FromStr for Timestamp {
 }
 
 #[cfg(feature = "derive-serde")]
-/// The display implementation tries to display the timestamp according to RFC3339
-/// format in the UTC time zone.
-/// If parsing to a [`chrono::DateTime<Utc>`] fails [`Timestamp`] milliseconds, [`u64`],
-/// is returned directly as a string.
+/// The display implementation tries to display the timestamp according to
+/// RFC3339 format in the UTC time zone.
+/// If parsing to a [`chrono::DateTime<Utc>`] fails [`Timestamp`] milliseconds,
+/// [`u64`], is returned directly as a string.
 impl fmt::Display for Timestamp {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use chrono::offset::TimeZone;


### PR DESCRIPTION
## Purpose

Currently deserialization of an `Type` in `to_json` fails if a Timestamp is too far in future.  This is because it calls `to_string` which used implementation of `Display`. The possible error in this implementation is never catched which makes the program panic.

## Changes
- Bugfix `Display` implementation on `Timestamp` such that an error isn’t returned. If parsing to RFC3339 fails then a u64 as string is returned.
- Updated `FromStr` on `Timestamp` to be able to parse u64 string. 

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.