### PR TITLE
Fix mobile wallet Android build script

### DIFF
--- a/mobile_wallet/android/build-android.sh
+++ b/mobile_wallet/android/build-android.sh
@@ -4,10 +4,10 @@ set -euxo pipefail
 
 min_ver=29
 
-(cd ../ && cargo ndk --target aarch64-linux-android --android-platform ${min_ver} -- build --release && \
-cargo ndk --target armv7-linux-androideabi --android-platform ${min_ver} -- build --release && \
-cargo ndk --target i686-linux-android --android-platform ${min_ver} -- build --release && \
-cargo ndk --target x86_64-linux-android --android-platform ${min_ver} -- build --release )
+(cd ../ && cargo ndk --target aarch64-linux-android --platform ${min_ver} -- build --release && \
+cargo ndk --target armv7-linux-androideabi --platform ${min_ver} -- build --release && \
+cargo ndk --target i686-linux-android --platform ${min_ver} -- build --release && \
+cargo ndk --target x86_64-linux-android --platform ${min_ver} -- build --release )
 
 jniLibs=$(pwd)/mobile_wallet_lib/src/main/jniLibs
 rm -rf ${jniLibs}


### PR DESCRIPTION
## Purpose

The script wasn't working as Cargo NDK only supports `-p, --platform` argument, while `--android-platform` was specified.

## Changes

- Fix incorrect arguments in `build-android` script

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
