### PR TITLE
Support validatorId in Rust credentials.

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased changes
 
 - Add `sign_message` function to sign a message with all `AccountKeys`. The return type is `AccountSignatures`.
+- Support using `validatorId` instead of `bakerId` when parsing
+  `BakerCredentials` from JSON.
 
 ## 3.1.1 (2023-10-27)
 

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -707,6 +707,7 @@ impl BakerKeyPairs {
 #[derive(SerdeSerialize, SerdeDeserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BakerCredentials {
+    #[serde(alias = "validatorId")]
     pub baker_id: BakerId,
     #[serde(flatten)]
     pub keys:     BakerKeyPairs,


### PR DESCRIPTION
## Purpose

Support validatorId in Rust baker credentials.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

