### PR TITLE
Make VersionedSchemaError public in concordium-contracts-common

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -1020,7 +1020,7 @@ pub fn deserial_length(source: &mut impl Read, size_len: SizeLength) -> ParseRes
 
 // Versioned schema helpers
 #[cfg(feature = "derive-serde")]
-mod impls {
+pub mod impls {
     use crate::{from_bytes, schema::*};
     use base64::{engine::general_purpose, Engine};
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -14,6 +14,8 @@ use core::{
     convert::{TryFrom, TryInto},
     num::TryFromIntError,
 };
+#[cfg(feature = "derive-serde")]
+pub use impls::VersionedSchemaError;
 /// Contract schema related types
 #[cfg(feature = "std")]
 use std::{
@@ -21,8 +23,6 @@ use std::{
     convert::{TryFrom, TryInto},
     num::TryFromIntError,
 };
-#[cfg(feature = "derive-serde")]
-pub use impls::VersionedSchemaError;
 
 /// The `SchemaType` trait provides means to generate a schema for structures.
 /// Schemas are used to make structures human readable and to avoid dealing

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/schema.rs
@@ -21,6 +21,8 @@ use std::{
     convert::{TryFrom, TryInto},
     num::TryFromIntError,
 };
+#[cfg(feature = "derive-serde")]
+pub use impls::VersionedSchemaError;
 
 /// The `SchemaType` trait provides means to generate a schema for structures.
 /// Schemas are used to make structures human readable and to avoid dealing
@@ -1020,7 +1022,7 @@ pub fn deserial_length(source: &mut impl Read, size_len: SizeLength) -> ParseRes
 
 // Versioned schema helpers
 #[cfg(feature = "derive-serde")]
-pub mod impls {
+mod impls {
     use crate::{from_bytes, schema::*};
     use base64::{engine::general_purpose, Engine};
 


### PR DESCRIPTION
## Purpose

Make public such that `VersionedSchemaError` can be matched in applications which depend on `concordium-contracts-common`.

## Changes

Made `VersionedSchemaError ` public in `concordium-contracts-common`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.