### PR TITLE
Unify WasmVersion into concordium_contracts_common

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -11,6 +11,8 @@
 - Change `Debug` instance of `dodis_yampolskiy_prf::SecretKey` to hide the value.
 - Remove `Timestamp` to instead reexport the similar type from `concordium_contracts_common`.
   This adds several new methods, but results in a breaking change in the `serde::Serialize` implementation, which is now using string containing RFC3393 representation instead the underlying milliseconds.
+- Remove `smart_contracts::WasmVersion` to instead reexport a similar type from `concordium_contracts_common`.
+  This adds a `FromStr` implementation and changes the associated type `TryFrom<u8>::Error` from `anyhow::Error` to `concordium_contracts_common::U8WasmVersionConvertError`.
 
 ## 3.2.0 (2023-11-22)
 

--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Add a `branch_statistics` function to get insight into smart contract state
   tree structure.
+- Remove `utils::WasmVersion` to instead reexport a similar type from `concordium_contracts_common`.
+  This adds `Display`, `Default`, `TryFrom<u8>`, `serde::Serialize` and `serde::Deserialize` for `WasmVersion` and `From<WasmVersion>` for `u8`.
+  The associated type `FromStr::Err` changes from `anyhow::Error` to `concordium_contracts_common::WasmVersionParseError`.
+  The method `WasmVersin::read` is removed.
 
 ## concordium-smart-contract-engine 3.1.0 (2023-10-18)
 

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -17,39 +17,6 @@ use concordium_wasm::{
 use rand::{prelude::*, RngCore};
 use std::{collections::BTreeMap, default::Default};
 
-#[derive(Debug, Clone, Copy)]
-pub enum WasmVersion {
-    V0,
-    V1,
-}
-
-impl std::str::FromStr for WasmVersion {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
-            "V0" | "v0" => Ok(WasmVersion::V0),
-            "V1" | "v1" => Ok(WasmVersion::V1),
-            _ => anyhow::bail!("Unsupported version: '{}'. Only 'V0' and 'V1' are supported.", s),
-        }
-    }
-}
-
-impl WasmVersion {
-    /// Get the version from the cursor. This is not a Serial implementation
-    /// since it uses big-endian.
-    pub fn read(source: &mut std::io::Cursor<&[u8]>) -> anyhow::Result<WasmVersion> {
-        let mut data = [0u8; 4];
-        use std::io::Read;
-        source.read_exact(&mut data).context("Not enough data to read WasmVersion.")?;
-        match u32::from_be_bytes(data) {
-            0 => Ok(WasmVersion::V0),
-            1 => Ok(WasmVersion::V1),
-            n => bail!("Unsupported Wasm version {}.", n),
-        }
-    }
-}
-
 /// A host which traps for any function call.
 pub struct TrapHost;
 
@@ -697,7 +664,7 @@ pub fn get_build_info_from_skeleton(
         }
     }
     let Some(cs) = build_context_section else {
-        return Err(CustomSectionLookupError::Missing)
+        return Err(CustomSectionLookupError::Missing);
     };
     let info: VersionedBuildInfo = from_bytes(cs.contents).context("Failed parsing build info")?;
     Ok(info)

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -3,6 +3,7 @@
 
 use crate::{v1::EmittedDebugStatement, ExecResult};
 use anyhow::{anyhow, bail, ensure, Context};
+pub use concordium_contracts_common::WasmVersion;
 use concordium_contracts_common::{
     self as concordium_std, from_bytes, hashes, schema, Cursor, Deserial,
 };


### PR DESCRIPTION
## Purpose

Closes #465.
This PR unifies `WasmVersion` in `concordium-base` and `wasm-chain-integration` into one type in `concordium-contracts-common`.
See also the PR updating `cargo-concordium` to use the unified type https://github.com/Concordium/concordium-smart-contract-tools/pull/151

## Changes

- Removes `WasmVersion::read` in favor of `common::Deserial` in `concordium-base`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

