### PR TITLE
Serialize to the correct chain parameters version.

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -2140,7 +2140,7 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
             SChainParametersV3 ->
                 let Parameters.ChainParameters{..} = params
                 in  Proto.make $
-                        ProtoFields.v2
+                        ProtoFields.v3
                             .= Proto.make
                                 ( do
                                     ProtoFields.consensusParameters .= toProto _cpConsensusParameters
@@ -2158,6 +2158,7 @@ instance ToProto (AccountAddress, EChainParametersAndKeys) where
                                     ProtoFields.level1Keys .= toProto (Updates.level1Keys keys)
                                     ProtoFields.level2Keys .= toProto (Updates.level2Keys keys)
                                     ProtoFields.finalizationCommitteeParameters .= toProto (Parameters.unOParam _cpFinalizationCommitteeParameters)
+                                    ProtoFields.validatorScoreParameters .= toProto (Parameters.unOParam _cpValidatorScoreParameters)
                                 )
 
 instance ToProto FinalizationIndex where


### PR DESCRIPTION
## Purpose

Related issue: https://github.com/Concordium/concordium-node/issues/1312

Ensure `ChainParmetersV3` is correctly serialized in protobuf.

## Changes

- Use `v3` instead of `v2`.
- Include the `validatorScoreParameters`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
