### PR TITLE
Rust support for new chain parameters version.

### DIFF
--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -503,6 +503,7 @@ impl Deserial for ProtocolVersion {
 pub struct ChainParameterVersion0;
 pub struct ChainParameterVersion1;
 pub struct ChainParameterVersion2;
+pub struct ChainParameterVersion3;
 
 /// Height of a block since chain genesis.
 #[repr(transparent)]
@@ -1204,6 +1205,10 @@ impl MintDistributionFamily for ChainParameterVersion2 {
     type Output = MintDistributionV1;
 }
 
+impl MintDistributionFamily for ChainParameterVersion3 {
+    type Output = MintDistributionV1;
+}
+
 /// Type family mapping a `ChainParameterVersion` to its corresponding type for
 /// the `MintDistribution`.
 pub type MintDistribution<CPV> = <CPV as MintDistributionFamily>::Output;
@@ -1222,6 +1227,10 @@ impl GASRewardsFamily for ChainParameterVersion1 {
 }
 
 impl GASRewardsFamily for ChainParameterVersion2 {
+    type Output = GASRewardsV1;
+}
+
+impl GASRewardsFamily for ChainParameterVersion3 {
     type Output = GASRewardsV1;
 }
 

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -464,6 +464,10 @@ impl AuthorizationsFamily for ChainParameterVersion2 {
     type Output = AuthorizationsV1;
 }
 
+impl AuthorizationsFamily for ChainParameterVersion3 {
+    type Output = AuthorizationsV1;
+}
+
 /// A mapping of chain parameter versions to authorization versions.
 pub type Authorizations<CPV> = <CPV as AuthorizationsFamily>::Output;
 
@@ -628,6 +632,7 @@ pub struct FinalizationCommitteeParameters {
 }
 
 #[derive(Debug, common::Serialize, Clone, Copy, SerdeSerialize, SerdeDeserialize)]
+#[serde(rename_all = "camelCase")]
 /// Validator score parameters. These parameters control the threshold of
 /// maximal missed rounds before a validator gets suspended.
 pub struct ValidatorScoreParameters {


### PR DESCRIPTION
## Purpose

Changes to support the genesis tool in protocol version 8.

## Changes

- Add `ChainParametersVersion3` with appropriate `impl`s.
- `camelCase` for serde `ValidatorScoreParameters` for consistency.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
