### PR TITLE
Add parameter to `ContractInitialized` events

### DIFF
--- a/haskell-src/Concordium/Types/InvokeContract.hs
+++ b/haskell-src/Concordium/Types/InvokeContract.hs
@@ -14,7 +14,7 @@ import qualified Data.ByteString.Base16 as BS16
 import qualified Data.Text.Encoding as Text
 
 import Concordium.Types (Address, Amount, ContractAddress, Energy)
-import Concordium.Types.Execution (Event, RejectReason)
+import Concordium.Types.Execution (RejectReason, SupplementedEvent)
 import qualified Concordium.Wasm as Wasm
 
 -- | Default energy used when using the invoke method functionality.
@@ -93,7 +93,7 @@ data InvokeContractResult
           --  the return value produced by the call.
           rcrReturnValue :: !(Maybe BS.ByteString),
           -- | Events produced by contract execution.
-          rcrEvents :: ![Event],
+          rcrEvents :: ![SupplementedEvent],
           -- | Energy used by the execution.
           rcrUsedEnergy :: !Energy
         }

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -27,11 +27,7 @@ import Concordium.Types
 import Concordium.Types.Accounts
 import qualified Concordium.Types.AnonymityRevokers as ARS
 import Concordium.Types.Block
-import Concordium.Types.Execution (
-    SupplementedTransactionSummary,
-    TransactionSummary',
-    ValidResult',
- )
+import Concordium.Types.Execution (SupplementedTransactionSummary)
 import qualified Concordium.Types.IdentityProviders as IPS
 import Concordium.Types.Parameters (
     AuthorizationsVersion (..),
@@ -361,24 +357,18 @@ data BlockBirkParameters = BlockBirkParameters
 
 $(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''BlockBirkParameters)
 
--- | The status of a transaction that is present in the transaction table.
-data TransactionStatus' (supplemented :: Bool)
+-- | The status of a transaction that is present in the transaction table or a finalized block,
+--  as returned by the @getTransactionStatus@ gRPC query.
+data SupplementedTransactionStatus
     = -- | Transaction was received but is not in any blocks
       Received
     | -- | Transaction was received and is present in some (non-finalized) block(s)
-      Committed (Map.Map BlockHash (Maybe (TransactionSummary' (ValidResult' supplemented))))
+      Committed (Map.Map BlockHash (Maybe SupplementedTransactionSummary))
     | -- | Transaction has been finalized in a block
-      Finalized BlockHash (Maybe (TransactionSummary' (ValidResult' supplemented)))
+      Finalized BlockHash (Maybe SupplementedTransactionSummary)
     deriving (Show)
 
--- | The status of a transaction that is present in the transaction table.
-type TransactionStatus = TransactionStatus' False
-
--- | The status of a transaction that is present in the transaction table, with
---  supplemental information.
-type SupplementedTransactionStatus = TransactionStatus' True
-
-instance ToJSON (TransactionStatus' supplemented) where
+instance ToJSON SupplementedTransactionStatus where
     toJSON Received = object ["status" .= String "received"]
     toJSON (Committed m) =
         object

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -39,6 +39,7 @@ import Concordium.Genesis.Parameters
 import Concordium.ID.DummyData
 import Concordium.ID.Types
 import Concordium.Types
+import Concordium.Types.Conditionally
 import Concordium.Types.Execution
 import Concordium.Types.Parameters
 import Concordium.Types.Transactions
@@ -685,7 +686,7 @@ genEvent :: (IsProtocolVersion pv) => SProtocolVersion pv -> Gen Event
 genEvent spv =
     oneof
         ( [ ModuleDeployed <$> genModuleRef,
-            ContractInitialized <$> genModuleRef <*> genCAddress <*> genAmount <*> genInitName <*> genWasmVersion spv <*> listOf genContractEvent,
+            ContractInitialized <$> genModuleRef <*> genCAddress <*> genAmount <*> genInitName <*> genWasmVersion spv <*> listOf genContractEvent <*> pure CFalse,
             Updated <$> genCAddress <*> genAddress <*> genAmount <*> genParameter <*> genReceiveName <*> genWasmVersion spv <*> listOf genContractEvent,
             Transferred <$> genAddress <*> genAmount <*> genAddress,
             AccountCreated <$> genAccountAddress,


### PR DESCRIPTION
## Purpose

Issue: https://github.com/Concordium/concordium-node/issues/1262
Related: https://github.com/Concordium/concordium-grpc-api/pull/68 and https://github.com/Concordium/concordium-node/pull/1261

Supplement `ContractInitialized` events with the initialization parameter for the purposes of queries. This is to support queries that get transaction events returning contract initialization parameters.

Note that we do not change the data that makes up the transaction outcome for the purposes of consensus. That is, the events as stored in the block state and hashed to compute the block hash do not include the contract initialization parameter. Instead, the parameter is added in response to queries from the original transaction data.

## Changes

- A number of types are augmented or replaced with "supplemented" versions that include contract initialization parameters (where appropriate). In particular, we have `Event` and `SupplementedEvent`, where the latter includes contract initialization parameters, and similar supplemented versions for types containing events.
- `addInitializeParameter` helper for adding contract initialization parameters to transform `Event`s into `SupplementedEvent`s.
- `SupplementEvents` type class for operating on types that can be converted from containing `Event`s to `SupplementedEvent`s.
- GRPC interface works with the supplemented versions of the types.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
