### PR TITLE
Support Rust 1.73 on Windows.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ See documentation for
 
 In order to build the components in this repository you need
 - The [cargo](https://doc.rust-lang.org/cargo/) tool for building the Rust
-components. The currently supported version is 1.68. Others may work, but we
+components. The currently supported version is 1.73. Others may work, but we
 do not regularly test with them. The easiest way to install it is via the
 [rustup](https://rustup.rs/) tool.
 - The [Haskell Stack](https://docs.haskellstack.org/en/stable/README/) tool for
@@ -140,7 +140,7 @@ issues.
 
 ## Rust workflow
 
-We use **stable version** of rust, 1.68, to compile the code. This is the
+We use **stable version** of rust, 1.73, to compile the code. This is the
 minimal supported version.
 
 The CI is configured to check two things

--- a/Setup.hs
+++ b/Setup.hs
@@ -55,7 +55,9 @@ linuxBuild False env verbosity = do
 windowsBuild :: WithEnvAndVerbosity
 windowsBuild env verbosity = do
     let copyLib lib = do
-            rawSystemExit verbosity "cp" ["-u", "rust-src/target/release/lib" ++ lib ++ ".a", "./lib/"]
+            -- We delete the static library if present to ensure that we only link with the
+            -- dynamic library.
+            rawSystemExit verbosity "rm" ["-f", "./lib/" ++ lib ++ ".a"]
             rawSystemExit verbosity "cp" ["-u", "rust-src/target/release/" ++ lib ++ ".dll", "./lib/"]
             notice verbosity $ "Copied " ++ lib ++ "."
     rawSystemExitWithEnv verbosity "cargo" (addFeatures ["build", "--release", "--manifest-path", "rust-src/Cargo.toml"]) env
@@ -101,10 +103,27 @@ makeRust _ flags _ lbi = do
     rawSystemExit verbosity "mkdir" ["-p", "./lib"]
     build env verbosity
 
+-- | On Windows, copy the DLL files to the binary install directory. This is to ensure that they
+-- are accessible when running the binaries, tests and benchmarks.
+copyDlls :: Args -> CopyFlags -> PackageDescription -> LocalBuildInfo -> IO ()
+copyDlls _ flags pkgDescr lbi = case buildOS of
+    Windows -> do
+        let installDirs = absoluteComponentInstallDirs pkgDescr lbi (localUnitId lbi) copydest
+        let copyLib lib = do
+                rawSystemExit verbosity "cp" ["-u", "./lib/" ++ lib ++ ".dll", bindir installDirs]
+                notice verbosity $ "Copy " ++ lib ++ " to " ++ bindir installDirs
+        mapM_ copyLib concordiumLibs
+    _ -> return ()
+  where
+    distPref = fromFlag (copyDistPref flags)
+    verbosity = fromFlag (copyVerbosity flags)
+    copydest = fromFlag (copyDest flags)
+
 main =
     defaultMainWithHooks $
         generatingProtos
             "./concordium-grpc-api"
             simpleUserHooks
-                { postConf = makeRust
+                { postConf = makeRust,
+                  postCopy = copyDlls
                 }

--- a/idiss/README.md
+++ b/idiss/README.md
@@ -119,7 +119,7 @@ Otherwise, the return value is an error.
 
 In order to build you need the following
 - the rust compiler, stable toolchain, a recent version. We've tested with
-  1.68.
+  1.73.
 - clang development libraries. On ubuntu these can be installed with 
   ```
   apt install libclang-dev


### PR DESCRIPTION
## Purpose

Support Rust version 1.73 on Windows. This changes how the Haskell code is linked to Rust code to use dynamic linking (instead of static, as previously) on Windows.

## Changes

- The build process no longer copies static libraries to the `lib` directory, and removes them if they are present.
- The DLLs are copied to the install directory in the post-copy build hook. This ensures that they are in the path when `stack` runs binaries


## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
