### PR TITLE
Validate mnemonic word length

### DIFF
--- a/mobile_wallet/CHANGELOG.md
+++ b/mobile_wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.1
+
+- Updated the internal library key_derivation to 2.0.0. This enforces that the seed phrase input must be 12, 15, 18, 21 or 24 words.
+
 ## 0.25.0
 - Added a function `get_verifiable_credential_keys` for deriving the keys for a verifiable credential.
 

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -800,7 +800,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",
@@ -810,6 +810,7 @@ dependencies = [
  "pbkdf2",
  "serde",
  "sha2 0.10.6",
+ "thiserror",
 ]
 
 [[package]]
@@ -877,7 +878,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mobile_wallet"
-version = "0.25.0"
+version = "0.25.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.25.0"
+version = "0.25.1"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"
@@ -26,7 +26,7 @@ base64 = "0.21"
 
 [dependencies.key_derivation]
 path = "../rust-src/key_derivation"
-version = "1.2.0"
+version = "2.0.0"
 
 [dependencies.ed25519_hd_key_derivation]
 path = "../rust-src/ed25519_hd_key_derivation"

--- a/rust-bins/CHANGELOG.md
+++ b/rust-bins/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
 
+## 2.0.2
+
+- Updated the internal library key_derivation to 2.0.0. This enforces that the seed phrase input must be 12, 15, 18, 21 or 24 words.
+
 ## 2.0.1
 - Fixed bug where the user_cli tool was unable to accept the `account` flag as it conflicted with the `expiry` flag that was always set due to a default value being provided.

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -1180,7 +1180,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",
@@ -1190,6 +1190,7 @@ dependencies = [
  "pbkdf2 0.10.1",
  "serde",
  "sha2 0.10.8",
+ "thiserror",
 ]
 
 [[package]]
@@ -1315,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "misc_tools"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "aes",
  "anyhow",

--- a/rust-bins/Cargo.toml
+++ b/rust-bins/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "misc_tools"
-version = "2.0.1"
+version = "2.0.2"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"
@@ -44,7 +44,7 @@ version = "1.0.0"
 
 [dependencies.key_derivation]
 path = "../rust-src/key_derivation"
-version = "1.1.0"
+version = "2.0.0"
 
 [dependencies.keygen_bls]
 path = "../rust-src/keygen_bls"

--- a/rust-bins/src/bin/client.rs
+++ b/rust-bins/src/bin/client.rs
@@ -22,7 +22,7 @@ use concordium_base::{
 use dialoguer::{Input, MultiSelect, Select};
 use ed25519_dalek as ed25519;
 use either::Either::{Left, Right};
-use key_derivation::{words_to_seed, ConcordiumHdWallet, CredentialContext, Net};
+use key_derivation::{ConcordiumHdWallet, CredentialContext, Net};
 use pairing::bls12_381::{Bls12, G1};
 use rand::*;
 use serde_json::{json, to_value};
@@ -1335,9 +1335,13 @@ fn handle_create_hd_wallet(chw: CreateHdWallet) {
     } else {
         Net::Mainnet
     };
-    let wallet = ConcordiumHdWallet {
-        seed: words_to_seed(&words_str),
-        net,
+
+    let wallet = match ConcordiumHdWallet::from_seed_phrase(&words_str, net) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("An invalid seed phrase was provided. Error: {}", e);
+            return;
+        }
     };
 
     if let Some(filepath) = chw.out {

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -929,7 +929,7 @@ dependencies = [
 
 [[package]]
 name = "key_derivation"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "concordium_base",
  "ed25519-dalek",
@@ -940,6 +940,7 @@ dependencies = [
  "pbkdf2 0.10.1",
  "serde",
  "sha2 0.10.7",
+ "thiserror",
 ]
 
 [[package]]

--- a/rust-src/key_derivation/CHANGELOG.md
+++ b/rust-src/key_derivation/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog 
+
+## [2.0.0]
+
+### Changed
+
+- Words input to HD wallet is validated to consist of 12, 15, 18, 21 or 24 words.

--- a/rust-src/key_derivation/Cargo.toml
+++ b/rust-src/key_derivation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "key_derivation"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE"
@@ -11,6 +11,7 @@ sha2 = "0.10.2"
 ed25519-dalek = "1.0.0"
 serde = "1"
 pbkdf2 = "0.10"
+thiserror = "1.0"
 
 [dependencies.ed25519_hd_key_derivation]
 path = "../ed25519_hd_key_derivation"

--- a/rust-src/key_derivation/src/lib.rs
+++ b/rust-src/key_derivation/src/lib.rs
@@ -39,10 +39,8 @@ impl fmt::Display for Net {
 }
 
 #[derive(Debug, Error)]
-pub enum MnemonicLengthError {
-    #[error("Invalid mnemonic length. The length must be 12, 15, 18, 21 or 24.")]
-    InvalidLength,
-}
+#[error("Invalid mnemonic length. The length must be 12, 15, 18, 21 or 24.")]
+pub struct MnemonicLengthError;
 
 fn bls_key_bytes_from_seed(key_seed: [u8; 32]) -> <ArCurve as Curve>::Scalar {
     keygen_bls(&key_seed, b"").expect("All the inputs are of the correct length, this cannot fail.")
@@ -64,7 +62,7 @@ pub fn words_to_seed_with_passphrase(
     let words_count = words.split(' ').collect::<Vec<&str>>().len();
     let allowed_word_counts: [usize; 5] = [12, 15, 18, 21, 24];
     if !allowed_word_counts.contains(&words_count) {
-        return Err(MnemonicLengthError::InvalidLength);
+        return Err(MnemonicLengthError);
     }
 
     let mut salt_string: String = "mnemonic".to_owned();


### PR DESCRIPTION
## Purpose
According to the documentation for BIP39 (https://github.com/bitcoin/bips/blob/master/bip-0039.mediawiki#generating-the-mnemonic) the mnemonic must encode entropy in multiples of 32 bits, and the allowed size is 128-256 bits. This corresponds to allowing for 12, 15, 18, 21 and 24 word mnemonics. The current implementation allowed for any type of input, but assumed it was always 24 words. This change updates it so that it restricts the input as described by the standard, and also adds the missing tests to cover the test vectors for 12 and 18 words. There are no "official" test vectors for 15 and 21, and therefore a single test has been added to ensure that those work.

Note that this is a breaking change to the interface, hence the major bump.

## Changes
- Restrict number of words to be in `[12, 15, 18, 21, 24]`.
- Added unit tests to cover test vectors for 12 and 18 words input.
- Added single unit tests for 15 and 21 words (no "official" test vectors available for these).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.