### PR TITLE
Bump version and release concordium_base.

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased changes
 
+## 7.0.0 (2025-02-03)
+
 - Add getter function `reward_period_epochs` to access the field in the struct `RewardPeriodLength`.
 - Add constructor `TokenAddress::new` for CIS2 type `TokenAddress`.
 - Introduce new chain parameters `ValidatorScoreParameters` that contain the
@@ -7,7 +9,7 @@
 - Add `Default` instance for `UpdateSequenceNumber`.
 - Add `FinalizationCommitteeHash` type.
 
-## 6.0.0
+## 6.0.0 (2024-08-26)
 
 - Extend `id::types::ATTRIBUTE_NAMES` with new company attribute tags: "legalName", "legalCountry", "businessNumber" and "registationAuth".
 - Add a new module `cis3_types` that defines the interface types for CIS3

--- a/rust-src/concordium_base/Cargo.toml
+++ b/rust-src/concordium_base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_base"
-version = "6.0.0"
+version = "7.0.0"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 rust-version = "1.73"


### PR DESCRIPTION
## Purpose

Release `concordium_base` 7.0.0
