### PR TITLE
Protocol 8: guard for p8 support

### DIFF
--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -174,6 +174,10 @@ module Concordium.Types.ProtocolVersion (
     AVSupportsFlexibleCooldown,
     PVSupportsFlexibleCooldown,
 
+    -- * Account suspension support
+    supportsAccountSuspension,
+    protocolSupportsSuspend,
+
     -- * Block hash version
 
     -- | The version of the block hashing structure.
@@ -332,6 +336,13 @@ $( singletons
         supportsFlexibleCooldown AccountV2 = False
         supportsFlexibleCooldown AccountV3 = True
         supportsFlexibleCooldown AccountV4 = True
+
+        supportsAccountSuspension :: AccountVersion -> Bool
+        supportsAccountSuspension AccountV0 = False
+        supportsAccountSuspension AccountV1 = False
+        supportsAccountSuspension AccountV2 = False
+        supportsAccountSuspension AccountV3 = False
+        supportsAccountSuspension AccountV4 = True
 
         -- \| A type representing the different hashing structures used for the block hash depending on
         -- the protocol version.
@@ -541,6 +552,13 @@ delegationSupport = case accountVersion @av of
 protocolSupportsDelegation :: SProtocolVersion pv -> Bool
 {-# INLINE protocolSupportsDelegation #-}
 protocolSupportsDelegation spv = case sSupportsDelegation (sAccountVersionFor spv) of
+    STrue -> True
+    SFalse -> False
+
+-- | Whether the protocol supports suspending/resuming validators.
+protocolSupportsSuspend :: SProtocolVersion pv -> Bool
+{-# INLINE protocolSupportsSuspend #-}
+protocolSupportsSuspend spv = case sSupportsAccountSuspension (sAccountVersionFor spv) of
     STrue -> True
     SFalse -> False
 

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -174,13 +174,13 @@ module Concordium.Types.ProtocolVersion (
     AVSupportsFlexibleCooldown,
     PVSupportsFlexibleCooldown,
 
-    -- * Account suspension support
+    -- * Validator suspension support
 
-    -- | Determine whether accounts can be suspended/resumed. A validator with
+    -- | Determine whether validators can be suspended/resumed. A validator with
     --   a suspended account is in essence not participating in the consensus.
     --   Its stake and delegators stay unchanged.
-    supportsAccountSuspension,
-    -- | Determine whether the protocol supports suspending/resuming accounts.
+    supportsValidatorSuspension,
+    -- | Determine whether the protocol supports suspending/resuming of validators.
     protocolSupportsSuspend,
 
     -- * Block hash version
@@ -342,12 +342,12 @@ $( singletons
         supportsFlexibleCooldown AccountV3 = True
         supportsFlexibleCooldown AccountV4 = True
 
-        supportsAccountSuspension :: AccountVersion -> Bool
-        supportsAccountSuspension AccountV0 = False
-        supportsAccountSuspension AccountV1 = False
-        supportsAccountSuspension AccountV2 = False
-        supportsAccountSuspension AccountV3 = False
-        supportsAccountSuspension AccountV4 = True
+        supportsValidatorSuspension :: AccountVersion -> Bool
+        supportsValidatorSuspension AccountV0 = False
+        supportsValidatorSuspension AccountV1 = False
+        supportsValidatorSuspension AccountV2 = False
+        supportsValidatorSuspension AccountV3 = False
+        supportsValidatorSuspension AccountV4 = True
 
         -- \| A type representing the different hashing structures used for the block hash depending on
         -- the protocol version.
@@ -563,7 +563,7 @@ protocolSupportsDelegation spv = case sSupportsDelegation (sAccountVersionFor sp
 -- | Whether the protocol supports suspending/resuming validators.
 protocolSupportsSuspend :: SProtocolVersion pv -> Bool
 {-# INLINE protocolSupportsSuspend #-}
-protocolSupportsSuspend spv = case sSupportsAccountSuspension (sAccountVersionFor spv) of
+protocolSupportsSuspend spv = case sSupportsValidatorSuspension (sAccountVersionFor spv) of
     STrue -> True
     SFalse -> False
 

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -175,7 +175,12 @@ module Concordium.Types.ProtocolVersion (
     PVSupportsFlexibleCooldown,
 
     -- * Account suspension support
+
+    -- | Determine whether accounts can be suspended/resumed. A validator with
+    --   a suspended account is in essence not participating in the consensus.
+    --   Its stake and delegators stay unchanged.
     supportsAccountSuspension,
+    -- | Determine whether the protocol supports suspending/resuming accounts.
     protocolSupportsSuspend,
 
     -- * Block hash version


### PR DESCRIPTION
This adds a guard for protocol versions supporting account suspension.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
