### PR TITLE
p8: Move the suspended flag

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -475,6 +475,7 @@ instance ToProto AccountStakingInfo where
                             case asiPoolInfo of
                                 Nothing -> return ()
                                 Just asipi -> ProtoFields.poolInfo .= toProto asipi
+                            ProtoFields.isSuspended .= asiIsSuspended
                         )
             )
     toProto AccountStakingDelegated{..} =
@@ -619,7 +620,6 @@ instance ToProto AccountInfo where
         ProtoFields.maybe'stake .= toProto aiStakingInfo
         ProtoFields.cooldowns .= fmap toProto aiAccountCooldowns
         ProtoFields.availableBalance .= toProto aiAccountAvailableAmount
-        ProtoFields.isSuspended .= aiAccountIsSuspended
 
 instance ToProto Wasm.Parameter where
     type Output Wasm.Parameter = Proto.Parameter


### PR DESCRIPTION
This moves the suspended flag from `AccountInfo` to `AccountStakingInfo.Baker`. This also needs a change in `concordium-grpc-api` that needs to go in first: https://github.com/Concordium/concordium-grpc-api/pull/63.

## Purpose

We move the suspended flag one level down to the `AccountStakingInfo` to reflect that it is a property of a validator and not the account.

## Changes

see above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
