### PR TITLE
Unify Timestamp in base and contracts_common

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -9,9 +9,6 @@
   The alternate formatter (using `#`) displays it as a list of bytes.
 - Add `FromStr` and `Display` instances to `dodis_yampolskiy_prf::SecretKey`.
 - Change `Debug` instance of `dodis_yampolskiy_prf::SecretKey` to hide the value.
-
-### Breaking changes
-
 - Remove `Timestamp` to instead reexport the similar type from `concordium_contracts_common`.
   This adds several new methods, but results in a breaking change in the `serde::Serialize` implementation, which is now using string containing RFC3393 representation instead the underlying milliseconds.
 

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased changes
 
 - Improve performance of `multiexp*` family of functions.
-- Add traits `Field` and `PrimeField` with implementations for the underlying field of the `BLS12-381`` curve.
+- Add traits `Field` and `PrimeField` with implementations for the underlying field of the `BLS12-381` curve.
 - Add `MultiExp` trait that allows to have different `multiexp` algorithm implementations for different curves.
 - Add implementations of `Field`, `PrimeField` and `Curve` for the Ristretto representation of `curve25519`.
 - Support `P7` protocol version.
@@ -9,6 +9,11 @@
   The alternate formatter (using `#`) displays it as a list of bytes.
 - Add `FromStr` and `Display` instances to `dodis_yampolskiy_prf::SecretKey`.
 - Change `Debug` instance of `dodis_yampolskiy_prf::SecretKey` to hide the value.
+
+### Breaking changes
+
+- Remove `Timestamp` to instead reexport the similar type from `concordium_contracts_common`.
+  This adds several new methods, but results in a breaking change in the `serde::Serialize` implementation, which is now using string containing RFC3393 representation instead the underlying milliseconds.
 
 ## 3.2.0 (2023-11-22)
 

--- a/rust-src/concordium_base/src/common/types.rs
+++ b/rust-src/concordium_base/src/common/types.rs
@@ -10,7 +10,9 @@ use concordium_contracts_common::{
     self as concordium_std, ContractAddress, ContractName, OwnedContractName, OwnedParameter,
     OwnedReceiveName, Parameter, ReceiveName,
 };
-pub use concordium_contracts_common::{AccountAddress, Address, Amount, ACCOUNT_ADDRESS_SIZE};
+pub use concordium_contracts_common::{
+    AccountAddress, Address, Amount, Timestamp, ACCOUNT_ADDRESS_SIZE,
+};
 use derive_more::{Display, From, FromStr, Into};
 use std::{collections::BTreeMap, num::ParseIntError, str::FromStr};
 /// Index of an account key that is to be used.
@@ -442,33 +444,6 @@ impl FromStr for TransactionTime {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         let seconds = u64::from_str(s)?;
         Ok(Self { seconds })
-    }
-}
-
-/// Datatype used to indicate a timestamp in milliseconds.
-#[derive(
-    SerdeDeserialize, SerdeSerialize, PartialEq, Eq, Debug, Serialize, Clone, Copy, PartialOrd, Ord,
-)]
-#[serde(transparent)]
-pub struct Timestamp {
-    /// Milliseconds since the unix epoch.
-    pub millis: u64,
-}
-
-impl Timestamp {
-    pub fn now() -> Self { (chrono::Utc::now().timestamp_millis() as u64).into() }
-}
-
-impl From<u64> for Timestamp {
-    fn from(millis: u64) -> Self { Self { millis } }
-}
-
-impl FromStr for Timestamp {
-    type Err = ParseIntError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        let millis = u64::from_str(s)?;
-        Ok(Self { millis })
     }
 }
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased changes
 
+- Add `SchemaType` implementation for `&str`.
+- Add missing functionality from `Timestamp` in `concordium-base` to `Timestamp` in this crate, i.e. make internal field `millis` public, implement `From<u64>` and add a `now` method.
 - The `Debug` implementations of `Parameter` and `OwnedParameter` now output the
   parameter as hex unless the alternate formatting (`#`) is specified.
-- Add missing functionality from `Timestamp` in `concordium-base` to `Timestamp` in this crate, i.e. make internal field `millis` public, implement `From<u64>` and add a `now` method.
 
 ## concordium-contracts-common 8.1.1 (2023-11-02)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - The `Debug` implementations of `Parameter` and `OwnedParameter` now output the
   parameter as hex unless the alternate formatting (`#`) is specified.
+- Add missing functionality from `Timestamp` in `concordium-base` to `Timestamp` in this crate, i.e. make internal field `millis` public, implement `From<u64>` and add a `now` method.
 
 ## concordium-contracts-common 8.1.1 (2023-11-02)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -409,6 +409,10 @@ impl SchemaType for String {
     fn get_type() -> Type { Type::String(SizeLength::U32) }
 }
 
+impl SchemaType for &str {
+    fn get_type() -> Type { Type::String(SizeLength::U32) }
+}
+
 impl SchemaType for OwnedContractName {
     fn get_type() -> Type { Type::ContractName(SizeLength::U16) }
 }

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -410,7 +410,7 @@ impl SchemaType for String {
 }
 
 impl SchemaType for &str {
-    fn get_type() -> Type { Type::String(SizeLength::U32) }
+    fn get_type() -> Type { String::get_type() }
 }
 
 impl SchemaType for OwnedContractName {

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -671,9 +671,7 @@ impl quickcheck::Arbitrary for Timestamp {
     }
 
     fn shrink(&self) -> Box<dyn Iterator<Item = Self>> {
-        Box::new(
-            quickcheck::Arbitrary::shrink(&self.milliseconds).map(Timestamp::from_timestamp_millis),
-        )
+        Box::new(quickcheck::Arbitrary::shrink(&self.millis).map(Timestamp::from_timestamp_millis))
     }
 }
 
@@ -2890,7 +2888,7 @@ mod test {
     fn test_given_millis_far_in_future_when_string_to_timestamp_then_map() {
         let millis = 100000001683508889u64;
         if let Ok(timestamp) = Timestamp::from_str(&millis.to_string()) {
-            assert_eq!(timestamp.milliseconds, millis);
+            assert_eq!(timestamp.millis, millis);
         } else {
             assert!(false)
         };
@@ -2901,7 +2899,7 @@ mod test {
     fn test_given_rfc3339_format_when_string_to_timestamp_then_map() {
         let datetime = "1970-01-01T00:00:00.042+00:00";
         if let Ok(timestamp) = Timestamp::from_str(datetime) {
-            assert_eq!(timestamp.milliseconds, 42);
+            assert_eq!(timestamp.millis, 42);
         } else {
             assert!(false)
         };

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -678,7 +678,6 @@ impl quickcheck::Arbitrary for Timestamp {
 impl Timestamp {
     /// Construct a timestamp corresponding to the current date and time.
     #[cfg(feature = "derive-serde")]
-    #[inline(always)]
     pub fn now() -> Self { (chrono::Utc::now().timestamp_millis() as u64).into() }
 
     /// Construct timestamp from milliseconds since unix epoch.


### PR DESCRIPTION
## Purpose

Closes #429 and closes #450.

## Changes

- Unify `Timestamp` from `concordium_base` and `concordium_contracts_common` in `concordium_contracts_common`.
- Add `SchemaType` implementation for `&str`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

