### PR TITLE
Make concordium_quickcheck macro work inside `concordium_std`

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common-derive/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common-derive/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Attribute macro `#[concordium_quickcheck]` generates code referencing `concordium_std` rather than `::concordium_std` allowing for user-provided `concordium_std`.
 - Set minimum supported Rust version to 1.73.
 - Support returning types that reference host or state from `init` or `receive`
   entrypoints. The generated code extends lifetimes of the `host` and `ctx`

--- a/smart-contracts/contracts-common/concordium-contracts-common-derive/src/attribute.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common-derive/src/attribute.rs
@@ -1063,7 +1063,7 @@ pub mod quickcheck {
             #(#attrs)*
             fn #name() {
                 #item_fn
-               ::concordium_std::test_infrastructure::concordium_qc(#num_tests, #name as (fn (#inputs) #codomain))
+               concordium_std::test_infrastructure::concordium_qc(#num_tests, #name as (fn (#inputs) #codomain))
             }
         };
         Ok(res)


### PR DESCRIPTION
## Purpose

Make concordium_quickcheck macro work inside `concordium_std`.
Needed by https://github.com/Concordium/concordium-rust-smart-contracts/pull/405.

## Changes

- Attribute macro `#[concordium_quickcheck]` generates code referencing `concordium_std` rather than `::concordium_std` allowing for user-provided `concordium_std`.