### PR TITLE
Extension of PoolCurrentPaydayInfo/PoolInfoResponse

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1691,6 +1691,7 @@ instance ToProto QueryTypes.BakerPoolStatus where
             ProtoFields.maybe'equityPendingChange .= toProto abpsBakerStakePendingChange
         ProtoFields.maybe'currentPaydayInfo .= fmap toProto psCurrentPaydayStatus
         ProtoFields.allPoolTotalCapital .= toProto psAllPoolTotalCapital
+        ProtoFields.maybe'isSuspended .= psIsSuspended
 
 instance ToProto QueryTypes.PassiveDelegationStatus where
     type Output QueryTypes.PassiveDelegationStatus = Proto.PassiveDelegationInfo
@@ -1731,6 +1732,8 @@ instance ToProto QueryTypes.CurrentPaydayBakerPoolStatus where
         ProtoFields.bakerEquityCapital .= toProto bpsBakerEquityCapital
         ProtoFields.delegatedCapital .= toProto bpsDelegatedCapital
         ProtoFields.commissionRates .= toProto bpsCommissionRates
+        ProtoFields.maybe'isPrimedForSuspension .= bpsIsPrimedForSuspension
+        ProtoFields.maybe'missedRounds .= bpsMissedRounds
 
 instance ToProto QueryTypes.RewardStatus where
     type Output QueryTypes.RewardStatus = Proto.TokenomicsInfo

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -511,7 +511,8 @@ data CurrentPaydayBakerPoolStatus = CurrentPaydayBakerPoolStatus
 
 $( deriveJSON
     defaultOptions
-        { fieldLabelModifier = firstLower . dropWhile isLower
+        { fieldLabelModifier = firstLower . dropWhile isLower,
+          omitNothingFields = True
         }
     ''CurrentPaydayBakerPoolStatus
  )
@@ -546,6 +547,7 @@ instance ToJSON BakerPoolStatus where
               "currentPaydayStatus" .= psCurrentPaydayStatus,
               "allPoolTotalCapital" .= psAllPoolTotalCapital
             ]
+                ++ ["isSuspended" .= isSuspended | Just isSuspended <- [psIsSuspended]]
                 ++ activeStatusFields
       where
         activeStatusFields = case psActiveStatus of

--- a/haskell-src/Concordium/Types/Queries.hs
+++ b/haskell-src/Concordium/Types/Queries.hs
@@ -500,7 +500,12 @@ data CurrentPaydayBakerPoolStatus = CurrentPaydayBakerPoolStatus
       -- | The effective delegated capital to the pool for the current reward period.
       bpsDelegatedCapital :: !Amount,
       -- | The commission rates that apply for the current reward period.
-      bpsCommissionRates :: !CommissionRates
+      bpsCommissionRates :: !CommissionRates,
+      -- | A flag indicating whether the baker is primed for suspension the
+      --  coming snapshot epoch. Present from protocol version P8.
+      bpsIsPrimedForSuspension :: !(Maybe Bool),
+      -- | The missed rounds of the baker. Present from protocol version P8.
+      bpsMissedRounds :: !(Maybe Word64)
     }
     deriving (Eq, Show)
 
@@ -525,7 +530,10 @@ data BakerPoolStatus = BakerPoolStatus
       --  for the current reward period.
       psCurrentPaydayStatus :: !(Maybe CurrentPaydayBakerPoolStatus),
       -- | Total capital staked across all pools, including passive delegation.
-      psAllPoolTotalCapital :: !Amount
+      psAllPoolTotalCapital :: !Amount,
+      -- | A flag indicating Whether the pool owner is suspended or not. Present
+      --  from protocol version P8.
+      psIsSuspended :: !(Maybe Bool)
     }
     deriving (Eq, Show)
 
@@ -568,6 +576,7 @@ instance FromJSON BakerPoolStatus where
                 abpsBakerStakePendingChange <- obj .: "bakerStakePendingChange"
                 return ActiveBakerPoolStatus{..}
         psActiveStatus <- optional activeStatusFields
+        psIsSuspended <- optional $ obj .: "isSuspended"
         return BakerPoolStatus{..}
 
 -- | Status of the passive delegators.


### PR DESCRIPTION
## Purpose

Add suspension info to `PoolCurrentPaydayInfo` /  `PoolInfoResponse`. This depends on https://github.com/Concordium/concordium-grpc-api/pull/74.

## Changes

See above.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
