### PR TITLE
Parallelized the running of tests using rayon.

### DIFF
--- a/smart-contracts/wasm-chain-integration/Cargo.lock
+++ b/smart-contracts/wasm-chain-integration/Cargo.lock
@@ -380,6 +380,7 @@ dependencies = [
  "ptree",
  "quickcheck",
  "rand",
+ "rayon",
  "secp256k1",
  "serde 1.0.213",
  "sha2",

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -39,6 +39,7 @@ ptree = { version = "0.4.0", optional = true }
 futures = {version = "0.3", optional = true }
 arbitrary = { version = "1.3", features = ["derive"], optional = true }
 rand = { version = "=0.8", features = ["small_rng"] }
+rayon = "1.10.0"
 
 [dependencies.concordium-wasm]
 path = "../wasm-transform"

--- a/smart-contracts/wasm-chain-integration/src/utils.rs
+++ b/smart-contracts/wasm-chain-integration/src/utils.rs
@@ -20,6 +20,7 @@ use concordium_wasm::{
 };
 use rand::{prelude::*, RngCore};
 use std::{collections::BTreeMap, default::Default};
+use rayon::prelude::*;
 
 /// A host which traps for any function call.
 pub struct TrapHost;
@@ -270,53 +271,56 @@ pub fn run_module_tests(module_bytes: &[u8], seed: u64) -> ExecResult<Vec<TestRe
         module_bytes,
     )?
     .artifact;
-    let mut out = Vec::with_capacity(artifact.export.len());
-    for name in artifact.export.keys() {
-        if let Some(test_name) = name.as_ref().strip_prefix("concordium_test ") {
-            // create a `TestHost` instance for each test with the usage flag set to `false`
-            let mut initial_state = trie::MutableState::initial_state();
-            let mut loader = trie::Loader::new(Vec::new());
-            let mut test_host = {
-                let inner = initial_state.get_inner(&mut loader);
-                let state = InstanceState::new(loader, inner);
-                TestHost::new(SmallRng::seed_from_u64(seed), state)
-            };
-            let res = artifact.run(&mut test_host, name, &[]);
-            match res {
-                Ok(_) => {
+    let artifact_keys: Vec<_> = artifact.export.keys().collect();
+
+    let get_result = |name: &Name| {
+        let test_name = name.as_ref().strip_prefix("concordium_test ")?;
+
+        // create a `TestHost` instance for each test with the usage flag set to `false`
+        let mut initial_state = trie::MutableState::initial_state();
+        let mut loader = trie::Loader::new(Vec::new());
+        let mut test_host = {
+            let inner = initial_state.get_inner(&mut loader);
+            let state = InstanceState::new(loader, inner);
+            TestHost::new(SmallRng::seed_from_u64(seed), state)
+        };
+        let res = artifact.run(&mut test_host, name, &[]);
+        match res {
+            Ok(_) => {
+                let result = TestResult {
+                    test_name:    test_name.to_owned(),
+                    result:       None,
+                    debug_events: test_host.debug_events,
+                };
+                Some(result)
+            }
+            Err(msg) => {
+                if let Some(err) = msg.downcast_ref::<ReportError>() {
                     let result = TestResult {
                         test_name:    test_name.to_owned(),
-                        result:       None,
+                        result:       Some((err.clone(), test_host.rng_used)),
                         debug_events: test_host.debug_events,
                     };
-                    out.push(result);
+                    Some(result)
+                } else {
+                    let result = TestResult {
+                        test_name:    test_name.to_owned(),
+                        result:       Some((
+                            ReportError::Other {
+                                msg: msg.to_string(),
+                            },
+                            test_host.rng_used,
+                        )),
+                        debug_events: test_host.debug_events,
+                    };
+                    Some(result)
                 }
-                Err(msg) => {
-                    if let Some(err) = msg.downcast_ref::<ReportError>() {
-                        let result = TestResult {
-                            test_name:    test_name.to_owned(),
-                            result:       Some((err.clone(), test_host.rng_used)),
-                            debug_events: test_host.debug_events,
-                        };
-                        out.push(result);
-                    } else {
-                        let result = TestResult {
-                            test_name:    test_name.to_owned(),
-                            result:       Some((
-                                ReportError::Other {
-                                    msg: msg.to_string(),
-                                },
-                                test_host.rng_used,
-                            )),
-                            debug_events: test_host.debug_events,
-                        };
-                        out.push(result);
-                    }
-                }
-            };
+            }
         }
-    }
-    Ok(out)
+    };
+
+    let test_results = artifact_keys.into_par_iter().filter_map(get_result).collect();
+    Ok(test_results)
 }
 
 /// Tries to generate a state schema and schemas for parameters of methods of a


### PR DESCRIPTION
This adds an unnecessary dependency, which is pretty bad for base, so we should either:

- Feature-gate
- Move this to cargo concordium (I prefer this)
- Parallelize with native std functions
- Remove

## Purpose

Tests ought to be run in parallel, instead of sequentially.

In the same vein, we might also consider printing results incrementally, such that the end user sees each test finish, instead of seeing them all by the end. This would give more feedback about what tests take a long time to run and it would also allow the user to see smaller tests fail much faster. This is not implemented in this draft.
