### PR TITLE
[contracts-common] Fix documentation regarding generating error schema for `init`

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common-derive/src/lib.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common-derive/src/lib.rs
@@ -561,7 +561,7 @@ pub fn deletable_derive(input: TokenStream) -> TokenStream {
 /// #[derive(SchemaType)]
 /// enum MyError { ... }
 ///
-/// #[init(contract = "my_contract", parameter = "MyError")]
+/// #[init(contract = "my_contract", error = "MyError")]
 /// fn some_init(ctx: &impl InitContext, state: &mut StateApi) -> Result<(), MyError> {...}
 /// ```
 ///


### PR DESCRIPTION
## Purpose

Noticed an error in the documentation for contract init macro.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
