### PR TITLE
Queries for accounts with scheduled releases or cooldowns.

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -2437,3 +2437,9 @@ instance ToProto (DryRunResponse (TransactionSummary' ValidResultWithReturn)) wh
 instance ToProto BlockSignature.Signature where
     type Output BlockSignature.Signature = Proto.BlockSignature
     toProto = mkSerialize
+
+instance ToProto AccountPending where
+    type Output AccountPending = Proto.AccountPending
+    toProto AccountPending{..} = Proto.make $ do
+        ProtoFields.accountIndex .= toProto apAccountIndex
+        ProtoFields.firstTimestamp .= toProto apFirstTimestamp

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -1110,3 +1110,13 @@ data DryRunResponse a = DryRunResponse
       drrQuotaRemaining :: !Energy
     }
     deriving (Eq)
+
+-- | Indicates that an account is pending -- either a scheduled release or a cooldown, depending on
+--  the context -- and when the first release or cooldown will elapse.
+data AccountPending = AccountPending
+    { -- | Index of the account with pending scheduled release/cooldown.
+      apAccountIndex :: !AccountIndex,
+      -- | Timestamp of the first pending event for the account.
+      apFirstTimestamp :: !Timestamp
+    }
+    deriving (Eq)


### PR DESCRIPTION
## Purpose

Support a GRPC endpoints for getting the list of accounts with pending cooldowns or scheduled releases.

## Changes

- Update GRPC
- `AccountPending` type for indicating that an account with a first pending release or cooldown at a particular time.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
