### PR TITLE
Add `bieAccountIsSuspended` field to `BakerInfoEx`

### DIFF
--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -237,10 +237,10 @@ bieBakerPoolInfo =
 -- | Lens for '_bieBakerIsSuspended'
 {-# INLINE bieAccountIsSuspended #-}
 bieAccountIsSuspended ::
-    (AVSupportsDelegation av) =>
-    Lens' (BakerInfoEx av) (Conditionally (SupportsValidatorSuspension av) Bool)
+    (AVSupportsDelegation av, AVSupportsValidatorSuspension av) =>
+    Lens' (BakerInfoEx av) Bool
 bieAccountIsSuspended =
-    lens _bieAccountIsSuspended (\bie x -> bie{_bieAccountIsSuspended = x})
+    lens (uncond . _bieAccountIsSuspended) (\bie x -> bie{_bieAccountIsSuspended = CTrue x})
 
 -- | Coerce a 'BakerInfoEx' between two account versions that support delegation.
 coerceBakerInfoExV1 ::

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -261,13 +261,14 @@ instance forall av. (IsAccountVersion av) => Serialize (BakerInfoEx av) where
     put BakerInfoExV1{..} = do
         put _bieBakerInfo
         put _bieBakerPoolInfo
-        put _bieAccountIsSuspended
+        mapM_ put _bieAccountIsSuspended
     get = case delegationSupport @av of
         SAVDelegationNotSupported -> BakerInfoExV0 <$> get
         SAVDelegationSupported -> do
             _bieBakerInfo <- get
             _bieBakerPoolInfo <- get
-            _bieAccountIsSuspended <- get
+            _bieAccountIsSuspended <-
+                conditionallyA (sSupportsValidatorSuspension (accountVersion @av)) get
             return BakerInfoExV1{..}
 
 instance HasBakerInfo (BakerInfoEx av) where

--- a/haskell-src/Concordium/Types/Conditionally.hs
+++ b/haskell-src/Concordium/Types/Conditionally.hs
@@ -80,4 +80,4 @@ uncond (CTrue a) = a
 
 fromCondDef :: Conditionally b a -> a -> a
 fromCondDef (CTrue a) _def = a
-fromCondDef CFalse def = def 
+fromCondDef CFalse def = def

--- a/haskell-src/Concordium/Types/Conditionally.hs
+++ b/haskell-src/Concordium/Types/Conditionally.hs
@@ -77,3 +77,7 @@ unconditionally f (CTrue a) = CTrue <$> f a
 -- | Unwrap a conditionally when the guard is 'True'.
 uncond :: Conditionally 'True a -> a
 uncond (CTrue a) = a
+
+fromCondDef :: Conditionally b a -> a -> a
+fromCondDef (CTrue a) _def = a
+fromCondDef CFalse def = def 

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -179,9 +179,15 @@ module Concordium.Types.ProtocolVersion (
     -- | Determine whether validators can be suspended/resumed. A validator with
     --   a suspended account is in essence not participating in the consensus.
     --   Its stake and delegators stay unchanged.
+    SupportsValidatorSuspension,
     supportsValidatorSuspension,
+    sSupportsValidatorSuspension,
     -- | Determine whether the protocol supports suspending/resuming of validators.
     protocolSupportsSuspend,
+    -- | Deterimne whether a specific account version supports suspending/
+    -- resuming of validators.
+    AVSupportsValidatorSuspension,
+    PVSupportsValidatorSuspension,
 
     -- * Block hash version
 
@@ -446,7 +452,7 @@ demoteProtocolVersion = fromSing
 
 -- | Constraint on a type level 'AccountVersion' that can be used to get a corresponding
 --  'SAccountVersion' (see 'accountVersion'). (An alias for 'SingI'.)
-type IsAccountVersion (av :: AccountVersion) = SingI av
+type IsAccountVersion (av :: AccountVersion) = (SingI av, SingI (SupportsValidatorSuspension av))
 
 -- | Constraint on a type level 'ChainParametersVersion' that can be used to get a corresponding
 --  'SChainParametersVersion' (see 'chainParametersVersion'). (An alias for 'SingI'.)
@@ -566,6 +572,14 @@ protocolSupportsSuspend :: SProtocolVersion pv -> Bool
 protocolSupportsSuspend spv = case sSupportsValidatorSuspension (sAccountVersionFor spv) of
     STrue -> True
     SFalse -> False
+
+-- | Constraint that an account version supports validator suspension.
+type AVSupportsValidatorSuspension (av :: AccountVersion) =
+    SupportsValidatorSuspension av ~ 'True
+
+-- | Constraint that a protocol version supports validator suspension.
+type PVSupportsValidatorSuspension (pv :: ProtocolVersion) =
+    AVSupportsValidatorSuspension (AccountVersionFor pv)
 
 -- | Constraint that an account version supports flexible cooldown.
 --

--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -452,7 +452,7 @@ demoteProtocolVersion = fromSing
 
 -- | Constraint on a type level 'AccountVersion' that can be used to get a corresponding
 --  'SAccountVersion' (see 'accountVersion'). (An alias for 'SingI'.)
-type IsAccountVersion (av :: AccountVersion) = (SingI av, SingI (SupportsValidatorSuspension av))
+type IsAccountVersion (av :: AccountVersion) = SingI av
 
 -- | Constraint on a type level 'ChainParametersVersion' that can be used to get a corresponding
 --  'SChainParametersVersion' (see 'chainParametersVersion'). (An alias for 'SingI'.)


### PR DESCRIPTION
We add the `bieAccountIsSuspended` field to `BakerInfoEx` to make the field persistent together with the account. There are also a few new types/constraints that are useful for the implementation in the consensus.

## Purpose

Add the suspended field to the persisted fields of the validator account.

## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
