### PR TITLE
Update the cache version in github actions.

### DIFF
--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -173,7 +173,7 @@ jobs:
     # Set up Rust and restore dependencies and targets from cache.
     # This must be done before checking the Rust sources.
     - name: Cache cargo dependencies and targets
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: |
           ~/.cargo/registry
@@ -230,7 +230,7 @@ jobs:
     # but will fall back to cache entries from different versions if no match is found.
     - name: Cache stack global package DB
       id: stack-global
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.stack
         key: ${{ runner.os }}-{{ env.dummy }}-stack-global-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
@@ -238,14 +238,14 @@ jobs:
           ${{ runner.os }}-{{ env.dummy }}-stack-global-${{ matrix.plan.ghc }}
     - name: Cache stack-installed programs in '~/.local/bin'
       id: stack-programs
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.local/bin
         key: ${{ runner.os }}-{{ env.dummy }}-stack-programs-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}
         restore-keys: |
           ${{ runner.os }}-{{ env.dummy }}-stack-programs-${{ matrix.plan.ghc }}
     - name: Cache '.stack-work'
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: .stack-work
         key: ${{ runner.os }}-{{ env.dummy }}-stack-work-${{ matrix.plan.ghc }}-${{ hashFiles('**.yaml') }}


### PR DESCRIPTION
## Purpose

Update the version of the cache action used in the build workflow since v2 has been deprecated.

## Changes

- Update `actions/cache@v2` to `actions/cache@v4`

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
