### PR TITLE
Made `HashBytes::new()` a const function

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- Made `HashBytes::new()` a const function
+
 ## concordium-contracts-common 9.0.0 (2024-01-22)
 
 - Add `SchemaType` implementation for `&str`.

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Made `HashBytes::new()` a const function
+- `HashBytes::new` is now a `const` function.
 
 ## concordium-contracts-common 9.0.0 (2024-01-22)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/hashes.rs
@@ -100,10 +100,10 @@ pub enum HashFromStrError {
 
 impl<Purpose> HashBytes<Purpose> {
     /// Construct [`HashBytes`] from a slice.
-    pub fn new(bytes: [u8; SHA256]) -> Self {
+    pub const fn new(bytes: [u8; SHA256]) -> Self {
         Self {
             bytes,
-            _phantom: Default::default(),
+            _phantom: PhantomData,
         }
     }
 }


### PR DESCRIPTION
## Purpose

Need this to make the `ModuleRef` procedural macro that embeds it as a constant.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.