### PR TITLE
GRPC support for missing events for baker/delegator configure transactions

### DIFF
--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -3,7 +3,7 @@ on:
   # but only for the main branch
   push:
     branches:
-      - main
+      - main, 7.0/branch
     paths:
       - 'smart-contracts/contracts-common/**/*.rs'
       - 'smart-contracts/contracts-common/**/*.toml'
@@ -11,7 +11,7 @@ on:
 
   pull_request:
     branches:
-      - main
+      - main, 7.0/branch
     paths:
       - 'smart-contracts/contracts-common/**/*.rs'
       - 'smart-contracts/contracts-common/**/*.toml'

--- a/.github/workflows/build-test-smart-contracts.yaml
+++ b/.github/workflows/build-test-smart-contracts.yaml
@@ -5,10 +5,10 @@ name: Build and test smart-contracts
 
 on:
   push:
-    branches: main
+    branches: main, 7.0/branch
 
   pull_request:
-    branches: main
+    branches: main, 7.0/branch
 
   workflow_dispatch: # allows manual trigger
 

--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -21,7 +21,7 @@ name: Check format, docs, build and run tests for Haskell and Rust sources
 
 on:
   pull_request:
-    branches: main
+    branches: main, 7.0/branch
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
     - '.github/workflows/build-test-sources.yaml'
@@ -33,7 +33,7 @@ on:
     - '**.rs'
     - 'testdata/**'
   push:
-    branches: main
+    branches: main, 7.0/branch
     paths:
     - '.github/workflows/build-test-sources.yaml'
     - '**.hs'

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1463,6 +1463,11 @@ convertAccountTransaction ty cost sender result = case ty of
                                                 ProtoFields.bakerId .= toProto ebsfrcBakerId
                                                 ProtoFields.finalizationRewardCommission .= toProto ebsfrcFinalizationRewardCommission
                                             )
+                            DelegationRemoved{..} ->
+                                Right . Proto.make $
+                                    ProtoFields.delegationRemoved
+                                        .= Proto.make
+                                            (ProtoFields.delegatorId .= toProto edrDelegatorId)
                             _ -> Left CEInvalidTransactionResult
                     v <- mapM toBakerEvent events
                     Right . Proto.make $ ProtoFields.bakerConfigured . ProtoFields.events .= v
@@ -1503,6 +1508,10 @@ convertAccountTransaction ty cost sender result = case ty of
                                             )
                             DelegationAdded{..} -> Right . Proto.make $ ProtoFields.delegationAdded .= toProto edaDelegatorId
                             DelegationRemoved{..} -> Right . Proto.make $ ProtoFields.delegationRemoved .= toProto edrDelegatorId
+                            BakerRemoved{..} ->
+                                Right . Proto.make $
+                                    ProtoFields.bakerRemoved
+                                        .= Proto.make (ProtoFields.bakerId .= toProto ebrBakerId)
                             _ -> Left CEInvalidTransactionResult
                     v <- mapM toDelegationEvent events
                     Right . Proto.make $ ProtoFields.delegationConfigured . ProtoFields.events .= v


### PR DESCRIPTION
## Purpose
The changes to cooldown behaviour now allow an account to transition directly from delegator to baker and vice-versa. In these cases, an additional event is generated in the configure baker/delegator transaction to indicate that the delegator/baker has been removed.

## Changes

- GRPC support for removing baker/delegator as part of configuring delegator/baker.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
