### PR TITLE
Fix the consistency of name validity between Haskell and Rust.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -318,6 +318,7 @@ test-suite test
       Types.TransactionSerializationSpec
       Types.TransactionSummarySpec
       Types.UpdatesSpec
+      Types.ValidName
       Paths_concordium_base
   autogen-modules:
       Paths_concordium_base

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -74,6 +74,7 @@ module Concordium.Wasm (
 
     --
 
+    isValidNameChar,
     -- | A contract has one init method and several receive methods. A module can
     -- contain several contracts.
     InitName (..),
@@ -146,7 +147,6 @@ import qualified Data.ByteString.Base16 as BS16
 import Data.ByteString.Short (ShortByteString)
 import qualified Data.ByteString.Short as BSS
 import Data.ByteString.Unsafe (unsafeUseAsCStringLen)
-import Data.Char (isAlphaNum, isAscii, isPunctuation)
 import qualified Data.HashMap.Strict as HM
 import Data.Hashable
 import Data.Int (Int32)
@@ -326,6 +326,21 @@ instance HashableTo H.Hash (WasmModuleV V1) where
 
 --------------------------------------------------------------------------------
 
+-- | Check whether the given character is an ascii alphanumeric or punctuation character.
+--  Only these characters can appear in init, receive or entrypoint names.
+--  Note: this is more permissive in terms of punctuation than 'Data.Char.isPunctuation'.
+--  It is intended to align with Rust @char::is_ascii_punctuation@ instead.
+isValidNameChar :: Char -> Bool
+isValidNameChar c
+    | 'A' <= c && c <= 'Z' = True
+    | 'a' <= c && c <= 'z' = True
+    | '0' <= c && c <= '9' = True
+    | '!' <= c && c <= '/' = True
+    | ':' <= c && c <= '@' = True
+    | '[' <= c && c <= '`' = True
+    | '{' <= c && c <= '~' = True
+    | otherwise = False
+
 -- | Name of an init method inside a module.
 newtype InitName = InitName {initName :: Text}
     deriving (Eq, Ord)
@@ -346,7 +361,7 @@ isValidInitName proposal =
     -- The limit is specified in bytes, but Text.length returns the number of chars.
     -- This is not a problem, as we only allow ASCII.
     let hasValidLength = Text.length proposal <= maxFuncNameSize
-        hasValidCharacters = Text.all (\c -> isAscii c && (isAlphaNum c || isPunctuation c)) proposal
+        hasValidCharacters = Text.all isValidNameChar proposal
         hasDot = Text.any (== '.') proposal
     in  "init_" `Text.isPrefixOf` proposal && hasValidLength && hasValidCharacters && not hasDot
 
@@ -404,7 +419,7 @@ isValidReceiveName proposal =
     -- The limit is specified in bytes, but Text.length returns the number of chars.
     -- This is not a problem, as we only allow ASCII.
     let hasValidLength = Text.length proposal <= maxFuncNameSize
-        hasValidCharacters = Text.all (\c -> isAscii c && (isAlphaNum c || isPunctuation c)) proposal
+        hasValidCharacters = Text.all isValidNameChar proposal
         hasDot = Text.any (== '.') proposal
     in  hasValidLength && hasValidCharacters && hasDot
 
@@ -426,7 +441,7 @@ isValidEntrypointName proposal =
     -- The limit is specified in bytes, but Text.length returns the number of chars.
     -- This is not a problem, as we only allow ASCII.
     let hasValidLength = Text.length proposal < maxFuncNameSize
-        hasValidCharacters = Text.all (\c -> isAscii c && (isAlphaNum c || isPunctuation c)) proposal
+        hasValidCharacters = Text.all isValidNameChar proposal
     in  hasValidLength && hasValidCharacters
 
 instance Serialize EntrypointName where

--- a/haskell-tests/Spec.hs
+++ b/haskell-tests/Spec.hs
@@ -25,6 +25,7 @@ import qualified Types.PayloadSerializationSpec
 import qualified Types.TransactionSerializationSpec
 import qualified Types.TransactionSummarySpec
 import qualified Types.UpdatesSpec
+import qualified Types.ValidName
 
 main :: IO ()
 main = hspec $ parallel $ do
@@ -54,3 +55,4 @@ main = hspec $ parallel $ do
     Types.AddressesSpec.tests
     Types.ParametersSpec.tests
     Genesis.ParametersSpec.tests
+    Types.ValidName.tests

--- a/haskell-tests/Types/ValidName.hs
+++ b/haskell-tests/Types/ValidName.hs
@@ -1,0 +1,96 @@
+module Types.ValidName where
+
+import qualified Data.Text as Text
+import Test.Hspec
+
+import Concordium.Wasm
+
+-- | Check that the valid name characters are as expected.
+testValidNameChars :: Expectation
+testValidNameChars = filter isValidNameChar [minBound .. maxBound] `shouldBe` validNameChars
+  where
+    validNameChars = "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+
+-- | Test valid init names.
+testValidInitName :: Spec
+testValidInitName = describe "valid init names" $ do
+    testIt "init_contract"
+    -- Max allowed length
+    testIt "init_01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234"
+    -- Shortest possible
+    testIt "init_"
+    -- All allowed symbols
+    testIt "init_!\"#$%&'()*+,-/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  where
+    testIt name = it name $ isValidInitName (Text.pack name)
+
+-- | Test invalid init names.
+testInvalidInitName :: Spec
+testInvalidInitName = describe "invalid init names" $ do
+    testIt "init"
+    testIt "init_ "
+    -- Incorrect prefix
+    testIt "no_init_prefix"
+    -- 1 character too long.
+    testIt "init_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345"
+    testIt "init_!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  where
+    testIt name = it name $ not $ isValidInitName (Text.pack name)
+
+-- | Test valid receive names.
+testValidReceiveName :: Spec
+testValidReceiveName = describe "valid receive names" $ do
+    testIt "contract.receive"
+    -- Max allowed length
+    testIt ".012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
+    -- Shortest possible
+    testIt "."
+    -- All allowed symbols
+    testIt "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  where
+    testIt name = it name $ isValidReceiveName (Text.pack name)
+
+-- | Test invalid receive names.
+testInvalidReceiveName :: Spec
+testInvalidReceiveName = describe "invalid receive names" $ do
+    -- No dot
+    testIt "no_dot_separator"
+    -- Too long
+    testIt ".0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+    -- Contains space
+    testIt "contract. receive"
+  where
+    testIt name = it name $ not $ isValidReceiveName (Text.pack name)
+
+-- | Test valid entrypoint names.
+testValidEntrypointName :: Spec
+testValidEntrypointName = describe "valid entrypoint names" $ do
+    testIt "entrypoint"
+    -- Max allowed length
+    testIt "012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678"
+    -- Shortest possible
+    testIt ""
+    -- All allowed symbols
+    testIt "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+  where
+    testIt name = it name $ isValidEntrypointName (Text.pack name)
+
+-- | Test invalid entrypoint names.
+testInvalidEntrypointName :: Spec
+testInvalidEntrypointName = describe "invalid entrypoint names" $ do
+    -- Too long
+    testIt "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789"
+    -- Contains space
+    testIt "entry point"
+  where
+    testIt name = it name $ not $ isValidEntrypointName (Text.pack name)
+
+tests :: Spec
+tests = describe "Contract name validation" $ do
+    it "isValidNameChar" testValidNameChars
+    testValidInitName
+    testInvalidInitName
+    testValidReceiveName
+    testInvalidReceiveName
+    testValidEntrypointName
+    testInvalidEntrypointName

--- a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
+++ b/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs
@@ -1754,7 +1754,7 @@ impl OwnedParameter {
 
 /// Check whether the given string is a valid contract entrypoint name.
 /// This is the case if and only if
-/// - the string is no more than [constants::MAX_FUNC_NAME_SIZE][m] bytes
+/// - the string is less than [constants::MAX_FUNC_NAME_SIZE][m] bytes
 /// - all characters are ascii alphanumeric or punctuation characters.
 ///
 /// [m]: ./constants/constant.MAX_FUNC_NAME_SIZE.html
@@ -3013,12 +3013,23 @@ mod test {
     #[test]
     fn test_valid_new_contract_name() {
         let contract_name = ContractName::new("init_contract");
-        assert!(contract_name.is_ok())
+        assert!(contract_name.is_ok());
+        let contract_name = ContractName::new("init_01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234");
+        assert!(contract_name.is_ok());
+        let contract_name = ContractName::new("init_");
+        assert!(contract_name.is_ok());
+        let contract_name = ContractName::new(
+            "init_!\"#$%&'()*+,-/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+        );
+        assert!(contract_name.is_ok());
     }
 
     #[test]
     fn test_invalid_new_contract_name_missing_prefix() {
         let contract_name = ContractName::new("no_init_prefix");
+        assert_eq!(contract_name, Err(NewContractNameError::MissingInitPrefix));
+        let contract_name = ContractName::new("init");
         assert_eq!(contract_name, Err(NewContractNameError::MissingInitPrefix))
     }
 
@@ -3027,6 +3038,10 @@ mod test {
         // Is too long when the prefix is included.
         let long_name = format!("init_{}", "c".repeat(constants::MAX_FUNC_NAME_SIZE));
         let contract_name = ContractName::new(long_name.as_str());
+        assert_eq!(contract_name, Err(NewContractNameError::TooLong));
+        // One character too long.
+        let long_name = "init_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+        let contract_name = ContractName::new(long_name);
         assert_eq!(contract_name, Err(NewContractNameError::TooLong))
     }
 
@@ -3040,12 +3055,24 @@ mod test {
     #[test]
     fn test_valid_new_owned_contract_name() {
         let contract_name = OwnedContractName::new("init_contract".to_string());
+        assert!(contract_name.is_ok());
+        let contract_name = OwnedContractName::new("init_01234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234".to_string());
+        assert!(contract_name.is_ok());
+        let contract_name = OwnedContractName::new("init_".to_string());
+        assert!(contract_name.is_ok());
+        let contract_name = OwnedContractName::new(
+            "init_!\"#$%&'()*+,-/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+                .to_string(),
+        );
         assert!(contract_name.is_ok())
     }
 
     #[test]
     fn test_invalid_new_owned_contract_name_missing_prefix() {
         let contract_name = OwnedContractName::new("no_init_prefix".to_string());
+        assert_eq!(contract_name, Err(NewContractNameError::MissingInitPrefix));
+        let contract_name = OwnedContractName::new("init".to_string());
         assert_eq!(contract_name, Err(NewContractNameError::MissingInitPrefix))
     }
 
@@ -3054,6 +3081,11 @@ mod test {
         // Is too long when the prefix is included.
         let long_name = format!("init_{}", "c".repeat(constants::MAX_FUNC_NAME_SIZE));
         let contract_name = OwnedContractName::new(long_name);
+        assert_eq!(contract_name, Err(NewContractNameError::TooLong));
+        // One character too long.
+        // One character too long.
+        let long_name = "init_012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345";
+        let contract_name = OwnedContractName::new(long_name.to_string());
         assert_eq!(contract_name, Err(NewContractNameError::TooLong))
     }
 
@@ -3067,6 +3099,15 @@ mod test {
     #[test]
     fn test_valid_new_receive_name() {
         let receive_name = ReceiveName::new("contract.receive");
+        assert!(receive_name.is_ok());
+        let receive_name = ReceiveName::new(".012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678");
+        assert!(receive_name.is_ok());
+        let receive_name = ReceiveName::new(".");
+        assert!(receive_name.is_ok());
+        let receive_name = ReceiveName::new(
+            "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+        );
         assert!(receive_name.is_ok())
     }
 
@@ -3085,6 +3126,19 @@ mod test {
     }
 
     #[test]
+    fn test_invalid_new_receive_name_one_too_long() {
+        let long_name = ".0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        let contract_name = ReceiveName::new(long_name);
+        assert_eq!(contract_name, Err(NewReceiveNameError::TooLong))
+    }
+
+    #[test]
+    fn test_invalid_new_receive_name_invalid_character() {
+        let contract_name = ReceiveName::new("contract. receive");
+        assert_eq!(contract_name, Err(NewReceiveNameError::InvalidCharacters))
+    }
+
+    #[test]
     fn test_getters_for_receive_name() {
         let expected_chain_name = "contract.receive";
         let receive_name = ReceiveName::new(expected_chain_name).unwrap();
@@ -3094,6 +3148,16 @@ mod test {
     #[test]
     fn test_valid_new_owned_receive_name() {
         let receive_name = OwnedReceiveName::new("contract.receive".to_string());
+        assert!(receive_name.is_ok());
+        let receive_name = OwnedReceiveName::new(".012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678".to_string());
+        assert!(receive_name.is_ok());
+        let receive_name = OwnedReceiveName::new(".".to_string());
+        assert!(receive_name.is_ok());
+        let receive_name = OwnedReceiveName::new(
+            "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+                .to_string(),
+        );
         assert!(receive_name.is_ok())
     }
 
@@ -3112,6 +3176,19 @@ mod test {
     }
 
     #[test]
+    fn test_invalid_new_owned_receive_name_one_too_long() {
+        let long_name = ".0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        let contract_name = OwnedReceiveName::new(long_name.to_string());
+        assert_eq!(contract_name, Err(NewReceiveNameError::TooLong))
+    }
+
+    #[test]
+    fn test_invalid_new_owned_receive_name_invalid_character() {
+        let contract_name = OwnedReceiveName::new("contract. receive".to_string());
+        assert_eq!(contract_name, Err(NewReceiveNameError::InvalidCharacters))
+    }
+
+    #[test]
     fn test_getters_for_owned_receive_name() {
         let receive_name = OwnedReceiveName::new("contract.receive".to_string()).unwrap();
         assert_eq!(receive_name.as_receive_name().get_chain_name(), "contract.receive");
@@ -3120,6 +3197,63 @@ mod test {
             receive_name.as_receive_name().entrypoint_name(),
             EntrypointName::new_unchecked("receive")
         );
+    }
+
+    #[test]
+    fn test_valid_new_entrypoint_name() {
+        let entrypoint_name = EntrypointName::new("entrypoint");
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = EntrypointName::new("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678");
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = EntrypointName::new("");
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = EntrypointName::new(
+            "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~",
+        );
+        assert!(entrypoint_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_new_entrypoint_name_too_long() {
+        let long_name = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        let entrypoint_name = EntrypointName::new(long_name);
+        assert_eq!(entrypoint_name, Err(NewReceiveNameError::TooLong))
+    }
+
+    #[test]
+    fn test_invalid_new_entrypoint_name_invalid_character() {
+        let entrypoint_name = EntrypointName::new("entry point");
+        assert_eq!(entrypoint_name, Err(NewReceiveNameError::InvalidCharacters))
+    }
+
+    #[test]
+    fn test_valid_owned_entrypoint_name() {
+        let entrypoint_name = OwnedEntrypointName::new("entrypoint".to_string());
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = OwnedEntrypointName::new("012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678".to_string());
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = OwnedEntrypointName::new("".to_string());
+        assert!(entrypoint_name.is_ok());
+        let entrypoint_name = OwnedEntrypointName::new(
+            "!\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\\
+             ]^_`abcdefghijklmnopqrstuvwxyz{|}~"
+                .to_string(),
+        );
+        assert!(entrypoint_name.is_ok())
+    }
+
+    #[test]
+    fn test_invalid_owned_entrypoint_name_too_long() {
+        let long_name = "0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789";
+        let entrypoint_name = OwnedEntrypointName::new(long_name.to_string());
+        assert_eq!(entrypoint_name, Err(NewReceiveNameError::TooLong))
+    }
+
+    #[test]
+    fn test_invalid_owned_entrypoint_name_invalid_character() {
+        let entrypoint_name = OwnedEntrypointName::new("entry point".to_string());
+        assert_eq!(entrypoint_name, Err(NewReceiveNameError::InvalidCharacters))
     }
 
     #[test]


### PR DESCRIPTION
## Purpose

Backport of #561.

Fix the consistency of how contract init, receive and entrypoint names are handled between Haskell and Rust.
Changes

## Changes

-    Broaden what is accepted in Haskell to match what is accepted in Rust.-
-    Additional test in Rust and Haskell.


## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
