### PR TITLE
Protocol version 8 boilerplate

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -62,6 +62,7 @@ library
       Concordium.Genesis.Data.P5
       Concordium.Genesis.Data.P6
       Concordium.Genesis.Data.P7
+      Concordium.Genesis.Data.P8
       Concordium.Genesis.Parameters
       Concordium.GRPC2
       Concordium.ID.Account

--- a/haskell-src/Concordium/Constants.hs
+++ b/haskell-src/Concordium/Constants.hs
@@ -23,6 +23,7 @@ maxPayloadSize SP4 = maxWasmModuleSizeV1 + 1 + 4 + 4 -- +1 for the payload tag, 
 maxPayloadSize SP5 = maxPayloadSize SP4
 maxPayloadSize SP6 = maxPayloadSize SP4
 maxPayloadSize SP7 = maxPayloadSize SP4
+maxPayloadSize SP8 = maxPayloadSize SP4
 
 -- * Web assembly related constants
 
@@ -36,6 +37,7 @@ maxParameterLen SP4 = 1024
 maxParameterLen SP5 = 65535
 maxParameterLen SP6 = maxParameterLen SP5
 maxParameterLen SP7 = maxParameterLen SP5
+maxParameterLen SP8 = maxParameterLen SP5
 
 -- | Whether the number of logs and size of return values should be limited.
 --  The limits have been removed in P5 and onward.
@@ -47,6 +49,7 @@ limitLogsAndReturnValues SP4 = True
 limitLogsAndReturnValues SP5 = False
 limitLogsAndReturnValues SP6 = False
 limitLogsAndReturnValues SP7 = False
+limitLogsAndReturnValues SP8 = False
 
 -- | Maximum module size of a V0 module.
 maxWasmModuleSizeV0 :: Word32

--- a/haskell-src/Concordium/Cost.hs
+++ b/haskell-src/Concordium/Cost.hs
@@ -223,6 +223,7 @@ lookupModule SP4 ms = fromIntegral ms `div` 50
 lookupModule SP5 ms = fromIntegral ms `div` 50
 lookupModule SP6 ms = fromIntegral ms `div` 50
 lookupModule SP7 ms = fromIntegral ms `div` 500
+lookupModule SP8 ms = fromIntegral ms `div` 500
 
 -- | The base cost of initializing a contract instance to cover administrative costs.
 -- Even if no code is run and no instance created.

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -269,6 +269,7 @@ instance ToProto ProtocolVersion where
     toProto P5 = Proto.PROTOCOL_VERSION_5
     toProto P6 = Proto.PROTOCOL_VERSION_6
     toProto P7 = Proto.PROTOCOL_VERSION_7
+    toProto P8 = Proto.PROTOCOL_VERSION_8
 
 instance ToProto QueryTypes.NextAccountNonce where
     type Output QueryTypes.NextAccountNonce = Proto.NextAccountSequenceNumber
@@ -2057,6 +2058,28 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
                                     ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
                                 )
             SChainParametersV2 ->
+                let Parameters.ChainParameters{..} = params
+                in  Proto.make $
+                        ProtoFields.v2
+                            .= Proto.make
+                                ( do
+                                    ProtoFields.consensusParameters .= toProto _cpConsensusParameters
+                                    ProtoFields.euroPerEnergy .= toProto (Parameters._erEuroPerEnergy _cpExchangeRates)
+                                    ProtoFields.microCcdPerEuro .= toProto (Parameters._erMicroGTUPerEuro _cpExchangeRates)
+                                    ProtoFields.cooldownParameters .= toProto _cpCooldownParameters
+                                    ProtoFields.timeParameters .= toProto (Parameters.unOParam _cpTimeParameters)
+                                    ProtoFields.accountCreationLimit .= toProto _cpAccountCreationLimit
+                                    ProtoFields.mintDistribution .= toProto (Parameters._rpMintDistribution _cpRewardParameters)
+                                    ProtoFields.transactionFeeDistribution .= toProto (Parameters._rpTransactionFeeDistribution _cpRewardParameters)
+                                    ProtoFields.gasRewards .= toProto (Parameters._rpGASRewards _cpRewardParameters)
+                                    ProtoFields.foundationAccount .= toProto foundationAddr
+                                    ProtoFields.poolParameters .= toProto _cpPoolParameters
+                                    ProtoFields.rootKeys .= toProto (Updates.rootKeys keys)
+                                    ProtoFields.level1Keys .= toProto (Updates.level1Keys keys)
+                                    ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
+                                    ProtoFields.finalizationCommitteeParameters .= toProto (Parameters.unOParam _cpFinalizationCommitteeParameters)
+                                )
+            SChainParametersV3 ->
                 let Parameters.ChainParameters{..} = params
                 in  Proto.make $
                         ProtoFields.v2

--- a/haskell-src/Concordium/Genesis/Data.hs
+++ b/haskell-src/Concordium/Genesis/Data.hs
@@ -46,6 +46,7 @@ import qualified Concordium.Genesis.Data.P4 as P4
 import qualified Concordium.Genesis.Data.P5 as P5
 import qualified Concordium.Genesis.Data.P6 as P6
 import qualified Concordium.Genesis.Data.P7 as P7
+import qualified Concordium.Genesis.Data.P8 as P8
 import Concordium.Types
 import Concordium.Types.Parameters
 
@@ -65,6 +66,7 @@ newtype instance GenesisData 'P4 = GDP4 {unGDP4 :: P4.GenesisDataP4}
 newtype instance GenesisData 'P5 = GDP5 {unGDP5 :: P5.GenesisDataP5}
 newtype instance GenesisData 'P6 = GDP6 {unGDP6 :: P6.GenesisDataP6}
 newtype instance GenesisData 'P7 = GDP7 {unGDP7 :: P7.GenesisDataP7}
+newtype instance GenesisData 'P8 = GDP8 {unGDP8 :: P8.GenesisDataP8}
 
 -- | Data family for regenesis data. This has been chosen to be a data family, as
 --  opposed to a type family principally so that it is injective, i.e., so that
@@ -78,6 +80,7 @@ newtype instance Regenesis 'P4 = RGDP4 {unRGP4 :: P4.RegenesisP4}
 newtype instance Regenesis 'P5 = RGDP5 {unRGP5 :: P5.RegenesisP5}
 newtype instance Regenesis 'P6 = RGDP6 {unRGP6 :: P6.RegenesisP6}
 newtype instance Regenesis 'P7 = RGDP7 {unRGP7 :: P7.RegenesisP7}
+newtype instance Regenesis 'P8 = RGDP8 {unRGP8 :: P8.RegenesisP8}
 
 instance (IsProtocolVersion pv, IsConsensusV0 pv) => BasicGenesisData (GenesisData pv) where
     gdGenesisTime = case protocolVersion @pv of
@@ -162,6 +165,7 @@ instance (IsProtocolVersion pv) => Eq (GenesisData pv) where
         SP5 -> (==) `on` unGDP5
         SP6 -> (==) `on` unGDP6
         SP7 -> (==) `on` unGDP7
+        SP8 -> (==) `on` unGDP8
 
 instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
     get = case protocolVersion @pv of
@@ -172,6 +176,7 @@ instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
         SP5 -> GDP5 <$> P5.getGenesisDataV7
         SP6 -> GDP6 <$> P6.getGenesisDataV8
         SP7 -> GDP7 <$> P7.getGenesisDataV9
+        SP8 -> GDP8 <$> P8.getGenesisDataV10
 
     put = case protocolVersion @pv of
         SP1 -> P1.putGenesisDataV3 . unGDP1
@@ -181,6 +186,7 @@ instance (IsProtocolVersion pv) => Serialize (GenesisData pv) where
         SP5 -> P5.putGenesisDataV7 . unGDP5
         SP6 -> P6.putGenesisDataV8 . unGDP6
         SP7 -> P7.putGenesisDataV9 . unGDP7
+        SP8 -> P8.putGenesisDataV10 . unGDP8
 
 -- | Deserialize 'GenesisConfiguration' given the hash of the genesis. If
 --  'GenesisData' or 'Regenesis' is decodable (using its Serialize instance) from a given
@@ -209,6 +215,7 @@ getVersionedGenesisData = case protocolVersion @pv of
     SP5 -> GDP5 <$> P5.getVersionedGenesisData
     SP6 -> GDP6 <$> P6.getVersionedGenesisData
     SP7 -> GDP7 <$> P7.getVersionedGenesisData
+    SP8 -> GDP8 <$> P8.getVersionedGenesisData
 
 -- | Serialize genesis data with a version tag.
 --  Each version tag must be specific to a protocol version, though more than one version tag can
@@ -233,6 +240,7 @@ putVersionedGenesisData = case protocolVersion @pv of
     SP5 -> P5.putVersionedGenesisData . unGDP5
     SP6 -> P6.putVersionedGenesisData . unGDP6
     SP7 -> P7.putVersionedGenesisData . unGDP7
+    SP8 -> P8.putVersionedGenesisData . unGDP8
 
 -- | Generate the block hash of a genesis block with the given genesis data.
 --  This is based on the presumption that a block hash is computed from a byte string
@@ -246,6 +254,7 @@ genesisBlockHash = case protocolVersion @pv of
     SP5 -> P5.genesisBlockHash . unGDP5
     SP6 -> P6.genesisBlockHash . unGDP6
     SP7 -> P7.genesisBlockHash . unGDP7
+    SP8 -> P8.genesisBlockHash . unGDP8
 
 -- | Generate the block hash of a regenesis block with the given regenesis data.
 regenesisBlockHash :: forall pv. (IsProtocolVersion pv) => Regenesis pv -> BlockHash
@@ -257,6 +266,7 @@ regenesisBlockHash = case protocolVersion @pv of
     SP5 -> P5.regenesisBlockHash . unRGP5
     SP6 -> P6.regenesisBlockHash . unRGP6
     SP7 -> P7.regenesisBlockHash . unRGP7
+    SP8 -> P8.regenesisBlockHash . unRGP8
 
 -- | Hash of the initial genesis of the chain to which the given genesis data belongs.
 --  Genesis created as part of a protocol update records the genesis
@@ -270,6 +280,7 @@ firstGenesisBlockHash = case protocolVersion @pv of
     SP5 -> P5.firstGenesisBlockHash . unRGP5
     SP6 -> P6.firstGenesisBlockHash . unRGP6
     SP7 -> P7.firstGenesisBlockHash . unRGP7
+    SP8 -> P8.firstGenesisBlockHash . unRGP8
 
 -- | Tag of the genesis variant used for serialization. This tag determines
 --  whether the genesis data is, e.g., initial genesis, or regenesis.
@@ -282,6 +293,7 @@ genesisVariantTag = case protocolVersion @pv of
     SP5 -> P5.genesisVariantTag . unGDP5
     SP6 -> P6.genesisVariantTag . unGDP6
     SP7 -> P7.genesisVariantTag . unGDP7
+    SP8 -> P8.genesisVariantTag . unGDP8
 
 -- | Tag of the regenesis variant used for serialization. This tag determines
 --  whether the genesis data is, e.g., initial genesis, or regenesis and allows
@@ -296,6 +308,7 @@ regenesisVariantTag = case protocolVersion @pv of
     SP5 -> P5.regenesisVariantTag . unRGP5
     SP6 -> P6.regenesisVariantTag . unRGP6
     SP7 -> P7.regenesisVariantTag . unRGP7
+    SP8 -> P8.regenesisVariantTag . unRGP8
 
 -- | A dependent pair of a protocol version and genesis data.
 data PVGenesisData = forall pv. (IsProtocolVersion pv) => PVGenesisData (GenesisData pv)
@@ -317,6 +330,7 @@ getPVGenesisData = do
         7 -> PVGenesisData . GDP5 <$> P5.getGenesisDataV7
         8 -> PVGenesisData . GDP6 <$> P6.getGenesisDataV8
         9 -> PVGenesisData . GDP7 <$> P7.getGenesisDataV9
+        10 -> PVGenesisData . GDP8 <$> P8.getGenesisDataV10
         n -> fail $ "Unsupported genesis version: " ++ show n
 
 -- | Deserialize a genesis data version tag and return the associated protocol
@@ -333,6 +347,7 @@ getPVGenesisDataPV = do
         7 -> return $ SomeProtocolVersion SP5
         8 -> return $ SomeProtocolVersion SP6
         9 -> return $ SomeProtocolVersion SP7
+        10 -> return $ SomeProtocolVersion SP8
         n -> fail $ "Unsupported genesis version: " ++ show n
 
 -- | Serialize genesis data with a version tag. This is a helper function that
@@ -370,6 +385,8 @@ data StateMigrationParameters (p1 :: ProtocolVersion) (p2 :: ProtocolVersion) wh
     StateMigrationParametersP5ToP6 :: P6.StateMigrationData -> StateMigrationParameters 'P5 'P6
     -- | The state is migrated from protocol version 'P6' to 'P7'.
     StateMigrationParametersP6ToP7 :: StateMigrationParameters 'P6 'P7
+    -- | The state is migrated from protocol version 'P7' to 'P8'.
+    StateMigrationParametersP7ToP8 :: StateMigrationParameters 'P7 'P8
 
 -- | Extract the genesis configuration from the genesis data.
 genesisConfiguration :: (IsProtocolVersion pv, IsConsensusV0 pv) => GenesisData pv -> GenesisConfiguration
@@ -400,6 +417,7 @@ genesisCoreParametersV1 ::
 genesisCoreParametersV1 = case protocolVersion @pv of
     SP6 -> \(GDP6 genData) -> P6.genesisCore genData
     SP7 -> \(GDP7 genData) -> P7.genesisCore genData
+    SP8 -> \(GDP8 genData) -> P8.genesisCore genData
 
 -- | Extract the V1 core genesis parameters from the regenesis data.
 regenesisCoreParametersV1 ::
@@ -410,3 +428,4 @@ regenesisCoreParametersV1 ::
 regenesisCoreParametersV1 = case protocolVersion @pv of
     SP6 -> \(RGDP6 genData) -> BaseV1.genesisCore $ P6.genesisRegenesis genData
     SP7 -> \(RGDP7 genData) -> BaseV1.genesisCore $ P7.genesisRegenesis genData
+    SP8 -> \(RGDP8 genData) -> BaseV1.genesisCore $ P8.genesisRegenesis genData

--- a/haskell-src/Concordium/Genesis/Data/P8.hs
+++ b/haskell-src/Concordium/Genesis/Data/P8.hs
@@ -1,0 +1,143 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | This module defines the genesis data format for the 'P8' protocol version.
+module Concordium.Genesis.Data.P8 where
+
+import Data.Serialize
+import Data.Word
+
+import Concordium.Common.Version
+import qualified Concordium.Crypto.SHA256 as Hash
+import qualified Concordium.Genesis.Data.Base as Base
+import qualified Concordium.Genesis.Data.BaseV1 as BaseV1
+import Concordium.Types
+
+-- | Initial genesis data for the P8 protocol version.
+data GenesisDataP8 = GDP8Initial
+    { -- | The immutable genesis parameters.
+      genesisCore :: !BaseV1.CoreGenesisParametersV1,
+      -- | Serialized initial block state.
+      genesisInitialState :: !(Base.GenesisState 'P8)
+    }
+    deriving (Eq, Show)
+
+-- | The regenesis represents a reset of the protocol with a new genesis block.
+--   This does not include the full new state, but only its hash.
+--
+--  The relationship between the new state and the state of the
+--  terminal block of the old chain should be defined by the
+--  chain update mechanism used.
+--
+--  There are two variants, one when migrating from 'P7' to 'P8' and
+--  one from 'P8' to 'P8'.
+data RegenesisP8
+    = GDP8Regenesis {genesisRegenesis :: !BaseV1.RegenesisDataV1}
+    | GDP8RegenesisFromP7
+        { genesisRegenesis :: !BaseV1.RegenesisDataV1,
+          genesisMigration :: ()
+        }
+    deriving (Eq, Show)
+
+-- | Deserialize genesis data in the V10 format.
+getGenesisDataV10 :: Get GenesisDataP8
+getGenesisDataV10 =
+    getWord8 >>= \case
+        0 -> do
+            genesisCore <- get
+            genesisInitialState <- get
+            return GDP8Initial{..}
+        _ -> fail "Unrecognized P8 genesis data type."
+
+getRegenesisData :: Get RegenesisP8
+getRegenesisData =
+    getWord8 >>= \case
+        1 -> do
+            genesisRegenesis <- get
+            return GDP8Regenesis{..}
+        2 -> do
+            genesisRegenesis <- get
+            genesisMigration <- get
+            return GDP8RegenesisFromP7{..}
+        _ -> fail "Unrecognized P8 regenesis data type."
+
+-- | Serialize genesis data in the V10 format.
+putGenesisDataV10 :: Putter GenesisDataP8
+putGenesisDataV10 GDP8Initial{..} = do
+    putWord8 0
+    put genesisCore
+    put genesisInitialState
+
+-- | Deserialize genesis data with a version tag. The expected version tag is 10
+--  and this must be distinct from version tags of other genesis data formats.
+getVersionedGenesisData :: Get GenesisDataP8
+getVersionedGenesisData =
+    getVersion >>= \case
+        10 -> getGenesisDataV10
+        n -> fail $ "Unsupported genesis data version for P8 genesis: " ++ show n
+
+-- | Serialize genesis data with a version tag.
+--  This will use the V10 format.
+putVersionedGenesisData :: Putter GenesisDataP8
+putVersionedGenesisData gd = do
+    putVersion 10
+    putGenesisDataV10 gd
+
+-- | Compute the block hash of the genesis block with the given genesis data.
+--  Every block hash is derived from a message that begins with the block slot,
+--  which is 0 for genesis blocks.
+--
+--  NB: For the regenesis variant the serialized state is not included in the
+--  block hash, only the state hash is. This makes it possible to optimize the
+--  format in the future since it does not have protocol defined meaning. In
+--  contrast, for the initial P8 genesis the initial state is hashed as is.
+genesisBlockHash :: GenesisDataP8 -> BlockHash
+genesisBlockHash GDP8Initial{..} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P8
+    putWord8 0 -- initial variant
+    put genesisCore
+    put genesisInitialState
+
+-- | Compute the block hash of the regenesis data as defined by the specified
+--  protocol. This becomes the block hash of the genesis block of the new chain
+--  after the protocol update.
+regenesisBlockHash :: RegenesisP8 -> BlockHash
+regenesisBlockHash GDP8Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P8
+    putWord8 1 -- regenesis variant
+    put genesisCore
+    put genesisFirstGenesis
+    put genesisPreviousGenesis
+    put genesisTerminalBlock
+    put genesisStateHash
+regenesisBlockHash GDP8RegenesisFromP7{genesisRegenesis = BaseV1.RegenesisDataV1{..}, ..} = BlockHash . Hash.hashLazy . runPutLazy $ do
+    put genesisSlot
+    put P8
+    putWord8 2 -- migration from P6 variant
+    put genesisCore
+    put genesisFirstGenesis
+    put genesisPreviousGenesis
+    put genesisTerminalBlock
+    put genesisStateHash
+    put genesisMigration
+
+-- | The hash of the first genesis block in the chain.
+firstGenesisBlockHash :: RegenesisP8 -> BlockHash
+firstGenesisBlockHash GDP8Regenesis{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = genesisFirstGenesis
+firstGenesisBlockHash GDP8RegenesisFromP7{genesisRegenesis = BaseV1.RegenesisDataV1{..}} = genesisFirstGenesis
+
+-- | Tag of the genesis data used for serialization.
+genesisVariantTag :: GenesisDataP8 -> Word8
+genesisVariantTag GDP8Initial{} = 0
+
+-- | Tag of the regenesis variant used for serialization. This tag determines
+--  whether the genesis data is, e.g., initial genesis, or regenesis and allows
+--  us to deserialize one or the other from the data without knowing a priori what
+--  the data is.
+regenesisVariantTag :: RegenesisP8 -> Word8
+regenesisVariantTag GDP8Regenesis{} = 1
+regenesisVariantTag GDP8RegenesisFromP7{} = 2

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -253,6 +253,37 @@ instance ToJSON (GenesisChainParameters' 'ChainParametersV2) where
               "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam gcpFinalizationCommitteeParameters)
             ]
 
+instance ToJSON (GenesisChainParameters' 'ChainParametersV3) where
+    toJSON GenesisChainParameters{..} =
+        object
+            [ "euroPerEnergy" AE..= _erEuroPerEnergy gcpExchangeRates,
+              "microGTUPerEuro" AE..= _erMicroGTUPerEuro gcpExchangeRates,
+              "poolOwnerCooldown" AE..= _cpPoolOwnerCooldown gcpCooldownParameters,
+              "delegatorCooldown" AE..= _cpDelegatorCooldown gcpCooldownParameters,
+              "accountCreationLimit" AE..= gcpAccountCreationLimit,
+              "rewardParameters" AE..= gcpRewardParameters,
+              "foundationAccount" AE..= gcpFoundationAccount,
+              "passiveFinalizationCommission" AE..= _finalizationCommission (_ppPassiveCommissions gcpPoolParameters),
+              "passiveBakingCommission" AE..= _bakingCommission (_ppPassiveCommissions gcpPoolParameters),
+              "passiveTransactionCommission" AE..= _transactionCommission (_ppPassiveCommissions gcpPoolParameters),
+              "finalizationCommissionRange" AE..= _finalizationCommissionRange (_ppCommissionBounds gcpPoolParameters),
+              "bakingCommissionRange" AE..= _bakingCommissionRange (_ppCommissionBounds gcpPoolParameters),
+              "transactionCommissionRange" AE..= _transactionCommissionRange (_ppCommissionBounds gcpPoolParameters),
+              "minimumEquityCapital" AE..= _ppMinimumEquityCapital gcpPoolParameters,
+              "capitalBound" AE..= _ppCapitalBound gcpPoolParameters,
+              "leverageBound" AE..= _ppLeverageBound gcpPoolParameters,
+              "rewardPeriodLength" AE..= _tpRewardPeriodLength (unOParam gcpTimeParameters),
+              "mintPerPayday" AE..= _tpMintPerPayday (unOParam gcpTimeParameters),
+              "timeoutBase" AE..= _tpTimeoutBase (_cpTimeoutParameters gcpConsensusParameters),
+              "timeoutIncrease" AE..= _tpTimeoutIncrease (_cpTimeoutParameters gcpConsensusParameters),
+              "timeoutDecrease" AE..= _tpTimeoutDecrease (_cpTimeoutParameters gcpConsensusParameters),
+              "minBlockTime" AE..= _cpMinBlockTime gcpConsensusParameters,
+              "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters,
+              "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam gcpFinalizationCommitteeParameters),
+              "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam gcpFinalizationCommitteeParameters),
+              "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam gcpFinalizationCommitteeParameters)
+            ]
+
 -- | 'GenesisParametersV2' provides a convenient abstraction for
 -- constructing 'GenesisData'. The following invariants are
 -- required to hold:

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -50,6 +50,7 @@ instance (IsChainParametersVersion cpv) => FromJSON (GenesisChainParameters' cpv
         SChainParametersV0 -> parseJSONForGCPV0
         SChainParametersV1 -> parseJSONForGCPV1
         SChainParametersV2 -> parseJSONForGCPV2
+        SChainParametersV3 -> parseJSONForGCPV3
 
 -- | Parse 'GenesisChainParameters' from JSON for 'ChainParametersV0'.
 parseJSONForGCPV0 :: Value -> Parser (GenesisChainParameters' 'ChainParametersV0)
@@ -105,6 +106,47 @@ parseJSONForGCPV1 =
 -- | Parse 'GenesisChainParameters' from JSON for 'ChainParametersV2'.
 parseJSONForGCPV2 :: Value -> Parser (GenesisChainParameters' 'ChainParametersV2)
 parseJSONForGCPV2 =
+    withObject "GenesisChainParametersV2" $ \v -> do
+        _erEuroPerEnergy <- v .: "euroPerEnergy"
+        _erMicroGTUPerEuro <- v .: "microGTUPerEuro"
+        _cpPoolOwnerCooldown <- v .: "poolOwnerCooldown"
+        _cpDelegatorCooldown <- v .: "delegatorCooldown"
+        gcpAccountCreationLimit <- v .: "accountCreationLimit"
+        gcpRewardParameters <- v .: "rewardParameters"
+        gcpFoundationAccount <- v .: "foundationAccount"
+        _finalizationCommission <- v .: "passiveFinalizationCommission"
+        _bakingCommission <- v .: "passiveBakingCommission"
+        _transactionCommission <- v .: "passiveTransactionCommission"
+        _finalizationCommissionRange <- v .: "finalizationCommissionRange"
+        _bakingCommissionRange <- v .: "bakingCommissionRange"
+        _transactionCommissionRange <- v .: "transactionCommissionRange"
+        _ppMinimumEquityCapital <- v .: "minimumEquityCapital"
+        _ppCapitalBound <- v .: "capitalBound"
+        _ppLeverageBound <- v .: "leverageBound"
+        _tpRewardPeriodLength <- v .: "rewardPeriodLength"
+        _tpMintPerPayday <- v .: "mintPerPayday"
+        _tpTimeoutBase <- v .: "timeoutBase"
+        _tpTimeoutIncrease <- v .: "timeoutIncrease"
+        _tpTimeoutDecrease <- v .: "timeoutDecrease"
+        _cpMinBlockTime <- v .: "minBlockTime"
+        _cpBlockEnergyLimit <- v .: "blockEnergyLimit"
+        _fcpMinFinalizers <- v .: "minimumFinalizers"
+        _fcpMaxFinalizers <- v .: "maximumFinalizers"
+        _fcpFinalizerRelativeStakeThreshold <- v .: "finalizerRelativeStakeThreshold"
+        let gcpCooldownParameters = CooldownParametersV1{..}
+            gcpTimeParameters = SomeParam TimeParametersV1{..}
+            gcpPoolParameters = PoolParametersV1{..}
+            gcpExchangeRates = makeExchangeRates _erEuroPerEnergy _erMicroGTUPerEuro
+            _ppPassiveCommissions = CommissionRates{..}
+            _ppCommissionBounds = CommissionRanges{..}
+            _cpTimeoutParameters = TimeoutParameters{..}
+            gcpFinalizationCommitteeParameters = SomeParam FinalizationCommitteeParameters{..}
+            gcpConsensusParameters = ConsensusParametersV1{..}
+        return GenesisChainParameters{..}
+
+-- | Parse 'GenesisChainParameters' from JSON for 'ChainParametersV2'.
+parseJSONForGCPV3 :: Value -> Parser (GenesisChainParameters' 'ChainParametersV3)
+parseJSONForGCPV3 =
     withObject "GenesisChainParametersV2" $ \v -> do
         _erEuroPerEnergy <- v .: "euroPerEnergy"
         _erMicroGTUPerEuro <- v .: "microGTUPerEuro"

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -113,6 +113,7 @@ type family AccountStructureVersionFor (av :: AccountVersion) :: AccountStructur
     AccountStructureVersionFor 'AccountV1 = 'AccountStructureV0
     AccountStructureVersionFor 'AccountV2 = 'AccountStructureV1
     AccountStructureVersionFor 'AccountV3 = 'AccountStructureV1
+    AccountStructureVersionFor 'AccountV4 = 'AccountStructureV1
 
 -- | The 'BakerId' of a baker and its public keys.
 data BakerInfo = BakerInfo
@@ -466,6 +467,11 @@ accountStakeNoneHashV3 :: AccountStakeHash 'AccountV3
 {-# NOINLINE accountStakeNoneHashV3 #-}
 accountStakeNoneHashV3 = AccountStakeHash $ Hash.hash "A3NoStake"
 
+-- | Hash of 'AccountStakeNone' in 'AccountV4'.
+accountStakeNoneHashV4 :: AccountStakeHash 'AccountV4
+{-# NOINLINE accountStakeNoneHashV4 #-}
+accountStakeNoneHashV4 = AccountStakeHash $ Hash.hash "A4NoStake"
+
 -- | The 'AccountV2' hashing of 'AccountStake' DOES NOT INCLUDE the staked amount.
 --  This is since the stake is accounted for separately in the @AccountHash@.
 instance HashableTo (AccountStakeHash 'AccountV2) (AccountStake 'AccountV2) where
@@ -516,6 +522,32 @@ instance HashableTo (AccountStakeHash 'AccountV3) (AccountStake 'AccountV3) wher
                             put _delegationTarget
                         )
 
+-- | The 'AccountV3' hashing of 'AccountStake' DOES NOT INCLUDE the staked amount.
+--  This is since the stake is accounted for separately in the @AccountHash@.
+instance HashableTo (AccountStakeHash 'AccountV4) (AccountStake 'AccountV4) where
+    getHash AccountStakeNone = accountStakeNoneHashV4
+    getHash (AccountStakeBaker AccountBaker{..}) =
+        AccountStakeHash $
+            Hash.hashLazy $
+                "A4Baker"
+                    <> runPutLazy
+                        ( do
+                            put _stakeEarnings
+                            put _accountBakerInfo
+                            put _bakerPendingChange
+                        )
+    getHash (AccountStakeDelegate AccountDelegationV1{..}) =
+        AccountStakeHash $
+            Hash.hashLazy $
+                "A4Delegation"
+                    <> runPutLazy
+                        ( do
+                            put _delegationIdentity
+                            put _delegationStakeEarnings
+                            put _delegationTarget
+                            put _delegationPendingChange
+                        )
+
 -- | Get the 'AccountStakeHash' from an 'AccountStake' for any account version.
 getAccountStakeHash :: forall av. (IsAccountVersion av) => AccountStake av -> AccountStakeHash av
 getAccountStakeHash = case accountVersion @av of
@@ -523,6 +555,7 @@ getAccountStakeHash = case accountVersion @av of
     SAccountV1 -> getHash
     SAccountV2 -> getHash
     SAccountV3 -> getHash
+    SAccountV4 -> getHash
 
 -- | A representation type (used for queries) for the staking status of an account.
 --  This representation is agnostic to the protocol version and represents pending change times

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -522,7 +522,7 @@ instance HashableTo (AccountStakeHash 'AccountV3) (AccountStake 'AccountV3) wher
                             put _delegationTarget
                         )
 
--- | The 'AccountV3' hashing of 'AccountStake' DOES NOT INCLUDE the staked amount.
+-- | The 'AccountV4' hashing of 'AccountStake' DOES NOT INCLUDE the staked amount.
 --  This is since the stake is accounted for separately in the @AccountHash@.
 instance HashableTo (AccountStakeHash 'AccountV4) (AccountStake 'AccountV4) where
     getHash AccountStakeNone = accountStakeNoneHashV4

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -157,7 +157,7 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
 migrateChainParameters StateMigrationParametersP6ToP7{} cps = cps
 -- TODO (drsk) Chain parameters will change in P8
-migrateChainParameters StateMigrationParametersP7ToP8{} _cps = error "define migration from chain parameters p7 to p8"
+migrateChainParameters StateMigrationParametersP7ToP8{} _cps = error "TODO (drsk). github issue#545. Define migration from chain parameters p7 to p8."
 
 -- | Migrate time of the effective change from V0 to V1 accounts. Currently this
 --  translates times relative to genesis to times relative to the unix epoch.

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -186,4 +186,4 @@ migrateStakePendingChange (StateMigrationParametersP3ToP4 migration) = \case
 migrateStakePendingChange StateMigrationParametersP4ToP5 = fmap coercePendingChangeEffectiveV1
 migrateStakePendingChange StateMigrationParametersP5ToP6{} = id
 migrateStakePendingChange StateMigrationParametersP6ToP7{} = const NoChange
-migrateStakePendingChange StateMigrationParametersP7ToP8{} = id
+migrateStakePendingChange StateMigrationParametersP7ToP8{} = const NoChange

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -36,6 +36,7 @@ migrateAuthorizations StateMigrationParametersP4ToP5 auths = auths
 -- are carried over to consensus parameters v1.
 migrateAuthorizations StateMigrationParametersP5ToP6{} auths = auths
 migrateAuthorizations StateMigrationParametersP6ToP7{} auths = auths
+migrateAuthorizations StateMigrationParametersP7ToP8{} auths = auths
 
 -- | Apply a state migration to an 'UpdateKeysCollection' structure.
 --
@@ -64,6 +65,7 @@ migrateMintDistribution StateMigrationParametersP3ToP4{} MintDistribution{..} =
 migrateMintDistribution StateMigrationParametersP4ToP5 mint = mint
 migrateMintDistribution StateMigrationParametersP5ToP6{} mint = mint
 migrateMintDistribution StateMigrationParametersP6ToP7{} mint = mint
+migrateMintDistribution StateMigrationParametersP7ToP8{} mint = mint
 
 -- | Apply a state migration to a 'PoolParameters' structure.
 --
@@ -81,6 +83,8 @@ migratePoolParameters (StateMigrationParametersP3ToP4 migration) _ =
 migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
 migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
 migratePoolParameters StateMigrationParametersP6ToP7{} poolParams = poolParams
+-- TODO (drsk) this might need to change with new pool parameters in P8
+migratePoolParameters StateMigrationParametersP7ToP8{} poolParams = poolParams
 
 -- | Apply a state migration to a 'GASRewards' structure.
 --
@@ -98,6 +102,7 @@ migrateGASRewards StateMigrationParametersP3ToP4{} gr = gr
 migrateGASRewards StateMigrationParametersP4ToP5 gr = gr
 migrateGASRewards StateMigrationParametersP5ToP6{} GASRewards{..} = GASRewards{_gasFinalizationProof = CFalse, ..}
 migrateGASRewards StateMigrationParametersP6ToP7{} gr = gr
+migrateGASRewards StateMigrationParametersP7ToP8{} gr = gr
 
 -- | Apply a state migration to a 'ChainParameters' structure.
 --
@@ -152,6 +157,8 @@ migrateChainParameters m@(StateMigrationParametersP5ToP6 migration) ChainParamet
     RewardParameters{..} = _cpRewardParameters
     finalizationCommitteeParameters = P6.updateFinalizationCommitteeParameters $ P6.migrationProtocolUpdateData migration
 migrateChainParameters StateMigrationParametersP6ToP7{} cps = cps
+-- TODO (drsk) Chain parameters will change in P8
+migrateChainParameters StateMigrationParametersP7ToP8{} _cps = error "define migration from chain parameters p7 to p8"
 
 -- | Migrate time of the effective change from V0 to V1 accounts. Currently this
 --  translates times relative to genesis to times relative to the unix epoch.
@@ -180,3 +187,4 @@ migrateStakePendingChange (StateMigrationParametersP3ToP4 migration) = \case
 migrateStakePendingChange StateMigrationParametersP4ToP5 = fmap coercePendingChangeEffectiveV1
 migrateStakePendingChange StateMigrationParametersP5ToP6{} = id
 migrateStakePendingChange StateMigrationParametersP6ToP7{} = const NoChange
+migrateStakePendingChange StateMigrationParametersP7ToP8{} = id

--- a/haskell-src/Concordium/Types/Migration.hs
+++ b/haskell-src/Concordium/Types/Migration.hs
@@ -83,8 +83,7 @@ migratePoolParameters (StateMigrationParametersP3ToP4 migration) _ =
 migratePoolParameters StateMigrationParametersP4ToP5 poolParams = poolParams
 migratePoolParameters StateMigrationParametersP5ToP6{} poolParams = poolParams
 migratePoolParameters StateMigrationParametersP6ToP7{} poolParams = poolParams
--- TODO (drsk) this might need to change with new pool parameters in P8
-migratePoolParameters StateMigrationParametersP7ToP8{} poolParams = poolParams
+migratePoolParameters StateMigrationParametersP7ToP8{} _poolParams = error "TODO (drsk) github issue #544. Implement pool parameter migration p7->p8."
 
 -- | Apply a state migration to a 'GASRewards' structure.
 --

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -217,6 +217,7 @@ module Concordium.Types.ProtocolVersion (
     P5Sym0,
     P6Sym0,
     P7Sym0,
+    P8Sym0,
 ) where
 
 import Control.Monad.Except (ExceptT)
@@ -245,12 +246,14 @@ $( singletons
             | P5
             | P6
             | P7
+            | P8
             deriving (Eq, Ord)
 
         data ChainParametersVersion
             = ChainParametersV0
             | ChainParametersV1
             | ChainParametersV2
+            | ChainParametersV3
             deriving (Eq, Ord)
 
         chainParametersVersionFor :: ProtocolVersion -> ChainParametersVersion
@@ -261,6 +264,7 @@ $( singletons
         chainParametersVersionFor P5 = ChainParametersV1
         chainParametersVersionFor P6 = ChainParametersV2
         chainParametersVersionFor P7 = ChainParametersV2
+        chainParametersVersionFor P8 = ChainParametersV3
 
         -- \* Account versions
 
@@ -276,6 +280,8 @@ $( singletons
               AccountV2
             | -- \|Account version used from P7. Modifies stake cooldown.
               AccountV3
+            | -- \|Account version used in P8. Adds suspension of inactive validators.
+              AccountV4
 
         -- \|'AccountVersion' associated with a 'ProtocolVersion'.
         accountVersionFor :: ProtocolVersion -> AccountVersion
@@ -286,6 +292,7 @@ $( singletons
         accountVersionFor P5 = AccountV2
         accountVersionFor P6 = AccountV2
         accountVersionFor P7 = AccountV3
+        accountVersionFor P8 = AccountV4
 
         -- \|Transaction outcomes versions.
         -- The difference between the two versions are only related
@@ -310,18 +317,21 @@ $( singletons
         transactionOutcomesVersionFor P5 = TOV1
         transactionOutcomesVersionFor P6 = TOV1
         transactionOutcomesVersionFor P7 = TOV2
+        transactionOutcomesVersionFor P8 = TOV2
 
         supportsDelegation :: AccountVersion -> Bool
         supportsDelegation AccountV0 = False
         supportsDelegation AccountV1 = True
         supportsDelegation AccountV2 = True
         supportsDelegation AccountV3 = True
+        supportsDelegation AccountV4 = True
 
         supportsFlexibleCooldown :: AccountVersion -> Bool
         supportsFlexibleCooldown AccountV0 = False
         supportsFlexibleCooldown AccountV1 = False
         supportsFlexibleCooldown AccountV2 = False
         supportsFlexibleCooldown AccountV3 = True
+        supportsFlexibleCooldown AccountV4 = True
 
         -- \| A type representing the different hashing structures used for the block hash depending on
         -- the protocol version.
@@ -340,6 +350,7 @@ $( singletons
         blockHashVersionFor P5 = BlockHashVersion0
         blockHashVersionFor P6 = BlockHashVersion0
         blockHashVersionFor P7 = BlockHashVersion1
+        blockHashVersionFor P8 = BlockHashVersion1
 
         -- \| Whether the block state hash is tracked as part of the block metadata.
         blockStateHashInMetadata :: BlockHashVersion -> Bool
@@ -364,6 +375,7 @@ protocolVersionToWord64 P4 = 4
 protocolVersionToWord64 P5 = 5
 protocolVersionToWord64 P6 = 6
 protocolVersionToWord64 P7 = 7
+protocolVersionToWord64 P8 = 8
 
 -- | Parse a 'Word64' as a 'ProtocolVersion'.
 protocolVersionFromWord64 :: (MonadFail m) => Word64 -> m ProtocolVersion
@@ -374,6 +386,7 @@ protocolVersionFromWord64 4 = return P4
 protocolVersionFromWord64 5 = return P5
 protocolVersionFromWord64 6 = return P6
 protocolVersionFromWord64 7 = return P7
+protocolVersionFromWord64 8 = return P8
 protocolVersionFromWord64 v = fail $ "Unknown protocol version: " ++ show v
 
 -- | Convert a @ChainParametersVersion@ to the corresponding 'Word64'.
@@ -381,6 +394,7 @@ chainParameterVersionToWord64 :: ChainParametersVersion -> Word64
 chainParameterVersionToWord64 ChainParametersV0 = 0
 chainParameterVersionToWord64 ChainParametersV1 = 1
 chainParameterVersionToWord64 ChainParametersV2 = 2
+chainParameterVersionToWord64 ChainParametersV3 = 3
 
 instance Serialize ProtocolVersion where
     put = putWord64be . protocolVersionToWord64
@@ -408,6 +422,7 @@ promoteProtocolVersion P4 = SomeProtocolVersion SP4
 promoteProtocolVersion P5 = SomeProtocolVersion SP5
 promoteProtocolVersion P6 = SomeProtocolVersion SP6
 promoteProtocolVersion P7 = SomeProtocolVersion SP7
+promoteProtocolVersion P8 = SomeProtocolVersion SP8
 
 -- | Demote an 'SProtocolVersion' to a 'ProtocolVersion'.
 demoteProtocolVersion :: SProtocolVersion pv -> ProtocolVersion
@@ -520,6 +535,7 @@ delegationSupport = case accountVersion @av of
     SAccountV1 -> SAVDelegationSupported
     SAccountV2 -> SAVDelegationSupported
     SAccountV3 -> SAVDelegationSupported
+    SAccountV4 -> SAVDelegationSupported
 
 -- | Whether the protocol supports delegation functionality.
 protocolSupportsDelegation :: SProtocolVersion pv -> Bool
@@ -549,6 +565,7 @@ supportsMemo SP4 = True
 supportsMemo SP5 = True
 supportsMemo SP6 = True
 supportsMemo SP7 = True
+supportsMemo SP8 = True
 
 -- | Whether the protocol version supports account aliases.
 --  (Account aliases are supported in 'P3' onwards.)
@@ -560,6 +577,7 @@ supportsAccountAliases SP4 = True
 supportsAccountAliases SP5 = True
 supportsAccountAliases SP6 = True
 supportsAccountAliases SP7 = True
+supportsAccountAliases SP8 = True
 
 -- | Whether the protocol version supports V1 smart contracts.
 --  (V1 contracts are supported in 'P4' onwards.)
@@ -571,6 +589,7 @@ supportsV1Contracts SP4 = True
 supportsV1Contracts SP5 = True
 supportsV1Contracts SP6 = True
 supportsV1Contracts SP7 = True
+supportsV1Contracts SP8 = True
 
 -- | Whether the protocol version supports delegation.
 --  (Delegation is supported in 'P4' onwards.)
@@ -578,7 +597,11 @@ supportsDelegationPV :: SProtocolVersion pv -> Bool
 supportsDelegationPV SP1 = False
 supportsDelegationPV SP2 = False
 supportsDelegationPV SP3 = False
-supportsDelegationPV _ = True
+supportsDelegationPV SP4 = True
+supportsDelegationPV SP5 = True
+supportsDelegationPV SP6 = True
+supportsDelegationPV SP7 = True
+supportsDelegationPV SP8 = True
 
 -- | Whether the protocol version supports upgradable smart contracts.
 --  (Supported in 'P5' and onwards)
@@ -591,6 +614,7 @@ supportsUpgradableContracts spv = case spv of
     SP5 -> True
     SP6 -> True
     SP7 -> True
+    SP8 -> True
 
 -- | Whether the protocol version supports chain queries in smart contracts.
 --  (Supported in 'P5' and onwards)
@@ -603,6 +627,7 @@ supportsChainQueryContracts spv = case spv of
     SP5 -> True
     SP6 -> True
     SP7 -> True
+    SP8 -> True
 
 -- | Whether the protocol version supports sign extension instructions for V1
 --  contracts. (Supported in 'P6' and onwards)
@@ -615,6 +640,7 @@ supportsSignExtensionInstructions spv = case spv of
     SP5 -> False
     SP6 -> True
     SP7 -> True
+    SP8 -> True
 
 -- | Whether the protocol version allows globals in data and element sections of
 --  Wasm modules for V1 contracts. (Supported before 'P6')
@@ -627,6 +653,7 @@ supportsGlobalsInInitSections spv = case spv of
     SP5 -> True
     SP6 -> False
     SP7 -> False
+    SP8 -> False
 
 -- | Whether the protocol version specifies that custom section should not be
 --  counted towards module size when executing V1 contracts.
@@ -645,6 +672,7 @@ supportsAccountSignatureChecks spv = case spv of
     SP5 -> False
     SP6 -> True
     SP7 -> True
+    SP8 -> True
 
 -- | Whether the protocol version supports querying a smart contract's module reference and name
 --  from smart contracts.
@@ -658,6 +686,7 @@ supportsContractInspectionQueries = \case
     SP5 -> False
     SP6 -> False
     SP7 -> True
+    SP8 -> True
 
 -- | Whether the protocol version supports encrypting balances and sending encrypted transfers.
 --  (Disabled in 'P7' and onwards.)
@@ -669,4 +698,5 @@ supportsEncryptedTransfers = \case
     SP4 -> True
     SP5 -> True
     SP6 -> True
-    _ -> False
+    SP7 -> False
+    SP8 -> False

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -762,6 +762,12 @@ instance ToJSON EChainParametersAndKeys where
                       "parameters" .= toJSON params,
                       "updateKeys" .= toJSON keys
                     ]
+            SChainParametersV3 ->
+                object
+                    [ "version" .= toJSON ChainParametersV3,
+                      "parameters" .= toJSON params,
+                      "updateKeys" .= toJSON keys
+                    ]
 
 -- | The committee information of a node which is configured with
 --  baker keys but is somehow is _not_ part of the current baking

--- a/haskell-src/Concordium/Types/SeedState.hs
+++ b/haskell-src/Concordium/Types/SeedState.hs
@@ -38,6 +38,7 @@ $( singletons
         seedStateVersionFor P5 = SeedStateVersion0
         seedStateVersionFor P6 = SeedStateVersion1
         seedStateVersionFor P7 = SeedStateVersion1
+        seedStateVersionFor P8 = SeedStateVersion1
 
         supportsEpochLength :: SeedStateVersion -> Bool
         supportsEpochLength SeedStateVersion0 = True

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -193,6 +193,7 @@ pvCostSemanticsVersion = \case
     SP5 -> CSV0
     SP6 -> CSV0
     SP7 -> CSV1
+    SP8 -> CSV1
 
 -- | Convert the version to a Word8. This is used when transferring information
 --  via FFI.

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -477,6 +477,19 @@ genChainParametersV2 = do
     _cpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
     return ChainParameters{..}
 
+genChainParametersV3 :: Gen (ChainParameters' 'ChainParametersV3)
+genChainParametersV3 = do
+    _cpConsensusParameters <- genConsensusParametersV1
+    _cpExchangeRates <- genExchangeRates
+    _cpCooldownParameters <- genCooldownParametersV1
+    _cpTimeParameters <- SomeParam <$> genTimeParametersV1
+    _cpAccountCreationLimit <- arbitrary
+    _cpRewardParameters <- genRewardParameters
+    _cpFoundationAccount <- AccountIndex <$> arbitrary
+    _cpPoolParameters <- genPoolParametersV1
+    _cpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
+    return ChainParameters{..}
+
 genGenesisChainParametersV0 :: Gen (GenesisChainParameters' 'ChainParametersV0)
 genGenesisChainParametersV0 = do
     gcpConsensusParameters <- ConsensusParametersV0 <$> genElectionDifficulty
@@ -505,6 +518,19 @@ genGenesisChainParametersV1 = do
 
 genGenesisChainParametersV2 :: Gen (GenesisChainParameters' 'ChainParametersV2)
 genGenesisChainParametersV2 = do
+    gcpConsensusParameters <- genConsensusParametersV1
+    gcpExchangeRates <- genExchangeRates
+    gcpCooldownParameters <- genCooldownParametersV1
+    gcpTimeParameters <- SomeParam <$> genTimeParametersV1
+    gcpAccountCreationLimit <- arbitrary
+    gcpRewardParameters <- genRewardParameters
+    gcpFoundationAccount <- genAccountAddress
+    gcpPoolParameters <- genPoolParametersV1
+    gcpFinalizationCommitteeParameters <- SomeParam <$> genFinalizationCommitteeParameters
+    return GenesisChainParameters{..}
+
+genGenesisChainParametersV3 :: Gen (GenesisChainParameters' 'ChainParametersV3)
+genGenesisChainParametersV3 = do
     gcpConsensusParameters <- genConsensusParametersV1
     gcpExchangeRates <- genExchangeRates
     gcpCooldownParameters <- genCooldownParametersV1
@@ -1004,6 +1030,7 @@ genRootUpdate scpv =
             SChainParametersV0 -> Level2KeysRootUpdate <$> genAuthorizations
             SChainParametersV1 -> Level2KeysRootUpdateV1 <$> genAuthorizations
             SChainParametersV2 -> Level2KeysRootUpdateV1 <$> genAuthorizations
+            SChainParametersV3 -> Level2KeysRootUpdateV1 <$> genAuthorizations
         ]
 
 genLevel1Update :: (IsChainParametersVersion cpv) => SChainParametersVersion cpv -> Gen Level1Update
@@ -1014,6 +1041,7 @@ genLevel1Update scpv =
             SChainParametersV0 -> Level2KeysLevel1Update <$> genAuthorizations
             SChainParametersV1 -> Level2KeysLevel1UpdateV1 <$> genAuthorizations
             SChainParametersV2 -> Level2KeysLevel1UpdateV1 <$> genAuthorizations
+            SChainParametersV3 -> Level2KeysLevel1UpdateV1 <$> genAuthorizations
         ]
 
 genLevel2UpdatePayload :: SChainParametersVersion cpv -> Gen UpdatePayload
@@ -1046,6 +1074,22 @@ genLevel2UpdatePayload scpv =
                   TimeParametersCPV1UpdatePayload <$> genTimeParametersV1
                 ]
         SChainParametersV2 ->
+            oneof
+                [ ProtocolUpdatePayload <$> genProtocolUpdate,
+                  EuroPerEnergyUpdatePayload <$> genExchangeRate,
+                  MicroGTUPerEuroUpdatePayload <$> genExchangeRate,
+                  FoundationAccountUpdatePayload <$> genAccountAddress,
+                  MintDistributionCPV1UpdatePayload <$> genMintDistribution,
+                  TransactionFeeDistributionUpdatePayload <$> genTransactionFeeDistribution,
+                  CooldownParametersCPV1UpdatePayload <$> genCooldownParametersV1,
+                  PoolParametersCPV1UpdatePayload <$> genPoolParametersV1,
+                  TimeParametersCPV1UpdatePayload <$> genTimeParametersV1,
+                  TimeoutParametersUpdatePayload <$> genTimeoutParameters,
+                  MinBlockTimeUpdatePayload <$> genDuration,
+                  BlockEnergyLimitUpdatePayload . Energy <$> arbitrary,
+                  GASRewardsCPV2UpdatePayload <$> genGASRewards
+                ]
+        SChainParametersV3 ->
             oneof
                 [ ProtocolUpdatePayload <$> genProtocolUpdate,
                   EuroPerEnergyUpdatePayload <$> genExchangeRate,

--- a/haskell-tests/Genesis/ParametersSpec.hs
+++ b/haskell-tests/Genesis/ParametersSpec.hs
@@ -32,6 +32,12 @@ checkJSONToFromIsIdentityV2 cp = do
         AE.Error err -> counterexample err False
         AE.Success jsonCp -> cp === jsonCp
 
+checkJSONToFromIsIdentityV3 :: GenesisChainParameters' 'ChainParametersV3 -> Property
+checkJSONToFromIsIdentityV3 cp = do
+    case AE.fromJSON (AE.toJSON cp) of
+        AE.Error err -> counterexample err False
+        AE.Success jsonCp -> cp === jsonCp
+
 testJSON :: ChainParametersVersion -> Int -> Int -> Spec
 testJSON cpv size num =
     modifyMaxSuccess (const num) $
@@ -43,6 +49,8 @@ testJSON cpv size num =
                     forAll (resize size genGenesisChainParametersV1) checkJSONToFromIsIdentityV1
                 ChainParametersV2 ->
                     forAll (resize size genGenesisChainParametersV2) checkJSONToFromIsIdentityV2
+                ChainParametersV3 ->
+                    forAll (resize size genGenesisChainParametersV3) checkJSONToFromIsIdentityV3
 
 tests :: Spec
 tests = do
@@ -53,3 +61,4 @@ tests = do
         testJSON ChainParametersV1 50 500
         testJSON ChainParametersV2 25 1000
         testJSON ChainParametersV2 50 500
+        testJSON ChainParametersV3 50 500

--- a/haskell-tests/Types/ParametersSpec.hs
+++ b/haskell-tests/Types/ParametersSpec.hs
@@ -31,6 +31,7 @@ testSerialization cpv size num =
                 ChainParametersV0 -> forAll (resize size genChainParametersV0) (checkPutGetIsIdentity SP1)
                 ChainParametersV1 -> forAll (resize size genChainParametersV1) (checkPutGetIsIdentity SP4)
                 ChainParametersV2 -> forAll (resize size genChainParametersV2) (checkPutGetIsIdentity SP6)
+                ChainParametersV3 -> forAll (resize size genChainParametersV3) (checkPutGetIsIdentity SP8)
 
 checkJSONToFromIsIdentityV0 :: ChainParameters' 'ChainParametersV0 -> Property
 checkJSONToFromIsIdentityV0 cp = do
@@ -50,6 +51,12 @@ checkJSONToFromIsIdentityV2 cp = do
         AE.Error err -> counterexample err False
         AE.Success jsonCp -> cp === jsonCp
 
+checkJSONToFromIsIdentityV3 :: ChainParameters' 'ChainParametersV3 -> Property
+checkJSONToFromIsIdentityV3 cp = do
+    case AE.fromJSON (AE.toJSON cp) of
+        AE.Error err -> counterexample err False
+        AE.Success jsonCp -> cp === jsonCp
+
 testJSON :: ChainParametersVersion -> Int -> Int -> Spec
 testJSON cpv size num =
     modifyMaxSuccess (const num) $
@@ -58,6 +65,7 @@ testJSON cpv size num =
                 ChainParametersV0 -> forAll (resize size genChainParametersV0) checkJSONToFromIsIdentityV0
                 ChainParametersV1 -> forAll (resize size genChainParametersV1) checkJSONToFromIsIdentityV1
                 ChainParametersV2 -> forAll (resize size genChainParametersV2) checkJSONToFromIsIdentityV2
+                ChainParametersV3 -> forAll (resize size genChainParametersV3) checkJSONToFromIsIdentityV3
 
 tests :: Spec
 tests = do
@@ -68,6 +76,8 @@ tests = do
         testSerialization ChainParametersV1 50 500
         testSerialization ChainParametersV2 25 1000
         testSerialization ChainParametersV2 50 500
+        testSerialization ChainParametersV3 25 1000
+        testSerialization ChainParametersV3 50 500
     describe "ChainParameters JSON tests" $ do
         testJSON ChainParametersV0 25 1000
         testJSON ChainParametersV0 50 500
@@ -75,3 +85,5 @@ tests = do
         testJSON ChainParametersV1 50 500
         testJSON ChainParametersV2 25 1000
         testJSON ChainParametersV2 50 500
+        testJSON ChainParametersV3 25 1000
+        testJSON ChainParametersV3 50 500

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -165,12 +165,15 @@ tests = do
         test SP6 50 500
         test SP7 25 1000
         test SP7 50 500
+        test SP8 50 500
     describe "Negative payload serialization tests" $ do
         negativeTest SP4 20 200
         negativeTest SP6 20 200
         negativeTest SP7 20 200
+        negativeTest SP8 20 200
         negativeTestPadded SP6 20 200
         negativeTestPadded SP7 20 200
+        negativeTestPadded SP8 20 200
     describe "Encrypted transfer payloads P6" $ do
         specify "Encrypted transfer" $ testSerializeEncryptedTransfer SP6
         specify "Encrypted transfer with memo" $ testSerializeEncryptedTransferWithMemo SP6
@@ -179,8 +182,12 @@ tests = do
         specify "Encrypted transfer" $ testSerializeEncryptedTransfer SP7
         specify "Encrypted transfer with memo" $ testSerializeEncryptedTransferWithMemo SP7
         specify "Transfer to public" $ testSecToPubTransfer SP7
+    describe "Encrypted transfer payloads P8" $ do
+        specify "Encrypted transfer" $ testSerializeEncryptedTransfer SP8
+        specify "Encrypted transfer with memo" $ testSerializeEncryptedTransferWithMemo SP8
+        specify "Transfer to public" $ testSecToPubTransfer SP8
     describe "Unsafe payload serialization tests" $ do
-        forM_ [P1, P2, P3, P4, P5, P6, P7] $ \pv -> do
+        forM_ [P1, P2, P3, P4, P5, P6, P7, P8] $ \pv -> do
             case promoteProtocolVersion pv of
                 (SomeProtocolVersion spv) -> testUnsafe spv 25 1000
   where

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -49,7 +49,9 @@ tests = describe "Transaction summaries" $ do
     versionedTests SP2
     versionedTests SP3
     versionedTests SP4
-    -- TODO(drsk) check back why there are no tests for the other protocol versions.
+    versionedTests SP5
+    versionedTests SP6
+    versionedTests SP7
     versionedTests SP8
   where
     versionedTests spv = describe (show $ demoteProtocolVersion spv) $ do

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -49,6 +49,8 @@ tests = describe "Transaction summaries" $ do
     versionedTests SP2
     versionedTests SP3
     versionedTests SP4
+    -- TODO(drsk) check back why there are no tests for the other protocol versions.
+    versionedTests SP8
   where
     versionedTests spv = describe (show $ demoteProtocolVersion spv) $ do
         specify "Event: serialize then deserialize is identity" $ withMaxSuccess 10000 $ testEventSerializationIdentity spv

--- a/haskell-tests/Types/UpdatesSpec.hs
+++ b/haskell-tests/Types/UpdatesSpec.hs
@@ -138,6 +138,7 @@ tests = parallel $ do
     specify "UpdatePayload JSON in CP0" $ withMaxSuccess 1000 $ testJSONUpdatePayload SChainParametersV0
     specify "UpdatePayload JSON in CP1" $ withMaxSuccess 1000 $ testJSONUpdatePayload SChainParametersV1
     specify "UpdatePayload JSON in CP2" $ withMaxSuccess 1000 $ testJSONUpdatePayload SChainParametersV2
+    specify "UpdatePayload JSON in CP3" $ withMaxSuccess 1000 $ testJSONUpdatePayload SChainParametersV3
     versionedTests SP1
     versionedTests SP2
     versionedTests SP3
@@ -145,6 +146,7 @@ tests = parallel $ do
     versionedTests SP5
     versionedTests SP6
     versionedTests SP7
+    versionedTests SP8
   where
     versionedTests spv = describe (show $ demoteProtocolVersion spv) $ do
         specify "UpdatePayload serialization" $ withMaxSuccess 1000 $ testSerializeUpdatePayload spv


### PR DESCRIPTION
## Purpose

This adds the boilerplate code for protocol version 8. Note that there is no difference currently between protocol version 7 and 8. We need a new account version, as well as a new chain parameters version to incorporate the planned changes for the suspension of inactive validators coming in protocol version 8.

## Changes

Boilerplate and tests are added for a new protocol version, account version and chain parameter version.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
