### PR TITLE
Add conversion helper

### DIFF
--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased changes
 
-- Add `TryFrom` implementation to convert `&[u8]` to `AccountAddress`.
+- Add `TryFrom` implementation to convert `&[u8]` to `AccountAddress`, when feature `derive-serde` is enabled.
 - Derive `serde::Serialize` and `serde::Serialize` for `PublicKeyEd25519` using
   `FromStr` and `Display` implementations, when feature `derive-serde` is
   enabled.

--- a/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
+++ b/smart-contracts/contracts-common/concordium-contracts-common/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Add `TryFrom` implementation to convert `&[u8]` to `AccountAddress`.
 - Derive `serde::Serialize` and `serde::Serialize` for `PublicKeyEd25519` using
   `FromStr` and `Display` implementations, when feature `derive-serde` is
   enabled.

--- a/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
+++ b/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
@@ -79,7 +79,7 @@ std = ["fnv/std"]
 wasm-test = ["concordium-contracts-common-derive/wasm-test"]
 build-schema = ["concordium-contracts-common-derive/build-schema"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common-derive/concordium-quickcheck"]
-derive-serde = ["serde", "serde_json", "bs58", "std", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
+derive-serde = ["serde", "serde_json", "std", "bs58", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
 fuzz = ["derive-serde", "arbitrary"]
 smart-contract = []
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
+++ b/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
@@ -40,6 +40,7 @@ optional = true
 version = "0.4.35" # the patch version is necessary since chrono adds new functionality in patch versions
 
 [dependencies.bs58]
+optional = true
 version = "0.5"
 features = ["check"]
 
@@ -78,7 +79,7 @@ std = ["fnv/std"]
 wasm-test = ["concordium-contracts-common-derive/wasm-test"]
 build-schema = ["concordium-contracts-common-derive/build-schema"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common-derive/concordium-quickcheck"]
-derive-serde = ["serde", "serde_json", "std", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
+derive-serde = ["serde", "serde_json", "bs58", "std", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
 fuzz = ["derive-serde", "arbitrary"]
 smart-contract = []
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
+++ b/smart-contracts/contracts-common/concordium-contracts-common/Cargo.toml
@@ -40,7 +40,6 @@ optional = true
 version = "0.4.35" # the patch version is necessary since chrono adds new functionality in patch versions
 
 [dependencies.bs58]
-optional = true
 version = "0.5"
 features = ["check"]
 
@@ -79,7 +78,7 @@ std = ["fnv/std"]
 wasm-test = ["concordium-contracts-common-derive/wasm-test"]
 build-schema = ["concordium-contracts-common-derive/build-schema"]
 concordium-quickcheck = ["getrandom", "quickcheck", "concordium-contracts-common-derive/concordium-quickcheck"]
-derive-serde = ["serde", "serde_json", "std", "bs58", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
+derive-serde = ["serde", "serde_json", "std", "chrono", "num-bigint", "num-traits", "num-integer", "rust_decimal", "thiserror", "hex"]
 fuzz = ["derive-serde", "arbitrary"]
 smart-contract = []
 

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -2719,7 +2719,7 @@ mod serde_impl {
         /// Failed parsing the Base58Check encoding.
         #[error("Invalid Base58Check encoding: {0}")]
         InvalidBase58Check(#[from] bs58::decode::Error),
-        /// The decoded bytes are not of length ACCOUNT_ADDRESS_SIZE.
+        /// The decoded bytes are not of length [`ACCOUNT_ADDRESS_SIZE`].
         #[error("Invalid number of bytes, expected {ACCOUNT_ADDRESS_SIZE}, but got {0}.")]
         InvalidByteLength(usize),
     }

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -1118,6 +1118,44 @@ impl AccountAddress {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum AccountAddressParseError {
+    InvalidBase58Check(bs58::decode::Error),
+    InvalidByteLength(usize),
+}
+
+impl fmt::Display for AccountAddressParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        use AccountAddressParseError::*;
+        match self {
+            InvalidBase58Check(e) => write!(f, "Invalid Base58Check encoding {e}."),
+            InvalidByteLength(size) => {
+                write!(
+                    f,
+                    "Invalid number of bytes, expected {ACCOUNT_ADDRESS_SIZE}, but got {size}."
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for AccountAddressParseError {}
+
+impl TryFrom<&[u8]> for AccountAddress {
+    type Error = AccountAddressParseError;
+
+    fn try_from(slice: &[u8]) -> Result<Self, Self::Error> {
+        if slice.len() == ACCOUNT_ADDRESS_SIZE {
+            let mut array = [0u8; ACCOUNT_ADDRESS_SIZE];
+            array.copy_from_slice(slice);
+            Ok(AccountAddress(array))
+        } else {
+            Err(AccountAddressParseError::InvalidByteLength(slice.len()))
+        }
+    }
+}
+
 /// Address of a contract.
 #[derive(Eq, PartialEq, Copy, Clone, Debug, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "derive-serde", derive(SerdeSerialize, SerdeDeserialize))]
@@ -2713,17 +2751,6 @@ mod serde_impl {
         }
     }
 
-    /// Error type for when parsing an account address.
-    #[derive(Debug, thiserror::Error)]
-    pub enum AccountAddressParseError {
-        /// Failed parsing the Base58Check encoding.
-        #[error("Invalid Base58Check encoding.")]
-        InvalidBase58Check(#[from] bs58::decode::Error),
-        /// The decoded bytes are not of length 32.
-        #[error("Invalid number of bytes, expected 32, but got {0}.")]
-        InvalidByteLength(usize),
-    }
-
     /// Parse from string assuming base58check encoding.
     impl str::FromStr for AccountAddress {
         type Err = AccountAddressParseError;
@@ -2732,7 +2759,10 @@ mod serde_impl {
             // The buffer must be large enough to contain the 32 bytes for the address, 4
             // bytes for a checksum and 1 byte for the version.
             let mut buf = [0u8; ACCOUNT_ADDRESS_SIZE + 4 + 1];
-            let len = bs58::decode(v).with_check(Some(1)).onto(&mut buf)?;
+            let len = bs58::decode(v)
+                .with_check(Some(1))
+                .onto(&mut buf)
+                .map_err(AccountAddressParseError::InvalidBase58Check)?;
             // Prepends 1 byte for the version
             if len != 1 + ACCOUNT_ADDRESS_SIZE {
                 return Err(AccountAddressParseError::InvalidByteLength(len));


### PR DESCRIPTION
## Purpose

Add conversion from `&[u8]` to `AccountAddress` to simplify constructing the type when reading byte values from a database.

## Changes

Add conversion from `&[u8]` to `AccountAddress`.
