### PR TITLE
`AccountIsSuspended` flag for `AccountInfo`

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -619,6 +619,7 @@ instance ToProto AccountInfo where
         ProtoFields.maybe'stake .= toProto aiStakingInfo
         ProtoFields.cooldowns .= fmap toProto aiAccountCooldowns
         ProtoFields.availableBalance .= toProto aiAccountAvailableAmount
+        ProtoFields.isSuspended .= aiAccountIsSuspended
 
 instance ToProto Wasm.Parameter where
     type Output Wasm.Parameter = Proto.Parameter

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -731,7 +731,9 @@ data AccountInfo = AccountInfo
       --  pre-cooldown or pre-pre-cooldown (e.g. if the cooldown interval has been decreased).
       aiAccountCooldowns :: ![Cooldown],
       -- | The balance of the account that is available for transactions.
-      aiAccountAvailableAmount :: !Amount
+      aiAccountAvailableAmount :: !Amount,
+      -- | Flag indicating whether the account is currently suspended.
+      aiAccountIsSuspended :: !Bool
     }
     deriving (Eq, Show)
 
@@ -749,7 +751,8 @@ accountInfoPairs AccountInfo{..} =
       "accountIndex" .= aiAccountIndex,
       "accountAddress" .= aiAccountAddress,
       "accountCooldowns" .= aiAccountCooldowns,
-      "accountAvailableAmount" .= aiAccountAvailableAmount
+      "accountAvailableAmount" .= aiAccountAvailableAmount,
+      "accountIsSuspended" .= aiAccountIsSuspended
     ]
         <> accountStakingInfoToJSON aiStakingInfo
 


### PR DESCRIPTION
This adds the `AccountIsSuspended` flag to the `AccountInfo` to signal when a account has been suspended. This is central to the suspended validator project NOD-599.