### PR TITLE
Add legal country to allowed attributes in wallet-library.

### DIFF
--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -2054,7 +2054,7 @@ dependencies = [
 
 [[package]]
 name = "wallet_library"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/rust-src/wallet_library/CHANGELOG.md
+++ b/rust-src/wallet_library/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.4.0]
+
+### Added
+
+- Added the company attribute `legalCountry` to the list of allowed attributes for set-membership proofs.
+
 ## [0.3.0]
 
 ### Added

--- a/rust-src/wallet_library/Cargo.toml
+++ b/rust-src/wallet_library/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet_library"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE"

--- a/rust-src/wallet_library/src/default_wallet_config.rs
+++ b/rust-src/wallet_library/src/default_wallet_config.rs
@@ -60,12 +60,13 @@ pub const ALLOWED_IDENTITY_RANGE_TAGS: [AttributeTag; 3] =
     [AttributeTag(3), AttributeTag(9), AttributeTag(10)];
 /// List of identity attribute tags that we allow set statements
 /// (membership/nonMembership) for. The list should correspond to "Country
-/// of residence", "Nationality", "IdDocType", "IdDocIssuer".
-pub const ALLOWED_IDENTITY_SET_TAGS: [AttributeTag; 4] = [
+/// of residence", "Nationality", "IdDocType", "IdDocIssuer", "LegalCountry".
+pub const ALLOWED_IDENTITY_SET_TAGS: [AttributeTag; 5] = [
     AttributeTag(4),
     AttributeTag(5),
     AttributeTag(6),
     AttributeTag(8),
+    AttributeTag(15),
 ];
 
 /// Returns the `WalletConfig` that is used by our wallet implementations for


### PR DESCRIPTION
## Purpose

To add the newly introduced company attribute "legalCountry" to the list of allowed attributes for set membership proofs in the wallet library. Closes #541.

## Changes

The above mentioned attribute is now among the allowed ones.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

