### PR TITLE
Refactor `TokenId`

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -322,6 +322,7 @@ test-suite test
       Types.PayloadSerializationSpec
       Types.PayloadSpec
       Types.TimestampSpec
+      Types.TokenIdSpec
       Types.TransactionSerializationSpec
       Types.TransactionSummarySpec
       Types.UpdatesSpec

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -179,6 +179,11 @@ module Concordium.Types (
     -- * PartsPerHundredThousands
     PartsPerHundredThousands (..),
     partsPerHundredThousandsToRational,
+
+    -- * Protocol-level tokens
+    TokenId (..),
+    makeTokenId,
+    unsafeGetTokenId,
 ) where
 
 import Data.Data (Data, Typeable)
@@ -1144,6 +1149,44 @@ createAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. re
   where
     rest = FBS.encodeInteger (toInteger (count .&. 0xffffff))
     mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
+
+-- * Protocol-level tokens
+
+-- | The unique token identifier for a protocol-level token.
+--  This is given as a symbol unique across the whole chain.
+--  The byte string must be at most 255 bytes long and be a valid UTF-8 string.
+newtype TokenId = TokenId {tokenSymbol :: BSS.ShortByteString}
+    deriving newtype (Eq, Ord, Show)
+
+-- | Try to construct a valid 'TokenId' from a 'BSS.ShortByteString'.
+--  This can fail if the string is longer than 255 bytes or is not valid UTF-8.
+--  In the event of a failure @Left err@ is returned, where @err@ describes the failure.
+makeTokenId :: BSS.ShortByteString -> Either String TokenId
+makeTokenId sbs
+    | BSS.length sbs > 255 =
+        Left $ "TokenId length (" ++ show (BSS.length sbs) ++ ") out of bounds."
+    | Left decodeErr <- T.decodeUtf8' (BSS.fromShort sbs) =
+        Left $ "TokenId is not valid UTF-8: " ++ show decodeErr
+    | otherwise = Right $ TokenId sbs
+
+instance S.Serialize TokenId where
+    put (TokenId tid) = do
+        S.putWord8 $ fromIntegral $ BSS.length tid
+        S.putShortByteString tid
+    get = do
+        len <- S.getWord8
+        sbs <- S.getShortByteString (fromIntegral len)
+        case makeTokenId sbs of
+            Left e -> fail e
+            Right tokId -> return tokId
+
+-- | Deserialize a 'TokenId' without checking the invariant that the string is valid UTF-8.
+--  This should only be used where deserializing from a trusted source.
+unsafeGetTokenId :: S.Get TokenId
+unsafeGetTokenId = do
+    len <- S.getWord8
+    sbs <- S.getShortByteString (fromIntegral len)
+    return (TokenId sbs)
 
 -- Template haskell derivations. At the end to get around staging restrictions.
 $(deriveJSON defaultOptions{sumEncoding = TaggedObject{tagFieldName = "type", contentsFieldName = "address"}} ''Address)

--- a/haskell-src/Concordium/Types/Queries/Tokens.hs
+++ b/haskell-src/Concordium/Types/Queries/Tokens.hs
@@ -1,12 +1,11 @@
+{-# LANGUAGE DerivingStrategies #-}
+
 -- | Types for protocol level tokens (PLT).
 module Concordium.Types.Queries.Tokens where
 
-import qualified Data.ByteString.Short as BS
 import Data.Word
 
--- | The unique token identifier. This is given as a symbol unique across the
---  whole chain.
-newtype TokenId = TokenId {symbol :: BS.ShortByteString} deriving (Eq, Show)
+import Concordium.Types
 
 -- | The token amount representation.
 --  The amount is computed as `amount = digits * 10^(-nrDecimals)`.

--- a/haskell-tests/Spec.hs
+++ b/haskell-tests/Spec.hs
@@ -24,6 +24,7 @@ import qualified Types.ParametersSpec
 import qualified Types.PayloadSerializationSpec
 import qualified Types.PayloadSpec
 import qualified Types.TimestampSpec
+import qualified Types.TokenIdSpec
 import qualified Types.TransactionSerializationSpec
 import qualified Types.TransactionSummarySpec
 import qualified Types.UpdatesSpec
@@ -60,3 +61,4 @@ main = hspec $ parallel $ do
     Types.PayloadSpec.tests
     Genesis.ParametersSpec.tests
     Types.ValidName.tests
+    Types.TokenIdSpec.tests

--- a/haskell-tests/Types/TokenIdSpec.hs
+++ b/haskell-tests/Types/TokenIdSpec.hs
@@ -1,0 +1,128 @@
+{-# LANGUAGE BinaryLiterals #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Types.TokenIdSpec where
+
+import Control.Monad
+import Data.Bits
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Short as BSS
+import Data.Serialize
+import Data.Word
+import Test.HUnit
+import Test.Hspec
+import Test.QuickCheck hiding ((.&.))
+
+import Concordium.Types
+
+-- | Generate a valid UTF-8 character. The size argument is used to determine how many bytes in
+--  size this can be (up to 4).
+genUtf8Char :: Gen [Word8]
+genUtf8Char = do
+    sz <- getSize
+    oneof $ [oneByte] ++ [twoByte | sz >= 2] ++ [threeByte | sz >= 3] ++ [fourByte | sz >= 4]
+  where
+    oneByte = do
+        cp <- chooseBoundedIntegral (0x00, 0x7f)
+        return [cp]
+    twoByte = do
+        (cp :: Word32) <- chooseBoundedIntegral (0x80, 0x07ff)
+        return
+            [ 0b11000000 .|. fromIntegral (cp `shiftR` 6),
+              0b10000000 .|. (fromIntegral cp .&. 0b00111111)
+            ]
+    threeByte = do
+        -- Surrogate codepoints are disallowed.
+        (cp :: Word32) <-
+            chooseBoundedIntegral (0x0800, 0xffff)
+                `suchThat` (\x -> x < 0xd800 || x > 0xdfff)
+        return
+            [ 0b11100000 .|. (fromIntegral (cp `shiftR` 12)),
+              0b10000000 .|. (0b00111111 .&. fromIntegral (cp `shiftR` 6)),
+              0b10000000 .|. (0b00111111 .&. fromIntegral cp)
+            ]
+    fourByte = do
+        (cp :: Word32) <- chooseBoundedIntegral (0x010000, 0x10ffff)
+        return
+            [ 0b11110000 .|. (fromIntegral (cp `shiftR` 18)),
+              0b10000000 .|. (0b00111111 .&. fromIntegral (cp `shiftR` 12)),
+              0b10000000 .|. (0b00111111 .&. fromIntegral (cp `shiftR` 6)),
+              0b10000000 .|. (0b00111111 .&. fromIntegral cp)
+            ]
+
+-- | Generate a valid UTF-8 string of the specified length.
+genUtf8String :: Int -> Gen [Word8]
+genUtf8String len
+    | len <= 0 = return []
+    | otherwise = do
+        c <- resize len genUtf8Char
+        rest <- genUtf8String (len - length c)
+        return (c ++ rest)
+
+-- | Shrink a UTF-8 string by removing one character in every possible way.
+shrinkUtf8String :: [Word8] -> [[Word8]]
+shrinkUtf8String [] = []
+shrinkUtf8String (a : r)
+    | a .&. 0b10000000 == 0 = r : ((a :) <$> shrinkUtf8String r)
+shrinkUtf8String (a : b : r)
+    | a .&. 0b11100000 == 0b11000000 = r : ((\r' -> a : b : r') <$> shrinkUtf8String r)
+shrinkUtf8String (a : b : c : r)
+    | a .&. 0b11110000 == 0b11100000 = r : ((\r' -> a : b : c : r') <$> shrinkUtf8String r)
+shrinkUtf8String (a : b : c : d : r)
+    | a .&. 0b11111000 == 0b11110000 = r : ((\r' -> a : b : c : d : r') <$> shrinkUtf8String r)
+shrinkUtf8String _ = error "shrinkUtf8String: invalid UTF-8 string"
+
+instance Arbitrary TokenId where
+    arbitrary = do
+        len <- chooseBoundedIntegral (0, 255)
+        TokenId . BSS.pack <$> genUtf8String len
+    shrink (TokenId tid) = [TokenId (BSS.pack shrunk) | shrunk <- shrinkUtf8String (BSS.unpack tid)]
+
+-- | Deserialize a value, ensuring that the input is fully consumed.
+decodeFull :: Get a -> BS.ByteString -> Either String a
+decodeFull getter =
+    runGet
+        ( do
+            g <- getter
+            done <- isEmpty
+            unless done $ fail "Input was not fully consumed"
+            return g
+        )
+
+-- | Test serializing and deserializing a valid 'TokenId'.
+testEncodeDecode :: Property
+testEncodeDecode = property $ \(tid :: TokenId) ->
+    decodeFull get (encode tid) == Right tid
+
+-- | Test serializing and unsafe-deserializing a valid 'TokenId'.
+testEncodeDecodeUnsafe :: Property
+testEncodeDecodeUnsafe = property $ \(tid :: TokenId) ->
+    decodeFull unsafeGetTokenId (encode tid) == Right tid
+
+-- | Test some invalid 'TokenId's
+testInvalidTokenIds :: Spec
+testInvalidTokenIds = do
+    -- Not a valid byte
+    checkInvalid "\xff"
+    -- Surrogate codepoint
+    checkInvalid "\xed\xbf\xbf"
+    -- Expect additional bytes
+    checkInvalid "\xcf"
+    checkInvalid "\xe0\xa0"
+    -- Overlong encoding
+    checkInvalid "\xc2\x01"
+    -- Too long
+    checkInvalid $ BSS.pack (replicate 256 0x41)
+  where
+    checkInvalid sbs = it ("makeTokenId invalid case: " ++ show sbs) $ case makeTokenId sbs of
+        Left _ -> return ()
+        Right _ -> assertFailure "makeTokenId should fail."
+
+-- | Tests for 'TokenId's.
+tests :: Spec
+tests = describe "TokenId" $ do
+    it "Serialization and deserialization of valid TokenIds" $ withMaxSuccess 10000 testEncodeDecode
+    it "Serialization and unsafe deserialization of valid TokenIds" $ withMaxSuccess 10000 testEncodeDecodeUnsafe
+    testInvalidTokenIds


### PR DESCRIPTION
## Purpose

Move `TokenId` into `Concordium.Types` and add some serialization and testing.

## Changes

- Move `TokenId`.
- Add `Ord` and `Serialize` instances. Change `Show` instance to use newtype deriving (i.e. show as a `ShortByteString`).
- Add parsing constructor `makeTokenId`.
- Add unsafe deserialization (does not check UTF-8 validity)
- Testing

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
