### PR TITLE
Add protocol version 7 and genesis data

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -61,6 +61,7 @@ library
       Concordium.Genesis.Data.P4
       Concordium.Genesis.Data.P5
       Concordium.Genesis.Data.P6
+      Concordium.Genesis.Data.P7
       Concordium.Genesis.Parameters
       Concordium.GRPC2
       Concordium.ID.Account

--- a/haskell-bins/genesis/Genesis.hs
+++ b/haskell-bins/genesis/Genesis.hs
@@ -39,6 +39,7 @@ import qualified Concordium.Genesis.Data.P3 as P3
 import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P5 as P5
 import qualified Concordium.Genesis.Data.P6 as P6
+import qualified Concordium.Genesis.Data.P7 as P7
 import Concordium.Genesis.Parameters
 import Concordium.Types
 import Concordium.Types.AnonymityRevokers
@@ -242,6 +243,8 @@ main =
                                 gd@(GDP5 P5.GDP5Initial{..}) -> printInitial SP5 (genesisBlockHash gd) (CGPV0 genesisCore) genesisInitialState
                             SP6 -> case gdata of
                                 gd@(GDP6 P6.GDP6Initial{..}) -> printInitial SP6 (genesisBlockHash gd) (CGPV1 genesisCore) genesisInitialState
+                            SP7 -> case gdata of
+                                gd@(GDP7 P7.GDP7Initial{..}) -> printInitial SP7 (genesisBlockHash gd) (CGPV1 genesisCore) genesisInitialState
 
 printInitial :: SProtocolVersion pv -> BlockHash -> VersionedCoreGenesisParameters -> GDBase.GenesisState pv -> IO ()
 printInitial spv gh vcgp GDBase.GenesisState{..} = do

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -19,7 +19,10 @@ maxPayloadSize :: SProtocolVersion pv -> Word32
 maxPayloadSize SP1 = 100 * 1024 -- 100kB
 maxPayloadSize SP2 = 100 * 1024 -- 100kB
 maxPayloadSize SP3 = 100 * 1024 -- 100kB
-maxPayloadSize _ = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, +4 for the length, +4 for the module version
+maxPayloadSize SP4 = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, +4 for the length, +4 for the module version
+maxPayloadSize SP5 = maxPayloadSize SP4
+maxPayloadSize SP6 = maxPayloadSize SP4
+maxPayloadSize SP7 = maxPayloadSize SP4
 
 -- * Web assembly related constants
 
@@ -30,7 +33,9 @@ maxParameterLen SP1 = 1024
 maxParameterLen SP2 = 1024
 maxParameterLen SP3 = 1024
 maxParameterLen SP4 = 1024
-maxParameterLen _ = 65535
+maxParameterLen SP5 = 65535
+maxParameterLen SP6 = maxParameterLen SP5
+maxParameterLen SP7 = maxParameterLen SP5
 
 -- | Whether the number of logs and size of return values should be limited.
 --  The limits have been removed in P5 and onward.
@@ -39,7 +44,9 @@ limitLogsAndReturnValues SP1 = True
 limitLogsAndReturnValues SP2 = True
 limitLogsAndReturnValues SP3 = True
 limitLogsAndReturnValues SP4 = True
-limitLogsAndReturnValues _ = False
+limitLogsAndReturnValues SP5 = False
+limitLogsAndReturnValues SP6 = False
+limitLogsAndReturnValues SP7 = False
 
 -- | Maximum module size of a V0 module.
 maxWasmModuleSizeV0 :: Word32

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -19,9 +19,7 @@ maxPayloadSize :: SProtocolVersion pv -> Word32
 maxPayloadSize SP1 = 100 * 1024 -- 100kB
 maxPayloadSize SP2 = 100 * 1024 -- 100kB
 maxPayloadSize SP3 = 100 * 1024 -- 100kB
-maxPayloadSize SP4 = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, +4 for the length, +4 for the module version
-maxPayloadSize SP5 = maxPayloadSize SP4
-maxPayloadSize SP6 = maxPayloadSize SP4
+maxPayloadSize _ = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, +4 for the length, +4 for the module version
 
 -- * Web assembly related constants
 
@@ -32,8 +30,7 @@ maxParameterLen SP1 = 1024
 maxParameterLen SP2 = 1024
 maxParameterLen SP3 = 1024
 maxParameterLen SP4 = 1024
-maxParameterLen SP5 = 65535
-maxParameterLen SP6 = 65535
+maxParameterLen _ = 65535
 
 -- | Whether the number of logs and size of return values should be limited.
 --  The limits have been removed in P5 and onward.
@@ -42,8 +39,7 @@ limitLogsAndReturnValues SP1 = True
 limitLogsAndReturnValues SP2 = True
 limitLogsAndReturnValues SP3 = True
 limitLogsAndReturnValues SP4 = True
-limitLogsAndReturnValues SP5 = False
-limitLogsAndReturnValues SP6 = False
+limitLogsAndReturnValues _ = False
 
 -- | Maximum module size of a V0 module.
 maxWasmModuleSizeV0 :: Word32

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -267,6 +267,7 @@ instance ToProto ProtocolVersion where
     toProto P4 = Proto.PROTOCOL_VERSION_4
     toProto P5 = Proto.PROTOCOL_VERSION_5
     toProto P6 = Proto.PROTOCOL_VERSION_6
+    toProto P7 = Proto.PROTOCOL_VERSION_7
 
 instance ToProto QueryTypes.NextAccountNonce where
     type Output QueryTypes.NextAccountNonce = Proto.NextAccountSequenceNumber

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -45,6 +45,7 @@ import qualified Concordium.Genesis.Data.P3 as P3
 import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P5 as P5
 import qualified Concordium.Genesis.Data.P6 as P6
+import qualified Concordium.Genesis.Data.P7 as P7
 import Concordium.Types
 import Concordium.Types.Parameters
 
@@ -63,6 +64,7 @@ newtype instance GenesisData 'P3 = GDP3 {unGDP3 :: P3.GenesisDataP3}
 newtype instance GenesisData 'P4 = GDP4 {unGDP4 :: P4.GenesisDataP4}
 newtype instance GenesisData 'P5 = GDP5 {unGDP5 :: P5.GenesisDataP5}
 newtype instance GenesisData 'P6 = GDP6 {unGDP6 :: P6.GenesisDataP6}
+newtype instance GenesisData 'P7 = GDP7 {unGDP7 :: P7.GenesisDataP7}
 
 -- | Data family for regenesis data. This has been chosen to be a data family, as
 --  opposed to a type family principally so that it is injective, i.e., so that
@@ -75,6 +77,7 @@ newtype instance Regenesis 'P3 = RGDP3 {unRGP3 :: P3.RegenesisP3}
 newtype instance Regenesis 'P4 = RGDP4 {unRGP4 :: P4.RegenesisP4}
 newtype instance Regenesis 'P5 = RGDP5 {unRGP5 :: P5.RegenesisP5}
 newtype instance Regenesis 'P6 = RGDP6 {unRGP6 :: P6.RegenesisP6}
+newtype instance Regenesis 'P7 = RGDP7 {unRGP7 :: P7.RegenesisP7}
 
 instance (IsProtocolVersion pv, IsConsensusV0 pv) => BasicGenesisData (GenesisData pv) where
     gdGenesisTime = case protocolVersion @pv of
@@ -158,6 +161,7 @@ instance (IsProtocolVersion pv) => Eq (GenesisData pv) where
         SP4 -> (==) `on` unGDP4
         SP5 -> (==) `on` unGDP5
         SP6 -> (==) `on` unGDP6
+        SP7 -> (==) `on` unGDP7
 
 instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
     get = case protocolVersion @pv of
@@ -167,6 +171,7 @@ instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
         SP4 -> GDP4 <$> P4.getGenesisDataV6
         SP5 -> GDP5 <$> P5.getGenesisDataV7
         SP6 -> GDP6 <$> P6.getGenesisDataV8
+        SP7 -> GDP7 <$> P7.getGenesisDataV9
 
     put = case protocolVersion @pv of
         SP1 -> P1.putGenesisDataV3 . unGDP1
@@ -175,6 +180,7 @@ instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
         SP4 -> P4.putGenesisDataV6 . unGDP4
         SP5 -> P5.putGenesisDataV7 . unGDP5
         SP6 -> P6.putGenesisDataV8 . unGDP6
+        SP7 -> P7.putGenesisDataV9 . unGDP7
 
 -- | Deserialize 'GenesisConfiguration' given the hash of the genesis. If
 --  'GenesisData' or 'Regenesis' is decodable (using its Serialize instance) from a given
@@ -202,6 +208,7 @@ getVersionedGenesisData = case protocolVersion @pv of
     SP4 -> GDP4 <$> P4.getVersionedGenesisData
     SP5 -> GDP5 <$> P5.getVersionedGenesisData
     SP6 -> GDP6 <$> P6.getVersionedGenesisData
+    SP7 -> GDP7 <$> P7.getVersionedGenesisData
 
 -- | Serialize genesis data with a version tag.
 --  Each version tag must be specific to a protocol version, though more than one version tag can
@@ -225,6 +232,7 @@ putVersionedGenesisData = case protocolVersion @pv of
     SP4 -> P4.putVersionedGenesisData . unGDP4
     SP5 -> P5.putVersionedGenesisData . unGDP5
     SP6 -> P6.putVersionedGenesisData . unGDP6
+    SP7 -> P7.putVersionedGenesisData . unGDP7
 
 -- | Generate the block hash of a genesis block with the given genesis data.
 --  This is based on the presumption that a block hash is computed from a byte string
@@ -237,6 +245,7 @@ genesisBlockHash = case protocolVersion @pv of
     SP4 -> P4.genesisBlockHash . unGDP4
     SP5 -> P5.genesisBlockHash . unGDP5
     SP6 -> P6.genesisBlockHash . unGDP6
+    SP7 -> P7.genesisBlockHash . unGDP7
 
 -- | Generate the block hash of a regenesis block with the given regenesis data.
 regenesisBlockHash :: forall pv. (IsProtocolVersion pv) => Regenesis pv -> BlockHash
@@ -247,6 +256,7 @@ regenesisBlockHash = case protocolVersion @pv of
     SP4 -> P4.regenesisBlockHash . unRGP4
     SP5 -> P5.regenesisBlockHash . unRGP5
     SP6 -> P6.regenesisBlockHash . unRGP6
+    SP7 -> P7.regenesisBlockHash . unRGP7
 
 -- | Hash of the initial genesis of the chain to which the given genesis data belongs.
 --  Genesis created as part of a protocol update records the genesis
@@ -259,6 +269,7 @@ firstGenesisBlockHash = case protocolVersion @pv of
     SP4 -> P4.firstGenesisBlockHash . unRGP4
     SP5 -> P5.firstGenesisBlockHash . unRGP5
     SP6 -> P6.firstGenesisBlockHash . unRGP6
+    SP7 -> P7.firstGenesisBlockHash . unRGP7
 
 -- | Tag of the genesis variant used for serialization. This tag determines
 --  whether the genesis data is, e.g., initial genesis, or regenesis.
@@ -270,6 +281,7 @@ genesisVariantTag = case protocolVersion @pv of
     SP4 -> P4.genesisVariantTag . unGDP4
     SP5 -> P5.genesisVariantTag . unGDP5
     SP6 -> P6.genesisVariantTag . unGDP6
+    SP7 -> P7.genesisVariantTag . unGDP7
 
 -- | Tag of the regenesis variant used for serialization. This tag determines
 --  whether the genesis data is, e.g., initial genesis, or regenesis and allows
@@ -283,6 +295,7 @@ regenesisVariantTag = case protocolVersion @pv of
     SP4 -> P4.regenesisVariantTag . unRGP4
     SP5 -> P5.regenesisVariantTag . unRGP5
     SP6 -> P6.regenesisVariantTag . unRGP6
+    SP7 -> P7.regenesisVariantTag . unRGP7
 
 -- | A dependent pair of a protocol version and genesis data.
 data PVGenesisData = forall pv. (IsProtocolVersion pv) => PVGenesisData (GenesisData pv)
@@ -303,6 +316,7 @@ getPVGenesisData = do
         6 -> PVGenesisData . GDP4 <$> P4.getGenesisDataV6
         7 -> PVGenesisData . GDP5 <$> P5.getGenesisDataV7
         8 -> PVGenesisData . GDP6 <$> P6.getGenesisDataV8
+        9 -> PVGenesisData . GDP7 <$> P7.getGenesisDataV9
         n -> fail $ "Unsupported genesis version: " ++ show n
 
 -- | Deserialize a genesis data version tag and return the associated protocol
@@ -318,6 +332,7 @@ getPVGenesisDataPV = do
         6 -> return $ SomeProtocolVersion SP4
         7 -> return $ SomeProtocolVersion SP5
         8 -> return $ SomeProtocolVersion SP6
+        9 -> return $ SomeProtocolVersion SP7
         n -> fail $ "Unsupported genesis version: " ++ show n
 
 -- | Serialize genesis data with a version tag. This is a helper function that
@@ -353,6 +368,8 @@ data StateMigrationParameters (p1 :: ProtocolVersion) (p2 :: ProtocolVersion) wh
     StateMigrationParametersP4ToP5 :: StateMigrationParameters 'P4 'P5
     -- | The state is migrated from protocol version 'P5' to 'P6'.
     StateMigrationParametersP5ToP6 :: P6.StateMigrationData -> StateMigrationParameters 'P5 'P6
+    -- | The state is migrated from protocol version 'P6' to 'P7'.
+    StateMigrationParametersP6ToP7 :: StateMigrationParameters 'P6 'P7
 
 -- | Extract the genesis configuration from the genesis data.
 genesisConfiguration :: (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GenesisConfiguration
@@ -382,6 +399,7 @@ genesisCoreParametersV1 ::
     BaseV1.CoreGenesisParametersV1
 genesisCoreParametersV1 = case protocolVersion @pv of
     SP6 -> \(GDP6 genData) -> P6.genesisCore genData
+    SP7 -> \(GDP7 genData) -> P7.genesisCore genData
 
 -- | Extract the V1 core genesis parameters from the regenesis data.
 regenesisCoreParametersV1 ::
@@ -391,3 +409,4 @@ regenesisCoreParametersV1 ::
     BaseV1.CoreGenesisParametersV1
 regenesisCoreParametersV1 = case protocolVersion @pv of
     SP6 -> \(RGDP6 genData) -> BaseV1.genesisCore $ P6.genesisRegenesis genData
+    SP7 -> \(RGDP7 genData) -> BaseV1.genesisCore $ P7.genesisRegenesis genData

--- a/haskell-src/Concordium/Genesis/Data/P7.hs
+++ b/haskell-src/Concordium/Genesis/Data/P7.hs
@@ -1,0 +1,144 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This module defines the genesis data format for the 'P7' protocol version.
+module Concordium.Genesis.Data.P7 where
+
+import Data.Serialize
+import Data.Word
+
+import Concordium.Common.Version
+import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.Genesis.Data.Base as Base
+import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
+import Concordium.Types
+
+-- | Initial genesis data for the P7 protocol version.
+data GenesisDataP7 = GDP7Initial
+    { -- | The immutable genesis parameters.
+      genesisCore :: !BaseV1.CoreGenesisParametersV1,
+      -- | Serialized initial block state.
+      --  NB: This block state contains some of the same values as 'genesisCore', and they should match.
+      genesisInitialState :: !(Base.GenesisState 'P7)
+    }
+    deriving (Eq, Show)
+
+-- | The regenesis represents a reset of the protocol with a new genesis block.
+--   This does not include the full new state, but only its hash.
+--
+--  The relationship between the new state and the state of the
+--  terminal block of the old chain should be defined by the
+--  chain update mechanism used.
+--
+--  There are two variants, one when migrating from 'P6' to 'P7' and
+--  one from 'P7' to 'P7'.
+data RegenesisP7
+    = GDP7Regenesis {genesisRegenesis :: !BaseV1.RegenesisDataV1}
+    | GDP7RegenesisFromP6
+        { genesisRegenesis :: !BaseV1.RegenesisDataV1,
+          genesisMigration :: ()
+        }
+    deriving (Eq, Show)
+
+-- | Deserialize genesis data in the V9 format.
+getGenesisDataV9 :: Get GenesisDataP7
+getGenesisDataV9 =
+    getWord8 >>= \case
+        0 -> do
+            genesisCore <- get
+            genesisInitialState <- get
+            return GDP7Initial{..}
+        _ -> fail "Unrecognized P7 genesis data type."
+
+getRegenesisData :: Get RegenesisP7
+getRegenesisData =
+    getWord8 >>= \case
+        1 -> do
+            genesisRegenesis <- get
+            return GDP7Regenesis{..}
+        2 -> do
+            genesisRegenesis <- get
+            genesisMigration <- get
+            return GDP7RegenesisFromP6{..}
+        _ -> fail "Unrecognized P7 regenesis data type."
+
+-- | Serialize genesis data in the V9 format.
+putGenesisDataV9 :: Putter GenesisDataP7
+putGenesisDataV9 GDP7Initial{..} = do
+    putWord8 0
+    put genesisCore
+    put genesisInitialState
+
+-- | Deserialize genesis data with a version tag. The expected version tag is 9
+--  and this must be distinct from version tags of other genesis data formats.
+getVersionedGenesisData :: Get GenesisDataP7
+getVersionedGenesisData =
+    getVersion >>= \case
+        9 -> getGenesisDataV9
+        n -> fail $ "Unsupported genesis data version for P7 genesis: " ++ show n
+
+-- | Serialize genesis data with a version tag.
+--  This will use the V9 format.
+putVersionedGenesisData :: Putter GenesisDataP7
+putVersionedGenesisData gd = do
+    putVersion 9
+    putGenesisDataV9 gd
+
+-- | Compute the block hash of the genesis block with the given genesis data.
+--  Every block hash is derived from a message that begins with the block slot,
+--  which is 0 for genesis blocks.
+--
+--  NB: For the regenesis variant the serialized state is not included in the
+--  block hash, only the state hash is. This makes it possible to optimize the
+--  format in the future since it does not have protocol defined meaning. In
+--  contrast, for the initial P7 genesis the initial state is hashed as is.
+genesisBlockHash :: GenesisDataP7 -> BlockHash
+genesisBlockHash GDP7Initial{..} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P7
+    putWord8 0 -- initial variant
+    put genesisCore
+    put genesisInitialState
+
+-- | Compute the block hash of the regenesis data as defined by the specified
+--  protocol. This becomes the block hash of the genesis block of the new chain
+--  after the protocol update.
+regenesisBlockHash :: RegenesisP7 -> BlockHash
+regenesisBlockHash GDP7Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P7
+    putWord8 1 -- regenesis variant
+    put genesisCore
+    put genesisFirstGenesis
+    put genesisPreviousGenesis
+    put genesisTerminalBlock
+    put genesisStateHash
+regenesisBlockHash GDP7RegenesisFromP6{genesisRegenesis = BaseV1.RegenesisDataV1{..}, ..} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P7
+    putWord8 2 -- migration from P6 variant
+    put genesisCore
+    put genesisFirstGenesis
+    put genesisPreviousGenesis
+    put genesisTerminalBlock
+    put genesisStateHash
+    put genesisMigration
+
+-- | The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: RegenesisP7 -> BlockHash
+firstGenesisBlockHash GDP7Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = genesisFirstGenesis
+firstGenesisBlockHash GDP7RegenesisFromP6{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = genesisFirstGenesis
+
+-- | Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP7 -> Word8
+genesisVariantTag GDP7Initial{} = 0
+
+-- | Tag of the regenesis variant used for serialization. This tag determines
+--  whether the genesis data is, e.g., initial genesis, or regenesis and allows
+--  us to deserialize one or the other from the data without knowing a priori what
+--  the data is.
+regenesisVariantTag :: RegenesisP7 -> Word8
+regenesisVariantTag GDP7Regenesis{} = 1
+regenesisVariantTag GDP7RegenesisFromP6{} = 2

--- a/haskell-src/Concordium/Genesis/Data/P7.hs
+++ b/haskell-src/Concordium/Genesis/Data/P7.hs
@@ -20,7 +20,6 @@ data GenesisDataP7 = GDP7Initial
     { -- | The immutable genesis parameters.
       genesisCore :: !BaseV1.CoreGenesisParametersV1,
       -- | Serialized initial block state.
-      --  NB: This block state contains some of the same values as 'genesisCore', and they should match.
       genesisInitialState :: !(Base.GenesisState 'P7)
     }
     deriving (Eq, Show)

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -35,6 +35,7 @@ migrateAuthorizations StateMigrationParametersP4ToP5 auths = auths
 -- Note that the authorization for the consensus parameters v0
 -- are carried over to consensus parameters v1.
 migrateAuthorizations StateMigrationParametersP5ToP6{} auths = auths
+migrateAuthorizations StateMigrationParametersP6ToP7 auths = auths
 
 -- | Apply a state migration to an 'UpdateKeysCollection' structure.
 --
@@ -62,6 +63,7 @@ migrateMintDistribution StateMigrationParametersP3ToP4{} MintDistribution{..} =
     MintDistribution{_mdMintPerSlot = CFalse, ..}
 migrateMintDistribution StateMigrationParametersP4ToP5 mint = mint
 migrateMintDistribution StateMigrationParametersP5ToP6{} mint = mint
+migrateMintDistribution StateMigrationParametersP6ToP7 mint = mint
 
 -- | Apply a state migration to a 'PoolParameters' structure.
 --
@@ -78,6 +80,7 @@ migratePoolParameters (StateMigrationParametersP3ToP4 migration) _ =
     P4.updatePoolParameters (P4.migrationProtocolUpdateData migration)
 migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
 migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
+migratePoolParameters StateMigrationParametersP6ToP7 poolParams = poolParams
 
 -- | Apply a state migration to a 'GASRewards' structure.
 --
@@ -94,6 +97,7 @@ migrateGASRewards StateMigrationParametersP2P3 gr = gr
 migrateGASRewards StateMigrationParametersP3ToP4{} gr = gr
 migrateGASRewards StateMigrationParametersP4ToP5 gr = gr
 migrateGASRewards StateMigrationParametersP5ToP6{} GASRewards{..} = GASRewards{_gasFinalizationProof = CFalse, ..}
+migrateGASRewards StateMigrationParametersP6ToP7 gr = gr
 
 -- | Apply a state migration to a 'ChainParameters' structure.
 --
@@ -147,6 +151,7 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
   where
     RewardParameters{..} = _cpRewardParameters
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
+migrateChainParameters StateMigrationParametersP6ToP7 cps = cps
 
 -- | Apply a state migration to an 'AccountStake' structure.
 --
@@ -188,6 +193,7 @@ migrateAccountStake StateMigrationParametersP4ToP5 =
                       ..
                     }
 migrateAccountStake StateMigrationParametersP5ToP6{} = id
+migrateAccountStake StateMigrationParametersP6ToP7 = id
 
 -- | Migrate time of the effective change from V0 to V1 accounts. Currently this
 --  translates times relative to genesis to times relative to the unix epoch.
@@ -215,3 +221,4 @@ migrateStakePendingChange (StateMigrationParametersP3ToP4 migration) = \case
     RemoveStake eff -> RemoveStake (migratePendingChangeEffective migration eff)
 migrateStakePendingChange StateMigrationParametersP4ToP5 = fmap coercePendingChangeEffectiveV1
 migrateStakePendingChange StateMigrationParametersP5ToP6{} = id
+migrateStakePendingChange StateMigrationParametersP6ToP7 = id

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -35,7 +35,7 @@ migrateAuthorizations StateMigrationParametersP4ToP5 auths = auths
 -- Note that the authorization for the consensus parameters v0
 -- are carried over to consensus parameters v1.
 migrateAuthorizations StateMigrationParametersP5ToP6{} auths = auths
-migrateAuthorizations StateMigrationParametersP6ToP7 auths = auths
+migrateAuthorizations StateMigrationParametersP6ToP7{} auths = auths
 
 -- | Apply a state migration to an 'UpdateKeysCollection' structure.
 --
@@ -63,7 +63,7 @@ migrateMintDistribution StateMigrationParametersP3ToP4{} MintDistribution{..} =
     MintDistribution{_mdMintPerSlot = CFalse, ..}
 migrateMintDistribution StateMigrationParametersP4ToP5 mint = mint
 migrateMintDistribution StateMigrationParametersP5ToP6{} mint = mint
-migrateMintDistribution StateMigrationParametersP6ToP7 mint = mint
+migrateMintDistribution StateMigrationParametersP6ToP7{} mint = mint
 
 -- | Apply a state migration to a 'PoolParameters' structure.
 --
@@ -80,7 +80,7 @@ migratePoolParameters (StateMigrationParametersP3ToP4 migration) _ =
     P4.updatePoolParameters (P4.migrationProtocolUpdateData migration)
 migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
 migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
-migratePoolParameters StateMigrationParametersP6ToP7 poolParams = poolParams
+migratePoolParameters StateMigrationParametersP6ToP7{} poolParams = poolParams
 
 -- | Apply a state migration to a 'GASRewards' structure.
 --
@@ -97,7 +97,7 @@ migrateGASRewards StateMigrationParametersP2P3 gr = gr
 migrateGASRewards StateMigrationParametersP3ToP4{} gr = gr
 migrateGASRewards StateMigrationParametersP4ToP5 gr = gr
 migrateGASRewards StateMigrationParametersP5ToP6{} GASRewards{..} = GASRewards{_gasFinalizationProof = CFalse, ..}
-migrateGASRewards StateMigrationParametersP6ToP7 gr = gr
+migrateGASRewards StateMigrationParametersP6ToP7{} gr = gr
 
 -- | Apply a state migration to a 'ChainParameters' structure.
 --
@@ -151,7 +151,7 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
   where
     RewardParameters{..} = _cpRewardParameters
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
-migrateChainParameters StateMigrationParametersP6ToP7 cps = cps
+migrateChainParameters StateMigrationParametersP6ToP7{} cps = cps
 
 -- | Apply a state migration to an 'AccountStake' structure.
 --
@@ -193,7 +193,7 @@ migrateAccountStake StateMigrationParametersP4ToP5 =
                       ..
                     }
 migrateAccountStake StateMigrationParametersP5ToP6{} = id
-migrateAccountStake StateMigrationParametersP6ToP7 = id
+migrateAccountStake StateMigrationParametersP6ToP7{} = id
 
 -- | Migrate time of the effective change from V0 to V1 accounts. Currently this
 --  translates times relative to genesis to times relative to the unix epoch.
@@ -221,4 +221,4 @@ migrateStakePendingChange (StateMigrationParametersP3ToP4 migration) = \case
     RemoveStake eff -> RemoveStake (migratePendingChangeEffective migration eff)
 migrateStakePendingChange StateMigrationParametersP4ToP5 = fmap coercePendingChangeEffectiveV1
 migrateStakePendingChange StateMigrationParametersP5ToP6{} = id
-migrateStakePendingChange StateMigrationParametersP6ToP7 = id
+migrateStakePendingChange StateMigrationParametersP6ToP7{} = id

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -2092,6 +2092,7 @@ delegationChainParameters = case protocolVersion @pv of
     SP4 -> DelegationChainParameters
     SP5 -> DelegationChainParameters
     SP6 -> DelegationChainParameters
+    SP7 -> DelegationChainParameters
 
 -- * Consensus versions
 
@@ -2125,3 +2126,4 @@ consensusVersionFor SP3 = ConsensusV0
 consensusVersionFor SP4 = ConsensusV0
 consensusVersionFor SP5 = ConsensusV0
 consensusVersionFor SP6 = ConsensusV1
+consensusVersionFor SP7 = ConsensusV1

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -464,14 +464,23 @@ protocolSupportsDelegation spv = case sSupportsDelegation (sAccountVersionFor sp
 --  (Memos are supported in 'P2' onwards.)
 supportsMemo :: SProtocolVersion pv -> Bool
 supportsMemo SP1 = False
-supportsMemo _ = True
+supportsMemo SP2 = True
+supportsMemo SP3 = True
+supportsMemo SP4 = True
+supportsMemo SP5 = True
+supportsMemo SP6 = True
+supportsMemo SP7 = True
 
 -- | Whether the protocol version supports account aliases.
 --  (Account aliases are supported in 'P3' onwards.)
 supportsAccountAliases :: SProtocolVersion pv -> Bool
 supportsAccountAliases SP1 = False
 supportsAccountAliases SP2 = False
-supportsAccountAliases _ = True
+supportsAccountAliases SP3 = True
+supportsAccountAliases SP4 = True
+supportsAccountAliases SP5 = True
+supportsAccountAliases SP6 = True
+supportsAccountAliases SP7 = True
 
 -- | Whether the protocol version supports V1 smart contracts.
 --  (V1 contracts are supported in 'P4' onwards.)
@@ -479,7 +488,10 @@ supportsV1Contracts :: SProtocolVersion pv -> Bool
 supportsV1Contracts SP1 = False
 supportsV1Contracts SP2 = False
 supportsV1Contracts SP3 = False
-supportsV1Contracts _ = True
+supportsV1Contracts SP4 = True
+supportsV1Contracts SP5 = True
+supportsV1Contracts SP6 = True
+supportsV1Contracts SP7 = True
 
 -- | Whether the protocol version supports delegation.
 --  (Delegation is supported in 'P4' onwards.)
@@ -497,7 +509,9 @@ supportsUpgradableContracts spv = case spv of
     SP2 -> False
     SP3 -> False
     SP4 -> False
-    _ -> True
+    SP5 -> True
+    SP6 -> True
+    SP7 -> True
 
 -- | Whether the protocol version supports chain queries in smart contracts.
 --  (Supported in 'P5' and onwards)
@@ -507,7 +521,9 @@ supportsChainQueryContracts spv = case spv of
     SP2 -> False
     SP3 -> False
     SP4 -> False
-    _ -> True
+    SP5 -> True
+    SP6 -> True
+    SP7 -> True
 
 -- | Whether the protocol version supports sign extension instructions for V1
 --  contracts. (Supported in 'P6' and onwards)
@@ -518,7 +534,8 @@ supportsSignExtensionInstructions spv = case spv of
     SP3 -> False
     SP4 -> False
     SP5 -> False
-    _ -> True
+    SP6 -> True
+    SP7 -> True
 
 -- | Whether the protocol version allows globals in data and element sections of
 --  Wasm modules for V1 contracts. (Supported before 'P6')
@@ -529,7 +546,8 @@ supportsGlobalsInInitSections spv = case spv of
     SP3 -> True
     SP4 -> True
     SP5 -> True
-    _ -> False
+    SP6 -> False
+    SP7 -> False
 
 -- | Whether the protocol version specifies that custom section should not be
 --  counted towards module size when executing V1 contracts.
@@ -546,4 +564,5 @@ supportsAccountSignatureChecks spv = case spv of
     SP3 -> False
     SP4 -> False
     SP5 -> False
-    _ -> True
+    SP6 -> True
+    SP7 -> True

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -178,6 +178,7 @@ module Concordium.Types.ProtocolVersion (
     P4Sym0,
     P5Sym0,
     P6Sym0,
+    P7Sym0,
 ) where
 
 import Control.Monad.Except (ExceptT)
@@ -204,6 +205,7 @@ $( singletons
             | P4
             | P5
             | P6
+            | P7
             deriving (Eq, Ord)
 
         data ChainParametersVersion
@@ -219,6 +221,7 @@ $( singletons
         chainParametersVersionFor P4 = ChainParametersV1
         chainParametersVersionFor P5 = ChainParametersV1
         chainParametersVersionFor P6 = ChainParametersV2
+        chainParametersVersionFor P7 = ChainParametersV2
 
         -- \* Account versions
 
@@ -241,6 +244,7 @@ $( singletons
         accountVersionFor P4 = AccountV1
         accountVersionFor P5 = AccountV2
         accountVersionFor P6 = AccountV2
+        accountVersionFor P7 = AccountV2
 
         -- \|Transaction outcomes versions.
         -- The difference between the two versions are only related
@@ -261,6 +265,7 @@ $( singletons
         transactionOutcomesVersionFor P4 = TOV0
         transactionOutcomesVersionFor P5 = TOV1
         transactionOutcomesVersionFor P6 = TOV1
+        transactionOutcomesVersionFor P7 = TOV1
 
         -- \|A type used at the kind level to denote that delegation is or is not expected to be supported
         -- at an account version. This is intended to give more descriptive type errors in cases where the
@@ -302,6 +307,7 @@ protocolVersionToWord64 P3 = 3
 protocolVersionToWord64 P4 = 4
 protocolVersionToWord64 P5 = 5
 protocolVersionToWord64 P6 = 6
+protocolVersionToWord64 P7 = 7
 
 -- | Parse a 'Word64' as a 'ProtocolVersion'.
 protocolVersionFromWord64 :: (MonadFail m) => Word64 -> m ProtocolVersion
@@ -311,6 +317,7 @@ protocolVersionFromWord64 3 = return P3
 protocolVersionFromWord64 4 = return P4
 protocolVersionFromWord64 5 = return P5
 protocolVersionFromWord64 6 = return P6
+protocolVersionFromWord64 7 = return P7
 protocolVersionFromWord64 v = fail $ "Unknown protocol version: " ++ show v
 
 -- | Convert a @ChainParametersVersion@ to the corresponding 'Word64'.
@@ -344,6 +351,7 @@ promoteProtocolVersion P3 = SomeProtocolVersion SP3
 promoteProtocolVersion P4 = SomeProtocolVersion SP4
 promoteProtocolVersion P5 = SomeProtocolVersion SP5
 promoteProtocolVersion P6 = SomeProtocolVersion SP6
+promoteProtocolVersion P7 = SomeProtocolVersion SP7
 
 -- | Demote an 'SProtocolVersion' to a 'ProtocolVersion'.
 demoteProtocolVersion :: SProtocolVersion pv -> ProtocolVersion
@@ -471,9 +479,7 @@ supportsV1Contracts :: SProtocolVersion pv -> Bool
 supportsV1Contracts SP1 = False
 supportsV1Contracts SP2 = False
 supportsV1Contracts SP3 = False
-supportsV1Contracts SP4 = True
-supportsV1Contracts SP5 = True
-supportsV1Contracts SP6 = True
+supportsV1Contracts _ = True
 
 -- | Whether the protocol version supports delegation.
 --  (Delegation is supported in 'P4' onwards.)
@@ -491,8 +497,7 @@ supportsUpgradableContracts spv = case spv of
     SP2 -> False
     SP3 -> False
     SP4 -> False
-    SP5 -> True
-    SP6 -> True
+    _ -> True
 
 -- | Whether the protocol version supports chain queries in smart contracts.
 --  (Supported in 'P5' and onwards)
@@ -502,8 +507,7 @@ supportsChainQueryContracts spv = case spv of
     SP2 -> False
     SP3 -> False
     SP4 -> False
-    SP5 -> True
-    SP6 -> True
+    _ -> True
 
 -- | Whether the protocol version supports sign extension instructions for V1
 --  contracts. (Supported in 'P6' and onwards)
@@ -514,7 +518,7 @@ supportsSignExtensionInstructions spv = case spv of
     SP3 -> False
     SP4 -> False
     SP5 -> False
-    SP6 -> True
+    _ -> True
 
 -- | Whether the protocol version allows globals in data and element sections of
 --  Wasm modules for V1 contracts. (Supported before 'P6')
@@ -525,7 +529,7 @@ supportsGlobalsInInitSections spv = case spv of
     SP3 -> True
     SP4 -> True
     SP5 -> True
-    SP6 -> False
+    _ -> False
 
 -- | Whether the protocol version specifies that custom section should not be
 --  counted towards module size when executing V1 contracts.
@@ -542,4 +546,4 @@ supportsAccountSignatureChecks spv = case spv of
     SP3 -> False
     SP4 -> False
     SP5 -> False
-    SP6 -> True
+    _ -> True

--- a/haskell-src/Concordium/Types/SeedState.hs
+++ b/haskell-src/Concordium/Types/SeedState.hs
@@ -37,6 +37,7 @@ $( singletons
         seedStateVersionFor P4 = SeedStateVersion0
         seedStateVersionFor P5 = SeedStateVersion0
         seedStateVersionFor P6 = SeedStateVersion1
+        seedStateVersionFor P7 = SeedStateVersion1
 
         supportsEpochLength :: SeedStateVersion -> Bool
         supportsEpochLength SeedStateVersion0 = True

--- a/haskell-tests/Types/UpdatesSpec.hs
+++ b/haskell-tests/Types/UpdatesSpec.hs
@@ -144,6 +144,7 @@ tests = parallel $ do
     versionedTests SP4
     versionedTests SP5
     versionedTests SP6
+    versionedTests SP7
   where
     versionedTests spv = describe (show $ demoteProtocolVersion spv) $ do
         specify "UpdatePayload serialization" $ withMaxSuccess 1000 $ testSerializeUpdatePayload spv


### PR DESCRIPTION
## Purpose

Add protocol version 7 boilerplate, at this point it should behave the same as P6.

Part of https://github.com/Concordium/concordium-node/issues/1066.
Should be merged after https://github.com/Concordium/concordium-grpc-api/pull/49.
See also https://github.com/Concordium/concordium-node/pull/1075.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

