### PR TITLE
Support state-related host calls in `TestHost`

### DIFF
--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased changes
 
+- `TestHost` can now be constructed with an instance state (using `TestHost::with_state`), making the test host support host functions related to the smart contract key-value state.
+- The function `utils::run_module_tests` now provides an empty in-memory instance state for each test case, allowing module tests to use host functions related to the smart contract key-value state.
 - Support for querying the module reference and contract name of an instance via
   `invoke` (for protocol version 7). These are enabled by a new
   `support_contract_inspection_queries` parameter in `ReceiveParams` and
@@ -31,7 +33,7 @@
 - `ReceiveParams` is extended with `support_account_signature_checks` flag, that
   enables or disables two new operations that can be `invoke`d. Querying account
   public keys and checking account signatures.
-- `InvokeFailure` is extended with two new variants 
+- `InvokeFailure` is extended with two new variants
   `SignatureDataMalformed` and `SignatureCheckFailed` that can be triggered as a
   result of checking a signature.
 

--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased changes
 
-- `TestHost` can now be constructed with an instance state (using `TestHost::with_state`), making the test host support host functions related to the smart contract key-value state.
+- `TestHost` no longer implements the `ValidateImportExport` trait, instead use `NoDuplicateImport` struct.
+- `TestHost::new` now takes an instance state, allowing for support of host functions related to the smart contract key-value state.
 - The function `utils::run_module_tests` now provides an empty in-memory instance state for each test case, allowing module tests to use host functions related to the smart contract key-value state.
 - Support for querying the module reference and contract name of an instance via
   `invoke` (for protocol version 7). These are enabled by a new

--- a/smart-contracts/wasm-chain-integration/benches/wasm.rs
+++ b/smart-contracts/wasm-chain-integration/benches/wasm.rs
@@ -4,7 +4,7 @@ use concordium_contracts_common::{
 };
 use concordium_smart_contract_engine::{
     constants::MAX_ACTIVATION_FRAMES,
-    utils::TestHost,
+    utils::{NoDuplicateImport, TrapHost},
     v0::{
         ConcordiumAllowedImports, InitContext, InitHost, ProcessedImports, ReceiveContext,
         ReceiveHost, State,
@@ -306,16 +306,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let skeleton = parse::parse_skeleton(black_box(CONTRACT_BYTES_INSTRUCTIONS)).unwrap();
         let module =
-            validate::validate_module(ValidationConfig::V1, &TestHost::uninitialized(), &skeleton)
-                .unwrap();
+            validate::validate_module(ValidationConfig::V1, &NoDuplicateImport, &skeleton).unwrap();
         let artifact = module.compile::<ArtifactNamedImport>().unwrap();
         for n in [0, 1, 10000, 100000, 200000].iter() {
             group.bench_with_input(format!("execute n = {}", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "foo_extern", &[Value::I64(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "foo_extern", &[Value::I64(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -325,16 +322,13 @@ pub fn criterion_benchmark(c: &mut Criterion) {
         let skeleton =
             parse::parse_skeleton(black_box(CONTRACT_BYTES_MEMORY_INSTRUCTIONS)).unwrap();
         let module =
-            validate::validate_module(ValidationConfig::V1, &TestHost::uninitialized(), &skeleton)
-                .unwrap();
+            validate::validate_module(ValidationConfig::V1, &NoDuplicateImport, &skeleton).unwrap();
         let artifact = module.compile::<ArtifactNamedImport>().unwrap();
         for n in [1, 10, 50, 100, 250, 500, 1000, 1024].iter() {
             group.bench_with_input(format!("allocate n = {} pages", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "foo_extern", &[Value::I32(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "foo_extern", &[Value::I32(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -347,9 +341,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u32 n = {} times", n / 4), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "write_u32", &[Value::I32(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "write_u32", &[Value::I32(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -362,9 +354,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u64 n = {} times", n / 8), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "write_u64", &[Value::I32(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "write_u64", &[Value::I32(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -377,9 +367,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u8 n  = {} times as u32", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "write_u32_u8", &[Value::I32(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "write_u32_u8", &[Value::I32(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -392,9 +380,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
             group.bench_with_input(format!("write u8 n  = {} times as u64", n), n, |b, m| {
                 b.iter(|| {
                     assert!(
-                        artifact
-                            .run(&mut TestHost::uninitialized(), "write_u64_u8", &[Value::I32(*m)])
-                            .is_ok(),
+                        artifact.run(&mut TrapHost, "write_u64_u8", &[Value::I32(*m)]).is_ok(),
                         "Precondition violation."
                     )
                 })
@@ -418,8 +404,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
 
         let skeleton = parse::parse_skeleton(black_box(CONTRACT_BYTES_LOOP)).unwrap();
         let mut module =
-            validate::validate_module(ValidationConfig::V1, &TestHost::uninitialized(), &skeleton)
-                .unwrap();
+            validate::validate_module(ValidationConfig::V1, &NoDuplicateImport, &skeleton).unwrap();
         module.inject_metering().unwrap();
         let artifact = module.compile::<MeteringImport>().unwrap();
 

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -189,6 +189,9 @@ impl<'a, R: RngCore, BackingStore: trie::BackingStoreLoad> machine::Host<Artifac
         memory: &mut Vec<u8>,
         stack: &mut machine::RuntimeStack,
     ) -> machine::RunResult<Option<NoInterrupt>> {
+        // We don't track the energy usage in this host, so to reuse code which does, we
+        // provide a really large amount of energy to preventing the case of
+        // running out of energy.
         let mut energy = crate::InterpreterEnergy::new(u64::MAX);
         if f.matches("concordium", "report_error") {
             let (filename, line, column, msg) = extract_debug(memory, stack)?;

--- a/smart-contracts/wasm-chain-integration/src/v1/mod.rs
+++ b/smart-contracts/wasm-chain-integration/src/v1/mod.rs
@@ -556,7 +556,7 @@ impl std::fmt::Display for EmittedDebugStatement {
     }
 }
 
-mod host {
+pub(crate) mod host {
     //! v1 host function implementations. Functions in this inner module are
     //! mostly just wrappers. They parse relevant arguments from the
     //! machine, e.g., read values from the stack or memory, and push values to


### PR DESCRIPTION
## Purpose

Extend the `TestHost` to allow unit tests to use the state-related host function calls.

Needed to do allow unit tests for the new `StateBTreeMap` and `StateBTreeSet` introduced in 
https://github.com/Concordium/concordium-rust-smart-contracts/pull/405 using cargo-concordium.

Related cargo-concordium PR: https://github.com/Concordium/concordium-smart-contract-tools/pull/158

## Changes

- Define a new constructor for `TestHost` taking the instance state to make available.
- `TestHost` support host function calls related to state.
- `run_module_tests` provide an empty instance state for every test case.