### PR TITLE
Remove check on padding in mobile wallets library

### DIFF
--- a/mobile_wallet/CHANGELOG.md
+++ b/mobile_wallet/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.25.3
+
+- Changed the base64 schema decoding to allow padded and not padded strings.
+
 ## 0.25.2
 
 - Allowed use of functions deprecated due to the removal of encrypted transfers in protocol version 7.

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -1041,7 +1041,7 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mobile_wallet"
-version = "0.25.2"
+version = "0.25.3"
 dependencies = [
  "anyhow",
  "base64",

--- a/mobile_wallet/Cargo.toml
+++ b/mobile_wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mobile_wallet"
-version = "0.25.2"
+version = "0.25.3"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2018"
 license-file = "../../LICENSE-APACHE"

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -1,5 +1,9 @@
 use anyhow::{bail, ensure, Context};
-use base64::Engine;
+use base64::{
+    alphabet,
+    engine::{DecodePaddingMode, GeneralPurpose, GeneralPurposeConfig},
+    Engine,
+};
 use concordium_base::{
     base::{self, Energy, Nonce},
     cis2_types::{self, AdditionalData},
@@ -190,17 +194,20 @@ fn get_parameter_as_json(
     let contract_name = receive_name.as_receive_name().contract_name();
     let entrypoint_name = &receive_name.as_receive_name().entrypoint_name().to_string();
 
+    let decoding_specs = GeneralPurpose::new(
+        &alphabet::STANDARD,
+        GeneralPurposeConfig::new().with_decode_padding_mode(DecodePaddingMode::Indifferent),
+    );
+
     let receive_schema: schema::Type = match schema {
         SchemaInputType::Module(raw) => {
-            let module_schema = schema::VersionedModuleSchema::new(
-                &base64::engine::general_purpose::STANDARD_NO_PAD.decode(raw)?,
-                schema_version,
-            )?;
+            let module_schema =
+                schema::VersionedModuleSchema::new(&decoding_specs.decode(raw)?, schema_version)?;
             module_schema.get_receive_param_schema(contract_name, entrypoint_name)?
         }
-        SchemaInputType::Parameter(raw) => contracts_common::from_bytes(
-            &base64::engine::general_purpose::STANDARD_NO_PAD.decode(raw)?,
-        )?,
+        SchemaInputType::Parameter(raw) => {
+            contracts_common::from_bytes(&decoding_specs.decode(raw)?)?
+        }
     };
 
     let mut parameter_cursor = Cursor::new(parameter.as_ref());

--- a/mobile_wallet/src/lib.rs
+++ b/mobile_wallet/src/lib.rs
@@ -193,14 +193,14 @@ fn get_parameter_as_json(
     let receive_schema: schema::Type = match schema {
         SchemaInputType::Module(raw) => {
             let module_schema = schema::VersionedModuleSchema::new(
-                &base64::engine::general_purpose::STANDARD.decode(raw)?,
+                &base64::engine::general_purpose::STANDARD_NO_PAD.decode(raw)?,
                 schema_version,
             )?;
             module_schema.get_receive_param_schema(contract_name, entrypoint_name)?
         }
-        SchemaInputType::Parameter(raw) => {
-            contracts_common::from_bytes(&base64::engine::general_purpose::STANDARD.decode(raw)?)?
-        }
+        SchemaInputType::Parameter(raw) => contracts_common::from_bytes(
+            &base64::engine::general_purpose::STANDARD_NO_PAD.decode(raw)?,
+        )?,
     };
 
     let mut parameter_cursor = Cursor::new(parameter.as_ref());


### PR DESCRIPTION
## Purpose

Not-enforcing padding of the base64 schema when signing a binary message in the CryptoX wallets.

In the past, some tools added and/or required padding on the schema in the Concordium ecosystem while others did not. At some point, we relaxed it and removed that requirement:
https://github.com/Concordium/concordium-dapp-libraries/pull/63/files

Currently,
- `cargo-concordium` does not add padding
- `browser wallet` does not enforce padding
- `dapp-libraries` does not enforce padding

Padding means that there are zero, one, or two `=` characters added at the end of the base64 string representing the schema to make it dividable.

The mobile wallets still enforce padding which was incompatible with the schema produced by `cargo-concordium`.

## Changes

- Remove check on padding in mobile wallets library