### PR TITLE
Credential deployment serialization

### DIFF
--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "wallet_library"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "concordium_base",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -1794,6 +1794,7 @@ dependencies = [
  "anyhow",
  "concordium_base",
  "ed25519-dalek",
+ "either",
  "hex",
  "key_derivation",
  "serde",

--- a/rust-src/wallet_library/CHANGELOG.md
+++ b/rust-src/wallet_library/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Added
 
-- Added method `serialize_credential_deployment_details` for serializing the credential deployment details that must be signed to deploy a new credential.
+- Added method `compute_credential_deployment_hash_to_sign` for computing the credential deployment sign digest that must be signed to deploy a new credential.
 - Added method `serialize_credential_deployment_payload` for serializing the credential deployment payload. 
 This payload is the one sent as a raw payload to the node when deploying a new credential.
 

--- a/rust-src/wallet_library/CHANGELOG.md
+++ b/rust-src/wallet_library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog 
 
+## [0.2.0]
+
+### Added
+
+- Added method `serialize_credential_deployment_details` for serializing the credential deployment details that must be signed to deploy a new credential.
+
 ## [0.1.0]
 
 ### Added

--- a/rust-src/wallet_library/CHANGELOG.md
+++ b/rust-src/wallet_library/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Added method `serialize_credential_deployment_details` for serializing the credential deployment details that must be signed to deploy a new credential.
+- Added method `serialize_credential_deployment_payload` for serializing the credential deployment payload. 
+This payload is the one sent as a raw payload to the node when deploying a new credential.
 
 ## [0.1.0]
 

--- a/rust-src/wallet_library/Cargo.toml
+++ b/rust-src/wallet_library/Cargo.toml
@@ -11,6 +11,7 @@ anyhow = "1.0"
 hex = "0.4"
 serde_json = "1.0"
 thiserror = "1.0"
+either = "1.6"
 
 [dependencies.key_derivation]
 path = "../key_derivation"

--- a/rust-src/wallet_library/Cargo.toml
+++ b/rust-src/wallet_library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet_library"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE"

--- a/rust-src/wallet_library/src/credential.rs
+++ b/rust-src/wallet_library/src/credential.rs
@@ -151,18 +151,16 @@ pub struct CredentialDeploymentPayload {
 /// Serializes the credential deployment payload. The result of this
 /// serialization should be sent as a raw payload to the node. The serialized
 /// bytes are returned hex encoded.
-pub fn serialize_credential_deployment_payload(
-    payload: CredentialDeploymentPayload,
-) -> Result<String> {
-    let cdi = get_credential_deployment_info(payload.signatures, payload.unsigned_cdi)?;
+pub fn serialize_credential_deployment_payload(payload: CredentialDeploymentPayload) -> String {
+    let cdi = get_credential_deployment_info(payload.signatures, payload.unsigned_cdi);
     let acc_cred = AccountCredential::Normal { cdi };
-    Ok(base16_encode_string(&acc_cred))
+    base16_encode_string(&acc_cred)
 }
 
 fn get_credential_deployment_info(
     signatures: BTreeMap<KeyIndex, AccountOwnershipSignature>,
     unsigned_cdi: UnsignedCredentialDeploymentInfo<IpPairing, ArCurve, AttributeKind>,
-) -> Result<CredentialDeploymentInfo<IpPairing, ArCurve, AttributeKind>, anyhow::Error> {
+) -> CredentialDeploymentInfo<IpPairing, ArCurve, AttributeKind> {
     let proof_acc_sk = AccountOwnershipProof { sigs: signatures };
 
     let cdp = CredDeploymentProofs {
@@ -170,10 +168,10 @@ fn get_credential_deployment_info(
         proof_acc_sk,
     };
 
-    Ok(CredentialDeploymentInfo {
+    CredentialDeploymentInfo {
         values: unsigned_cdi.values,
         proofs: cdp,
-    })
+    }
 }
 
 #[cfg(test)]
@@ -298,7 +296,7 @@ mod tests {
             signatures,
         };
 
-        let serialized_payload = serialize_credential_deployment_payload(payload).unwrap();
+        let serialized_payload = serialize_credential_deployment_payload(payload);
 
         assert!(serialized_payload.contains("0101000029723ec9a0b4ca16d5d548b676a1a0adbecdedc5446894151acb7699293d69b101b317d3fea7de56f8c96f6e72820c5cd502cc0eef8454016ee548913255897c6b52156cc60df965d3efb3f160eff6ced40000000001000300000001"));
         assert!(serialized_payload.contains(signature_hex));


### PR DESCRIPTION
## Purpose
To reduce serialization code duplication the code for serializing a new credential for signing and for submission to the node is added to `wallet_library`.

## Changes
- Added methods for serializing the credential deployment details (that which must be serialized, hashed and signed) and the credential deployment payload (that which is sent as a raw payload to the node).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.