### PR TITLE
Disable encrypted transfers in P7.

### DIFF
--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -195,6 +195,7 @@ module Concordium.Types.ProtocolVersion (
     omitCustomSectionFromSize,
     supportsAccountSignatureChecks,
     supportsContractInspectionQueries,
+    supportsEncryptedTransfers,
 
     -- * Defunctionalisation symbols
     P1Sym0,
@@ -640,3 +641,15 @@ supportsContractInspectionQueries = \case
     SP5 -> False
     SP6 -> False
     SP7 -> True
+
+-- | Whether the protocol version supports encrypting balances and sending encrypted transfers.
+--  (Disabled in 'P7' and onwards.)
+supportsEncryptedTransfers :: SProtocolVersion pv -> Bool
+supportsEncryptedTransfers = \case
+    SP1 -> True
+    SP2 -> True
+    SP3 -> True
+    SP4 -> True
+    SP5 -> True
+    SP6 -> True
+    _ -> False


### PR DESCRIPTION
## Purpose

Disable encrypted transfers in protocol version 7. This disallows the deserialization of payload types `TransferToEncrypted`, `EncryptedAmountTransfer` and `EncryptedAmountTransferWithMemo` in P7. (`TransferToPublic` is unaffected.)

## Changes

- Introduce `supportsEncryptedTransfers` predicate that indicates which protocol versions support encrypted transfers (P6 and earlier).
- Condition deserialization of the relevant payload types on encrypted transfers being supported.
- Update and bolster serialization tests.
- `decodePayload` no longer takes the payload size as a separate parameter, since in practice it is always the size of the payload.

## Checklist

- [X] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
