### PR TITLE
Add singleton account access structure

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased changes
 
+- Add `singleton` and `generate` function to `AccountAccessStructure`.
 - Export `PublicKey`, `SecretKey`, and `Signature` type from `ed25519_dalek` crate.
 - Add `sign_message` function to sign a message with all `AccountKeys`. The return type is `AccountSignatures`.
 

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased changes
 
-- Add `singleton` and `generate` function to `AccountAccessStructure`.
+- Add `singleton` and `new` function to `AccountAccessStructure`.
 - Export `PublicKey`, `SecretKey`, and `Signature` type from `ed25519_dalek` crate.
 - Add `sign_message` function to sign a message with all `AccountKeys`. The return type is `AccountSignatures`.
 

--- a/rust-src/concordium_base/src/lib.rs
+++ b/rust-src/concordium_base/src/lib.rs
@@ -32,7 +32,11 @@ pub mod ps_sig;
 
 pub mod dodis_yampolskiy_prf;
 
-pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
+/// We expose the `PublicKey`, `SecretKey`, and `Signature` from the third-party
+/// `ed25519_dalek` crate here because these types appear in Concordium's API.
+pub mod ed25519 {
+    pub use ed25519_dalek::{PublicKey, SecretKey, Signature};
+}
 
 #[cfg(feature = "ffi")]
 mod ffi_helpers;

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -1465,7 +1465,9 @@ pub struct AccountAccessStructure {
     pub threshold: AccountThreshold,
 }
 
-type AccountStructure<'a> = &'a [(
+/// Input parameter containing indices, signature thresholds,
+/// and public keys for creating a new `AccountAccessStructure`.
+pub type AccountStructure<'a> = &'a [(
     CredentialIndex,
     SignatureThreshold,
     &'a [(KeyIndex, ed25519_dalek::PublicKey)],
@@ -1475,7 +1477,7 @@ impl AccountAccessStructure {
     /// Generate a new [`AccountAccessStructure`] for the thresholds, public
     /// keys, and key indices specified in the input. If there are duplicate
     /// indices then later ones override the previous ones.
-    pub fn generate(account_threshold: AccountThreshold, structure: AccountStructure) -> Self {
+    pub fn new(account_threshold: AccountThreshold, structure: AccountStructure) -> Self {
         let mut map: BTreeMap<CredentialIndex, CredentialPublicKeys> = BTreeMap::new();
 
         for credential_structure in structure {
@@ -1503,7 +1505,7 @@ impl AccountAccessStructure {
     /// Generate a new [`AccountAccessStructure`] with a single credential and
     /// public key, at credential and key indices 0.
     pub fn singleton(public_key: ed25519_dalek::PublicKey) -> Self {
-        Self::generate(AccountThreshold::ONE, &[(
+        Self::new(AccountThreshold::ONE, &[(
             0.into(),
             SignatureThreshold::ONE,
             &[(0.into(), public_key)],


### PR DESCRIPTION
## Purpose

- Add `singleton` function to `accountAccessSructure` that generates the most basic `account access structure` with one public key at index 0 in both maps.
- Add `new` function to `accountAccessStructure` that given the indices, public_keys, and thresholds generates corresponding  `account access structure`.  

## Changes
-  Add `singleton` function
- Add `new` function

Note: The PR contains the two line changes from https://github.com/Concordium/concordium-base/pull/477.
