### PR TITLE
Add account address to transaction outcomes and special events.

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1979,7 +1979,7 @@ instance ToProto TxTypes.SpecialTransactionOutcome where
                     )
     toProto TxTypes.ValidatorPrimedForSuspension{..} =
         Proto.make $
-            ProtoFields.validatorSuspended
+            ProtoFields.validatorPrimedForSuspension
                 .= Proto.make
                     ( do
                         ProtoFields.bakerId .= toProto vpfsBakerId

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1980,11 +1980,19 @@ instance ToProto TxTypes.SpecialTransactionOutcome where
     toProto TxTypes.ValidatorPrimedForSuspension{..} =
         Proto.make $
             ProtoFields.validatorSuspended
-                .= Proto.make (ProtoFields.bakerId .= toProto vpfsBakerId)
+                .= Proto.make
+                    ( do
+                        ProtoFields.bakerId .= toProto vpfsBakerId
+                        ProtoFields.account .= toProto vpfsAccount
+                    )
     toProto TxTypes.ValidatorSuspended{..} =
         Proto.make $
             ProtoFields.validatorSuspended
-                .= Proto.make (ProtoFields.bakerId .= toProto vsBakerId)
+                .= Proto.make
+                    ( do
+                        ProtoFields.bakerId .= toProto vsBakerId
+                        ProtoFields.account .= toProto vsAccount
+                    )
 
 instance ToProto (TransactionTime, QueryTypes.PendingUpdateEffect) where
     type Output (TransactionTime, QueryTypes.PendingUpdateEffect) = Proto.PendingUpdate

--- a/haskell-src/Concordium/Genesis/Parameters.hs
+++ b/haskell-src/Concordium/Genesis/Parameters.hs
@@ -290,7 +290,8 @@ instance ToJSON (GenesisChainParameters' 'ChainParametersV3) where
               "blockEnergyLimit" AE..= _cpBlockEnergyLimit gcpConsensusParameters,
               "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam gcpFinalizationCommitteeParameters),
               "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam gcpFinalizationCommitteeParameters),
-              "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam gcpFinalizationCommitteeParameters)
+              "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam gcpFinalizationCommitteeParameters),
+              "maximumMissedRounds" AE..= _vspMaxMissedRounds (unOParam gcpValidatorScoreParameters)
             ]
 
 -- | 'GenesisParametersV2' provides a convenient abstraction for

--- a/haskell-src/Concordium/Types/Parameters.hs
+++ b/haskell-src/Concordium/Types/Parameters.hs
@@ -2124,7 +2124,8 @@ instance forall cpv. (IsChainParametersVersion cpv) => ToJSON (ChainParameters' 
                   "blockEnergyLimit" AE..= _cpBlockEnergyLimit _cpConsensusParameters,
                   "minimumFinalizers" AE..= _fcpMinFinalizers (unOParam _cpFinalizationCommitteeParameters),
                   "maximumFinalizers" AE..= _fcpMaxFinalizers (unOParam _cpFinalizationCommitteeParameters),
-                  "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam _cpFinalizationCommitteeParameters)
+                  "finalizerRelativeStakeThreshold" AE..= _fcpFinalizerRelativeStakeThreshold (unOParam _cpFinalizationCommitteeParameters),
+                  "maximumMissedRounds" AE..= _vspMaxMissedRounds (unOParam _cpValidatorScoreParameters)
                 ]
 
 -- | Parameters that affect finalization.

--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -749,12 +749,16 @@ data SpecialTransactionOutcome
       --  because it missed too many rounds.
       ValidatorPrimedForSuspension
         { -- | The id of the validator that will get suspended.
-          vpfsBakerId :: !BakerId
+          vpfsBakerId :: !BakerId,
+          -- | The address of the account associated with the validator.
+          vpfsAccount :: !AccountAddress
         }
     | -- | A validator was suspended because it missed too many rounds.
       ValidatorSuspended
         { -- | The id of the suspended validator.
-          vsBakerId :: !BakerId
+          vsBakerId :: !BakerId,
+          -- | The address of the account associated with the validator.
+          vsAccount :: !AccountAddress
         }
     deriving (Show, Eq)
 
@@ -818,9 +822,11 @@ instance S.Serialize SpecialTransactionOutcome where
     put ValidatorPrimedForSuspension{..} = do
         S.putWord8 8
         S.put vpfsBakerId
+        S.put vpfsAccount
     put ValidatorSuspended{..} = do
         S.putWord8 9
         S.put vsBakerId
+        S.put vsAccount
 
     get =
         S.getWord8 >>= \case
@@ -874,8 +880,10 @@ instance S.Serialize SpecialTransactionOutcome where
                 return PaydayPoolReward{..}
             8 -> do
                 vpfsBakerId <- S.get
+                vpfsAccount <- S.get
                 return ValidatorPrimedForSuspension{..}
             9 -> do
                 vsBakerId <- S.get
+                vsAccount <- S.get
                 return ValidatorSuspended{..}
             _ -> fail "Invalid SpecialTransactionOutcome type"

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -724,6 +724,7 @@ genEvent spv =
             ++ maybeV1ContractEvents
             ++ maybeDelegationEvents
             ++ maybeUpgrade
+            ++ maybeSuspendEvents
         )
   where
     maybeUpgrade = if supportsUpgradableContracts spv then [Upgraded <$> genCAddress <*> genModuleRef <*> genModuleRef] else []
@@ -749,6 +750,13 @@ genEvent spv =
                   DelegationSetDelegationTarget <$> genDelegatorId <*> genAccountAddress <*> genDelegationTarget,
                   DelegationAdded <$> genDelegatorId <*> genAccountAddress,
                   DelegationRemoved <$> genDelegatorId <*> genAccountAddress
+                ]
+            else []
+    maybeSuspendEvents =
+        if protocolSupportsSuspend spv
+            then
+                [ BakerSuspended <$> genBakerId <*> genAccountAddress,
+                  BakerResumed <$> genBakerId <*> genAccountAddress
                 ]
             else []
     genBakerAdded = do

--- a/haskell-tests/Types/TimestampSpec.hs
+++ b/haskell-tests/Types/TimestampSpec.hs
@@ -41,6 +41,6 @@ testExamples = mapM_ testEx decodeExamples
                     "Parsing " ++ show s ++ " expected " ++ show e ++ " but got " ++ show p
 
 tests :: Spec
-tests = focus $ describe "Timestamp" $ parallel $ do
+tests = describe "Timestamp" $ parallel $ do
     specify "Timestamp JSON serialization" $ withMaxSuccess 1000 $ testEncodeDecode
     specify "Timestamp JSON examples" $ testExamples


### PR DESCRIPTION
## Purpose

Add the account address to `BakerSuspended` and `BakerResumed` transaction outcomes, and to `ValidatorSuspended` and `ValidatorPrimedForSuspension` special outcomes.

## Changes

- Fix: encode `ValidatorPrimedForSuspension` at the correct message type in the protobuf encoding.
- Add the account address fields to `ValidatorSuspended` and `ValidatorPrimedForSuspension`.
  - Update the GRPC protobuf encoding to include the account address
  - Update the binary serialization and deserialization of the events.
- Add the account address fields to `BakerSuspended` and `BakerResumed`
  - Update the binary serialization and deserialization of the events.
  - Update the JSON serialization and deserialization of the events.
  - Update test generators
- Fix: remove test focus on timestamp serialization.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
