### PR TITLE
removed get_module_tests

### DIFF
--- a/smart-contracts/wasm-chain-integration/CHANGELOG.md
+++ b/smart-contracts/wasm-chain-integration/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased changes
 
+- Removed `TestResult` and `run_module_tests` since they will be moved to `cargo-concordium`. As part of this `TestHost.rng_used` has been made public.
 - Support more smart contract host-functions in `TestHost` (used by cargo concordium test):
     - `get_slot_time`
     - `get_receive_self_address`

--- a/smart-contracts/wasm-chain-integration/Cargo.toml
+++ b/smart-contracts/wasm-chain-integration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium-smart-contract-engine"
-version = "6.0.0"
+version = "6.1.0"
 authors = ["Concordium <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE"


### PR DESCRIPTION
## Purpose

Removed `get_module_tests` in order to move them to:
- Move the code to `cargo-concordium`
- Parallelize unit test execution
- Incrementally print test results

See also #600 

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
