### PR TITLE
Support timestamp JSON deserialization from strings.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -1,6 +1,6 @@
 cabal-version: 2.0
 
--- This file has been generated from package.yaml by hpack version 0.36.0.
+-- This file has been generated from package.yaml by hpack version 0.37.0.
 --
 -- see: https://github.com/sol/hpack
 
@@ -317,6 +317,7 @@ test-suite test
       Types.ParametersSpec
       Types.PayloadSerializationSpec
       Types.PayloadSpec
+      Types.TimestampSpec
       Types.TransactionSerializationSpec
       Types.TransactionSummarySpec
       Types.UpdatesSpec

--- a/haskell-tests/Spec.hs
+++ b/haskell-tests/Spec.hs
@@ -23,6 +23,7 @@ import qualified Types.AmountSpec
 import qualified Types.ParametersSpec
 import qualified Types.PayloadSerializationSpec
 import qualified Types.PayloadSpec
+import qualified Types.TimestampSpec
 import qualified Types.TransactionSerializationSpec
 import qualified Types.TransactionSummarySpec
 import qualified Types.UpdatesSpec
@@ -49,6 +50,7 @@ main = hspec $ parallel $ do
     Types.PayloadSerializationSpec.tests
     Types.TransactionSerializationSpec.tests
     Types.AmountSpec.tests
+    Types.TimestampSpec.tests
     Types.UpdatesSpec.tests
     Types.AccountEncryptedAmountSpec.tests
     Types.AmountFraction.tests

--- a/haskell-tests/Types/TimestampSpec.hs
+++ b/haskell-tests/Types/TimestampSpec.hs
@@ -1,0 +1,46 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+-- | Basic JSON serialization and deserialization tests for 'Timestamp'.
+module Types.TimestampSpec where
+
+import Control.Monad
+import qualified Data.Aeson as AE
+import qualified Data.ByteString.Lazy as LBS
+import Test.Hspec
+import Test.QuickCheck
+
+import Concordium.Common.Time
+
+import Generators
+
+testEncodeDecode :: Property
+testEncodeDecode = forAll genTimestamp $ \ts -> AE.decode (AE.encode ts) === Just ts
+
+decodeExamples :: [(LBS.ByteString, Maybe Timestamp)]
+decodeExamples =
+    [ ("0", Just $ Timestamp 0),
+      ("1", Just $ Timestamp 1),
+      ("1.0", Just $ Timestamp 1),
+      ("-2", Nothing),
+      ("-2e5", Nothing),
+      ("\"10\"", Just $ Timestamp 10),
+      ("\"1.0\"", Nothing),
+      ("\"2024-12-07T15:00:00.726Z\"", Just $ Timestamp 1733583600726),
+      ("\"2024-12-07T15:00:00.726+00:00\"", Just $ Timestamp 1733583600726),
+      ("\"2024-12-07T15:00:00.726+01:00\"", Just $ Timestamp 1733580000726),
+      ("\"2024-12-07T15:00:00.726-01:00\"", Just $ Timestamp 1733587200726)
+    ]
+
+testExamples :: Expectation
+testExamples = mapM_ testEx decodeExamples
+  where
+    testEx (s, e) =
+        let p = AE.decode s
+        in  unless (p == e) $
+                expectationFailure $
+                    "Parsing " ++ show s ++ " expected " ++ show e ++ " but got " ++ show p
+
+tests :: Spec
+tests = focus $ describe "Timestamp" $ parallel $ do
+    specify "Timestamp JSON serialization" $ withMaxSuccess 1000 $ testEncodeDecode
+    specify "Timestamp JSON examples" $ testExamples


### PR DESCRIPTION
## Purpose

Allow JSON deserializing `Timestamp` in Haskell from the format produced by the [Rust serialization](https://github.com/Concordium/concordium-base/blob/58f871e57ab8543ae499d3cccc14ff7ce7b4842a/smart-contracts/contracts-common/concordium-contracts-common/src/types.rs#L873). The divergence was introduced as a consequence of https://github.com/Concordium/concordium-base/pull/499/files, which unified two previously distinct Rust `Timestamp` implementations. The JSON serialization is in particular used by the transaction logger when ScheduleTransfer transactions are logged in the wallet proxy database. This change allows the wallet proxy to parse the String-formatted timestamps.

## Changes

- New `FromJSON` implementation for `Timestamp`.
- Testing

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
