### PR TITLE
Fix static node build

### DIFF
--- a/Setup.hs
+++ b/Setup.hs
@@ -40,7 +40,7 @@ linuxBuild True env verbosity = do
 linuxBuild False env verbosity = do
     noticeNoWrap verbosity "Dynamic linking."
     let makeLib (libName, libFeatures) = do
-            rawSystemExitWithEnv verbosity "cargo" (["rustc", "--release", "--manifest-path", "rust-src/" ++ libName ++ "/Cargo.toml", "--crate-type", "cdylib"] ++ libFeatures) env
+            rawSystemExitWithEnv verbosity "cargo" (["rustc", "--release", "--manifest-path", "rust-src/" ++ libName ++ "/Cargo.toml", "--crate-type", "cdylib", "--crate-type", "staticlib"] ++ libFeatures) env
             notice verbosity "Linking library to ./lib"
             let source = "../rust-src/target/release/lib" ++ libName
                 target = "./lib/lib" ++ libName


### PR DESCRIPTION
## Purpose

The static build of the node uses the "dynamic linking" mode for building `concordium-base`, but requires that the rust library is also statically built. This was changed as a result of #559, so here we bring it back.

## Changes

- Build the rust libraries as both `cdylib` and `staticlib` in the dynamic Linux build process.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
