### PR TITLE
Re-export ed25519_dalek crate

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Export `PublicKey`, `SecretKey`, and `Signature` type from `ed25519_dalek` crate.
 - Add `sign_message` function to sign a message with all `AccountKeys`. The return type is `AccountSignatures`.
 
 ## 3.1.1 (2023-10-27)

--- a/rust-src/concordium_base/src/lib.rs
+++ b/rust-src/concordium_base/src/lib.rs
@@ -32,6 +32,8 @@ pub mod ps_sig;
 
 pub mod dodis_yampolskiy_prf;
 
+pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
+
 #[cfg(feature = "ffi")]
 mod ffi_helpers;
 


### PR DESCRIPTION
## Purpose

It would be nice to re-export the type `ed25519_dalek::PublicKey` in the smart contract integration testing library so that the `ed25519_dalek` crate does not have to be added as a dev-dependency in smart contract projects.

## Changes

Re-export `ed25519_dalek` crate.
