### PR TITLE
Move isSuspended from BakerPoolStatus to ActiveBakerPoolStatus.

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -1689,9 +1689,9 @@ instance ToProto QueryTypes.BakerPoolStatus where
             ProtoFields.delegatedCapitalCap .= toProto abpsDelegatedCapitalCap
             ProtoFields.poolInfo .= toProto abpsPoolInfo
             ProtoFields.maybe'equityPendingChange .= toProto abpsBakerStakePendingChange
+            ProtoFields.maybe'isSuspended .= abpsIsSuspended
         ProtoFields.maybe'currentPaydayInfo .= fmap toProto psCurrentPaydayStatus
         ProtoFields.allPoolTotalCapital .= toProto psAllPoolTotalCapital
-        ProtoFields.maybe'isSuspended .= psIsSuspended
 
 instance ToProto QueryTypes.PassiveDelegationStatus where
     type Output QueryTypes.PassiveDelegationStatus = Proto.PassiveDelegationInfo


### PR DESCRIPTION
## Purpose

Relates to: https://github.com/Concordium/concordium-node/issues/1309
Depends on: https://github.com/Concordium/concordium-grpc-api/pull/76

This is intended to address the correct presentation of the suspended status of a validator pool: a validator pool's suspended status should be based on the suspended status on the pool owner's account.

## Changes

- Add `abpsIsSuspended` to `ActiveBakerPoolStatus`.
- Remove `psIsSuspended` from `BakerPoolStatus`. This change should not affect the JSON serialization of `BakerPoolStatus`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

