### PR TITLE
plt: type level constraints for PLT support

### DIFF
--- a/haskell-src/Concordium/Types/ProtocolVersion.hs
+++ b/haskell-src/Concordium/Types/ProtocolVersion.hs
@@ -193,6 +193,17 @@ module Concordium.Types.ProtocolVersion (
     AVSupportsValidatorSuspension,
     PVSupportsValidatorSuspension,
 
+    -- * PLT support
+
+    -- | Determine whether protocol level tokens are supported.
+    SupportsPLT,
+    supportsPLT,
+    sSupportsPLT,
+    -- | Determine whether a specific account version supports protocol level tokens.
+    AVSupportsPLT,
+    -- | Determine whether a specific protocol version supports protocol level tokens.
+    PVSupportsPLT,
+
     -- * Block hash version
 
     -- | The version of the block hashing structure.
@@ -368,6 +379,14 @@ $( singletons
         supportsValidatorSuspension AccountV3 = False
         supportsValidatorSuspension AccountV4 = True
         supportsValidatorSuspension AccountV5 = True
+
+        supportsPLT :: AccountVersion -> Bool
+        supportsPLT AccountV0 = False
+        supportsPLT AccountV1 = False
+        supportsPLT AccountV2 = False
+        supportsPLT AccountV3 = False
+        supportsPLT AccountV4 = False
+        supportsPLT AccountV5 = True
 
         -- \| A type representing the different hashing structures used for the block hash depending on
         -- the protocol version.
@@ -599,6 +618,14 @@ type AVSupportsValidatorSuspension (av :: AccountVersion) =
 -- | Constraint that a protocol version supports validator suspension.
 type PVSupportsValidatorSuspension (pv :: ProtocolVersion) =
     AVSupportsValidatorSuspension (AccountVersionFor pv)
+
+-- | Constraint that an account version supports protocol level tokens.
+type AVSupportsPLT (av :: AccountVersion) =
+    SupportsPLT av ~ 'True
+
+-- | Constraint that a protocol version supports protocol level tokens.
+type PVSupportsPLT (pv :: ProtocolVersion) =
+    AVSupportsPLT (AccountVersionFor pv)
 
 -- | Constraint that an account version supports flexible cooldown.
 --


### PR DESCRIPTION
This commit introduces type-level constraints to ensure functions and fields can only be used with protocol and account versions that support Protocol Level Tokens (PLTs).

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
