### PR TITLE
Add `FinalizationCommitteeHash` type.

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Introduce new chain parameters `ValidatorScoreParameters` that contain the
   threshold of maximal missed rounds before a validator gets suspended.
 - Add `Default` instance for `UpdateSequenceNumber`.
+- Add `FinalizationCommitteeHash` type.
 
 ## 6.0.0
 

--- a/rust-src/concordium_base/src/hashes.rs
+++ b/rust-src/concordium_base/src/hashes.rs
@@ -36,6 +36,11 @@ pub enum ElectionNonceMarker {}
 /// epoch finalization entry.
 pub enum SuccessorProofMarker {}
 
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+/// Used as a phantom type to indicate a hash of a finalization committee,
+/// derived from the weights and aggregation keys of the finalizers.
+pub enum FinalizationCommitteeMarker {}
+
 /// The leadership election nonce is an unpredictable value updated once an
 /// epoch to make sure that bakers cannot predict too far in the future when
 /// they will win blocks.
@@ -54,3 +59,5 @@ pub type UpdateSignHash = HashBytes<UpdateSignMarker>;
 pub type StateHash = HashBytes<StateMarker>;
 /// Hash that is a successor proof of an epoch finalization entry.
 pub type SuccessorProof = HashBytes<SuccessorProofMarker>;
+/// Hash of a finalization committee.
+pub type FinalizationCommitteeHash = HashBytes<FinalizationCommitteeMarker>;


### PR DESCRIPTION
## Purpose

Relates to: https://github.com/Concordium/concordium-rust-sdk/issues/216

Add a type `FinalizationCommitteeHash` for use in the Rust SDK.

## Changes

- Add `FinalizationCommitteeHash`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
