### PR TITLE
Avoid Rust warnings

### DIFF
--- a/rust-src/Cargo.toml
+++ b/rust-src/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 
 members=[
    "sha_2",

--- a/rust-src/concordium_base/src/common/mod.rs
+++ b/rust-src/concordium_base/src/common/mod.rs
@@ -1,5 +1,6 @@
 //! Common types and operations used throughout the Concordium chain
 //! development.
+#[cfg(test)]
 mod helpers;
 mod impls;
 mod serde_impls;
@@ -7,7 +8,9 @@ mod serialize;
 pub mod types;
 mod version;
 
-pub use self::{helpers::*, impls::*, serialize::*, version::*};
+#[cfg(test)]
+pub use self::helpers::serialize_deserialize;
+pub use self::{serialize::*, version::*};
 
 // Reexport for ease of use.
 pub use byteorder::{ReadBytesExt, WriteBytesExt};

--- a/rust-src/concordium_base/src/common/serialize.rs
+++ b/rust-src/concordium_base/src/common/serialize.rs
@@ -1,4 +1,3 @@
-pub use super::impls::*;
 use anyhow::{bail, ensure, Context};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use concordium_contracts_common::{Duration, ExchangeRate};

--- a/smart-contracts/contracts-common/Cargo.toml
+++ b/smart-contracts/contracts-common/Cargo.toml
@@ -1,4 +1,6 @@
 [workspace]
+resolver = "2"
+
 members = [
     "concordium-contracts-common",
     "concordium-contracts-common-derive",


### PR DESCRIPTION
```
warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions
```

## Purpose

Avoid some warnings with newer rust versions.

## Changes

- Set explicit resolver
- Don't re-export modules which have no public definitions.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.