### PR TITLE
Fix JSON serialization of SpeicalTransacationOutcome

### DIFF
--- a/haskell-src/Concordium/Types/Transactions.hs
+++ b/haskell-src/Concordium/Types/Transactions.hs
@@ -18,6 +18,7 @@ import Data.Aeson (FromJSON (..), ToJSON (..))
 import qualified Data.Aeson as AE
 import Data.Aeson.TH
 import qualified Data.ByteString as BS
+import Data.Char (isLower)
 import Data.List (foldl')
 import qualified Data.Map.Strict as Map
 import qualified Data.Serialize as S
@@ -762,7 +763,7 @@ data SpecialTransactionOutcome
         }
     deriving (Show, Eq)
 
-$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . drop 3} ''SpecialTransactionOutcome)
+$(deriveJSON defaultOptions{fieldLabelModifier = firstLower . dropWhile isLower} ''SpecialTransactionOutcome)
 
 instance HashableTo H.Hash SpecialTransactionOutcome where
     getHash = H.hash . S.encode


### PR DESCRIPTION
## Purpose

Linked: https://github.com/Concordium/concordium-client/pull/338 https://github.com/Concordium/concordium-wallet-proxy/pull/119

Fix JSON serialization of `SpeicalTransacationOutcome`. This is needed for the wallet proxy.

## Changes

- Use `dropWhile isLower` instead of `drop 3` to account for the new constructors having different prefixes.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
