### PR TITLE
Improve the multiscalar multiplication precomputation step.

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+- Improve performance of `multiexp*` family of functions.
+
 ## 3.2.0 (2023-11-22)
 
 - Add `From` trait to convert `AccountKeys` into `AccountPublicKeys`.

--- a/rust-src/concordium_base/benches/encrypted_transfers_benchmarks.rs
+++ b/rust-src/concordium_base/benches/encrypted_transfers_benchmarks.rs
@@ -53,23 +53,26 @@ pub fn enc_trans_bench(c: &mut Criterion) {
 
     let context_clone = context.clone();
     let sk_clone = sk_sender.clone();
-    c.bench_function("Create transaction with proofs", move |b| {
-        b.iter(|| {
-            gen_enc_trans(
-                &context_clone,
-                &mut ro.split(),
-                &pk_sender,
-                &sk_clone,
-                &pk_receiver,
-                index,
-                &S,
-                Amount::from_micro_ccd(s),
-                Amount::from_micro_ccd(a),
-                &mut csprng,
-            )
-            .expect("Could not produce proof.");
-        })
-    });
+    c.bench_function(
+        &format!("{}: Create transaction with proofs", module_path!()),
+        move |b| {
+            b.iter(|| {
+                gen_enc_trans(
+                    &context_clone,
+                    &mut ro.split(),
+                    &pk_sender,
+                    &sk_clone,
+                    &pk_receiver,
+                    index,
+                    &S,
+                    Amount::from_micro_ccd(s),
+                    Amount::from_micro_ccd(a),
+                    &mut csprng,
+                )
+                .expect("Could not produce proof.");
+            })
+        },
+    );
 
     let challenge_prefix = generate_challenge_prefix(&mut csprng);
     let ro = RandomOracle::domain(&challenge_prefix);
@@ -89,22 +92,25 @@ pub fn enc_trans_bench(c: &mut Criterion) {
         &mut csprng,
     )
     .expect("Could not produce proof.");
-    c.bench_function("Verify transaction and proofs", move |b| {
-        b.iter(|| {
-            let mut ro = RandomOracle::domain(&challenge_prefix);
-            assert_eq!(
-                verify_enc_trans(
-                    &context,
-                    &mut ro,
-                    &transaction,
-                    &pk_sender,
-                    &pk_receiver,
-                    &S,
-                ),
-                Ok(())
-            )
-        })
-    });
+    c.bench_function(
+        &format!("{}: Verify transaction and proofs", module_path!()),
+        move |b| {
+            b.iter(|| {
+                let mut ro = RandomOracle::domain(&challenge_prefix);
+                assert_eq!(
+                    verify_enc_trans(
+                        &context,
+                        &mut ro,
+                        &transaction,
+                        &pk_sender,
+                        &pk_receiver,
+                        &S,
+                    ),
+                    Ok(())
+                )
+            })
+        },
+    );
 }
 
 #[allow(non_snake_case)]
@@ -133,22 +139,28 @@ pub fn sec_to_pub_bench(c: &mut Criterion) {
 
     let context_clone = context.clone();
     let sk_clone = sk.clone();
-    c.bench_function("Create sec to pub transaction with proofs", move |b| {
-        b.iter(|| {
-            gen_sec_to_pub_trans(
-                &context_clone,
-                &mut ro.split(),
-                &pk,
-                &sk_clone,
-                index,
-                &S,
-                Amount::from_micro_ccd(s),
-                Amount::from_micro_ccd(a),
-                &mut csprng,
-            )
-            .expect("Could not produce proof.");
-        })
-    });
+    c.bench_function(
+        &format!(
+            "{}: Create sec to pub transaction with proofs",
+            module_path!()
+        ),
+        move |b| {
+            b.iter(|| {
+                gen_sec_to_pub_trans(
+                    &context_clone,
+                    &mut ro.split(),
+                    &pk,
+                    &sk_clone,
+                    index,
+                    &S,
+                    Amount::from_micro_ccd(s),
+                    Amount::from_micro_ccd(a),
+                    &mut csprng,
+                )
+                .expect("Could not produce proof.");
+            })
+        },
+    );
 
     let challenge_prefix = generate_challenge_prefix(&mut csprng);
     let ro = RandomOracle::domain(&challenge_prefix);
@@ -167,22 +179,28 @@ pub fn sec_to_pub_bench(c: &mut Criterion) {
         &mut csprng,
     )
     .expect("Could not produce proof.");
-    c.bench_function("Verify sec to pub transaction and proofs", move |b| {
-        b.iter(|| {
-            let mut ro = RandomOracle::domain(&challenge_prefix);
-            assert_eq!(
-                verify_sec_to_pub_trans(&context, &mut ro, &transaction, &pk, &S,),
-                Ok(())
-            )
-        })
-    });
+    c.bench_function(
+        &format!(
+            "{}: Verify sec to pub transaction and proofs",
+            module_path!()
+        ),
+        move |b| {
+            b.iter(|| {
+                let mut ro = RandomOracle::domain(&challenge_prefix);
+                assert_eq!(
+                    verify_sec_to_pub_trans(&context, &mut ro, &transaction, &pk, &S,),
+                    Ok(())
+                )
+            })
+        },
+    );
 }
 
 criterion_group! {
-    name = elgamal_benches;
+    name = encrypted_transfer_benches;
     config = Criterion::default().measurement_time(Duration::from_millis(100000)).sample_size(20);
     targets =
         enc_trans_bench
 }
 
-criterion_main!(elgamal_benches);
+criterion_main!(encrypted_transfer_benches);

--- a/rust-src/concordium_base/benches/multiexp_bench.rs
+++ b/rust-src/concordium_base/benches/multiexp_bench.rs
@@ -8,7 +8,7 @@ use rand::*;
 
 pub fn bench_multiexp(c: &mut Criterion) {
     let mut csprng = thread_rng();
-    let m = 10;
+    let m = 3;
     let ns = (1..=m).map(|x| x * x);
     let mut gs = Vec::with_capacity(m * m);
     let mut es = Vec::with_capacity(m * m);
@@ -21,7 +21,7 @@ pub fn bench_multiexp(c: &mut Criterion) {
         let gsc = gs[..i].to_vec();
         let esc = es[..i].to_vec();
         let mut group = c.benchmark_group(format!("Group({})", i));
-        group.bench_function("Baseline", move |b| {
+        group.bench_function(format!("{}: Baseline", module_path!()), move |b| {
             b.iter(|| {
                 let mut a = G1::zero_point();
                 for (g, e) in gsc.iter().zip(esc.iter()) {
@@ -32,9 +32,10 @@ pub fn bench_multiexp(c: &mut Criterion) {
         for w in 2..=8 {
             let gsc = gs[..i].to_vec();
             let esc = es[..i].to_vec();
-            group.bench_function(&format!("multiexp({})", w), move |b| {
-                b.iter(|| multiexp_worker(&gsc, &esc, w))
-            });
+            group.bench_function(
+                &format!("{}: Multiexp (window = {w})", module_path!()),
+                move |b| b.iter(|| multiexp_worker(&gsc, &esc, w)),
+            );
         }
         group.finish();
     }

--- a/rust-src/concordium_base/src/curve_arithmetic/mod.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/mod.rs
@@ -215,10 +215,10 @@ pub fn multiexp_worker_given_table<C: Curve>(
     window: usize,
 ) -> C {
     // Compute the wnaf
-    let window_size = window + 1;
+    let window_plus1 = window + 1;
     let k = exps.len();
-    // assert_eq!(gs.len(), k);
-    assert!(window_size < 62);
+    assert!(window_plus1 >= 2);
+    assert!(window_plus1 < 63);
 
     let mut wnaf = Vec::with_capacity(k);
 
@@ -228,7 +228,7 @@ pub fn multiexp_worker_given_table<C: Curve>(
     // this avoids any field arithmetic and operates directly on the bit
     // representation of the scalars, leading to a substantial performance
     // improvement.
-    let width = 1u64 << window_size;
+    let width = 1u64 << window_plus1;
     let window_mask = width - 1;
 
     for c in exps.iter() {
@@ -243,7 +243,7 @@ pub fn multiexp_worker_given_table<C: Curve>(
             let u64_idx = pos / 64;
             let bit_idx = pos % 64;
             let cur_u64 = repr_limbs[u64_idx];
-            let bit_buf = if bit_idx + window_size < 64 {
+            let bit_buf = if bit_idx + window_plus1 < 64 {
                 // This window's bits are contained in a single u64
                 cur_u64 >> bit_idx
             } else {
@@ -273,8 +273,8 @@ pub fn multiexp_worker_given_table<C: Curve>(
                         (window_val as i64).wrapping_sub(width as i64)
                     },
                 );
-                v.extend(std::iter::repeat(0).take(window_size - 1));
-                pos += window_size;
+                v.extend(std::iter::repeat(0).take(window_plus1 - 1));
+                pos += window_plus1;
             }
         }
         wnaf.push(v);

--- a/rust-src/concordium_base/src/curve_arithmetic/mod.rs
+++ b/rust-src/concordium_base/src/curve_arithmetic/mod.rs
@@ -212,46 +212,70 @@ pub fn multiexp_worker<C: Curve, X: Borrow<C>>(
 pub fn multiexp_worker_given_table<C: Curve>(
     exps: &[C::Scalar],
     table: &[Vec<C>],
-    window_size: usize,
+    window: usize,
 ) -> C {
     // Compute the wnaf
-
+    let window_size = window + 1;
     let k = exps.len();
     // assert_eq!(gs.len(), k);
-    assert!(window_size >= 1);
     assert!(window_size < 62);
 
-    // 2^{window_size + 1}
-    let two_to_wp1: u64 = 2 << window_size;
-    let two_to_wp1_scalar = C::scalar_from_u64(two_to_wp1);
-    // a mask to extract the lowest window_size + 1 bits from a scalar.
-    let mask: u64 = two_to_wp1 - 1;
     let mut wnaf = Vec::with_capacity(k);
-    // 1 / 2 scalar
-    let half = C::scalar_from_u64(2)
-        .inverse()
-        .expect("Field size must be at least 3.");
+
+    // The computation of the wnaf table here is a modification of the
+    // implementation in <https://github.com/zkcrypto/group>
+    // Compared to the high-level algorithm described in https://link.springer.com/content/pdf/10.1007%2F3-540-45537-X_13.pdf
+    // this avoids any field arithmetic and operates directly on the bit
+    // representation of the scalars, leading to a substantial performance
+    // improvement.
+    let width = 1u64 << window_size;
+    let window_mask = width - 1;
 
     for c in exps.iter() {
+        let mut pos = 0;
+        let mut carry = 0;
+        let repr = c.into_repr();
+        let repr_limbs = repr.as_ref();
         let mut v = Vec::new();
-        let mut c = *c;
-        while !c.is_zero() {
-            let limb = c.into_repr().as_ref()[0];
-            // if the first bit is set
-            if limb & 1 == 1 {
-                let u = limb & mask;
-                // check if window_size'th bit is set.
-                c.sub_assign(&C::scalar_from_u64(u));
-                if u & (1 << window_size) != 0 {
-                    c.add_assign(&two_to_wp1_scalar);
-                    v.push((u as i64) - (two_to_wp1 as i64));
-                } else {
-                    v.push(u as i64);
-                }
+        let num_bits = repr_limbs.len() * 64;
+        while pos < num_bits {
+            // Construct a buffer of bits of the scalar, starting at bit `pos`
+            let u64_idx = pos / 64;
+            let bit_idx = pos % 64;
+            let cur_u64 = repr_limbs[u64_idx];
+            let bit_buf = if bit_idx + window_size < 64 {
+                // This window's bits are contained in a single u64
+                cur_u64 >> bit_idx
             } else {
+                let next_u64 = repr_limbs.get(u64_idx + 1).copied().unwrap_or(0);
+                // Combine the current u64's bits with the bits from the next u64
+                (cur_u64 >> bit_idx) | (next_u64 << (64 - bit_idx))
+            };
+
+            // Add the carry into the current window
+            let window_val = carry + (bit_buf & window_mask);
+
+            if window_val & 1 == 0 {
+                // If the window value is even, preserve the carry and emit 0.
+                // Why is the carry preserved?
+                // If carry == 0 and window_val & 1 == 0, then the next carry should be 0
+                // If carry == 1 and window_val & 1 == 0, then bit_buf & 1 == 1 so the next
+                // carry should be 1
                 v.push(0);
+                pos += 1;
+            } else {
+                v.push(
+                    if window_val < width / 2 {
+                        carry = 0;
+                        window_val as i64
+                    } else {
+                        carry = 1;
+                        (window_val as i64).wrapping_sub(width as i64)
+                    },
+                );
+                v.extend(std::iter::repeat(0).take(window_size - 1));
+                pos += window_size;
             }
-            c.mul_assign(&half);
         }
         wnaf.push(v);
     }


### PR DESCRIPTION
## Purpose

Avoid field operations since they can be slow.

While it does not appear to have a significant effect for the BLS curve, but still has non-trivial effect, it might matter more with other curves.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
