### PR TITLE
Derive default on Amount

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Derive `serde::Serialize` and `serde::Serialize` for `PublicKeyEd25519` using
   `FromStr` and `Display` implementations, when feature `derive-serde` is
   enabled.
+- Derive `Default` on `Amount` (defaults to 0).
 
 ## concordium-contracts-common 9.1.0 (2024-03-25)
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -46,9 +46,9 @@ pub type ContractSubIndex = u64;
 /// NB: This is different from the Base58 representation.
 pub const ACCOUNT_ADDRESS_SIZE: usize = 32;
 
-/// The type of amounts on the chain
+/// The type of amounts on the chain.
 #[repr(transparent)]
-#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "fuzz", derive(Arbitrary))]
 pub struct Amount {
     pub micro_ccd: u64,


### PR DESCRIPTION
## Purpose

Deriving default is useful and convenient, especially for a small type such as this.

## Changes

Simply derives Default on `Amount`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
