### PR TITLE
CBOR (de)serialization for token initialization parameter

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -90,6 +90,7 @@ library
       Concordium.Types.InvokeContract
       Concordium.Types.Migration
       Concordium.Types.Parameters
+      Concordium.Types.ProtocolLevelTokens.CBOR
       Concordium.Types.ProtocolVersion
       Concordium.Types.ProtocolVersion.TH
       Concordium.Types.Queries
@@ -140,6 +141,7 @@ library
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , containers >=0.6
     , cryptonite >=0.27
@@ -202,6 +204,7 @@ executable generate-update-keys
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6
@@ -262,6 +265,7 @@ executable genesis
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , cmdargs >=0.10
     , concordium-base
@@ -318,6 +322,7 @@ test-suite test
       Types.AddressesSpec
       Types.AmountFraction
       Types.AmountSpec
+      Types.CBOR
       Types.ParametersSpec
       Types.PayloadSerializationSpec
       Types.PayloadSpec
@@ -352,6 +357,7 @@ test-suite test
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers
@@ -413,6 +419,7 @@ benchmark bls-perf
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6
@@ -471,6 +478,7 @@ benchmark ed25519-perf
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6
@@ -529,6 +537,7 @@ benchmark ed25519dlog-perf
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6
@@ -587,6 +596,7 @@ benchmark sha256-perf
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6
@@ -645,6 +655,7 @@ benchmark verify-credential-perf
     , base64-bytestring >=1.1.0.0
     , binary >=0.8
     , bytestring >=0.10
+    , cborg >=0.2
     , cereal >=0.5
     , concordium-base
     , containers >=0.6

--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -98,6 +98,7 @@ library
       Concordium.Types.Queries.Tokens
       Concordium.Types.SeedState
       Concordium.Types.SmartContracts
+      Concordium.Types.Tokens
       Concordium.Types.Transactions
       Concordium.Types.UpdateQueues
       Concordium.Types.Updates

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -1161,6 +1161,8 @@ createAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. re
     rest = FBS.encodeInteger (toInteger (count .&. 0xffffff))
     mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
 
+-- * Protocol level tokens
+
 -- | Parameter for a Token module.
 newtype TokenParameter = TokenParameter {parameterBytes :: BSS.ShortByteString}
     deriving (Eq)
@@ -1246,7 +1248,8 @@ instance AE.ToJSON CreatePLT where
               "tokenModule" AE..= _cpltTokenModule,
               "governanceAccount" AE..= _cpltGovernanceAccount,
               "decimals" AE..= _cpltDecimals,
-              "initializationParameters" AE..= _cpltInitializationParameters
+              "initializationParameters"
+                AE..= EncodedTokenInitializationParameters _cpltInitializationParameters
             ]
 
 instance AE.FromJSON CreatePLT where
@@ -1255,7 +1258,8 @@ instance AE.FromJSON CreatePLT where
         _cpltTokenModule <- o AE..: "tokenModule"
         _cpltGovernanceAccount <- o AE..: "governanceAccount"
         _cpltDecimals <- o AE..: "decimals"
-        _cpltInitializationParameters <- o AE..: "initializationParameters"
+        (EncodedTokenInitializationParameters _cpltInitializationParameters) <-
+            o AE..: "initializationParameters"
         return CreatePLT{..}
 
 -- Template haskell derivations. At the end to get around staging restrictions.

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -211,8 +211,10 @@ import qualified Concordium.Crypto.VRF as VRF
 import Concordium.ID.Types
 import Concordium.Types.Block
 import Concordium.Types.HashableTo
+import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 import Concordium.Types.ProtocolVersion
 import Concordium.Types.SmartContracts
+import Concordium.Types.Tokens
 import qualified Data.FixedByteString as FBS
 
 import Control.Exception (assert)
@@ -220,6 +222,7 @@ import Control.Monad
 import Control.Monad.Except
 
 import Data.Bits
+import qualified Data.ByteString.Builder as BSBuilder
 import Data.ByteString.Char8 (ByteString)
 import qualified Data.ByteString.Char8 as BS
 import qualified Data.ByteString.Short as BSS
@@ -231,7 +234,6 @@ import Data.Word
 
 import Data.Aeson as AE
 import Data.Aeson.TH
-import Data.Aeson.Types as AE
 
 import Data.Time
 import Data.Time.Clock.POSIX
@@ -1159,53 +1161,6 @@ createAlias (AccountAddress addr) count = AccountAddress ((addr .&. mask) .|. re
     rest = FBS.encodeInteger (toInteger (count .&. 0xffffff))
     mask = complement (FBS.encodeInteger 0xffffff) -- mask to clear out the last three bytes of the addr
 
--- * Protocol-level tokens
-
--- | The unique token identifier for a protocol-level token.
---  This is given as a symbol unique across the whole chain.
---  The byte string must be at most 255 bytes long and be a valid UTF-8 string.
-newtype TokenId = TokenId {tokenSymbol :: BSS.ShortByteString}
-    deriving newtype (Eq, Ord, Show)
-
--- | Try to construct a valid 'TokenId' from a 'BSS.ShortByteString'.
---  This can fail if the string is longer than 255 bytes or is not valid UTF-8.
---  In the event of a failure @Left err@ is returned, where @err@ describes the failure.
-makeTokenId :: BSS.ShortByteString -> Either String TokenId
-makeTokenId sbs
-    | BSS.length sbs > 255 =
-        Left $ "TokenId length (" ++ show (BSS.length sbs) ++ ") out of bounds."
-    | Left decodeErr <- T.decodeUtf8' (BSS.fromShort sbs) =
-        Left $ "TokenId is not valid UTF-8: " ++ show decodeErr
-    | otherwise = Right $ TokenId sbs
-
-instance S.Serialize TokenId where
-    put (TokenId tid) = do
-        S.putWord8 $ fromIntegral $ BSS.length tid
-        S.putShortByteString tid
-    get = do
-        len <- S.getWord8
-        sbs <- S.getShortByteString (fromIntegral len)
-        case makeTokenId sbs of
-            Left e -> fail e
-            Right tokId -> return tokId
-
--- | Deserialize a 'TokenId' without checking the invariant that the string is valid UTF-8.
---  This should only be used where deserializing from a trusted source.
-unsafeGetTokenId :: S.Get TokenId
-unsafeGetTokenId = do
-    len <- S.getWord8
-    sbs <- S.getShortByteString (fromIntegral len)
-    return (TokenId sbs)
-
-instance AE.ToJSON TokenId where
-    -- decodeUtf8 will throw an exception if it fails, but we should be safe since the TokenId
-    -- should enforce valid UTF-8.
-    toJSON TokenId{..} = AE.String $ T.decodeUtf8 $ BSS.fromShort tokenSymbol
-
-instance AE.FromJSON TokenId where
-    parseJSON (AE.String text) = return $ TokenId $ BSS.toShort $ T.encodeUtf8 text
-    parseJSON invalid = AE.prependFailure "parsing TokenId failed" (AE.typeMismatch "String" invalid)
-
 -- | Parameter for a Token module.
 newtype TokenParameter = TokenParameter {parameterBytes :: BSS.ShortByteString}
     deriving (Eq)
@@ -1218,6 +1173,30 @@ instance S.Serialize TokenParameter where
     put (TokenParameter parameter) = do
         S.putWord32be (fromIntegral (BSS.length parameter))
         S.putShortByteString parameter
+
+-- | A wrapper type for (de)-serializing an CBOR-encoded initialization parameter to/from JSON.
+--  This can parse either an JSON object representation of 'TokenInitializationParameters'
+--  (which is then re-encoded as CBOR) or a hex-encoded byte string. When rendering JSON,
+--  it will render as a JSON object if the contents can be decoded to a
+-- 'TokenInitializationParameters', or otherwise as the hex-encoded byte string.
+newtype EncodedTokenInitializationParameters = EncodedTokenInitializationParameters TokenParameter
+
+instance AE.ToJSON EncodedTokenInitializationParameters where
+    toJSON (EncodedTokenInitializationParameters tp@(TokenParameter sbs)) =
+        case CBOR.tokenInitializationParametersFromBytes
+            (BSBuilder.toLazyByteString $ BSBuilder.shortByteString sbs) of
+            Left _ -> AE.toJSON tp
+            Right v -> AE.toJSON v
+
+instance AE.FromJSON EncodedTokenInitializationParameters where
+    parseJSON o@(AE.Object _) = do
+        tip <- AE.parseJSON o
+        return $
+            EncodedTokenInitializationParameters $
+                TokenParameter $
+                    BSS.toShort $
+                        CBOR.tokenInitializationParametersToBytes tip
+    parseJSON val = EncodedTokenInitializationParameters <$> AE.parseJSON val
 
 -- | A hash that identifies the specific implementation to use for a token.
 newtype TokenModuleRef = TokenModuleRef {theTokenModuleRef :: Hash.Hash}

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1,0 +1,156 @@
+{-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Concordium.Types.ProtocolLevelTokens.CBOR where
+
+import Codec.CBOR.Decoding
+import Control.Monad
+import Data.Maybe
+import Data.Scientific
+import Data.Text
+import Data.Word
+import Lens.Micro.Platform
+
+import Concordium.Types.Queries.Tokens
+
+-- | The parsed token-initialization-parameters. These parameters are passed to the token module
+--  to initialize the token.
+data TokenInitializationParameters = TokenInitializationParameters
+    { -- | The name of the token.
+      tipName :: !Text,
+      -- | A URL pointing to the token metadata.
+      tipMetadata :: !Text,
+      -- | Whether the token supports an allow list.
+      tipAllowList :: !Bool,
+      -- | Whether the token supports a deny list.
+      tipDenyList :: !Bool,
+      -- | The initial supply of the token. If not present, no tokens are minted initially.
+      tipInitialSupply :: !(Maybe TokenAmount),
+      -- | Whether the token is mintable.
+      tipMintable :: !Bool,
+      -- | Whether the token is burnable.
+      tipBurnable :: !Bool
+    }
+    deriving (Eq, Show)
+
+data TokenInitializationParametersBuilder = TokenInitializationParametersBuilder
+    { _tipbName :: Maybe Text,
+      _tipbMetadata :: Maybe Text,
+      _tipbAllowList :: Maybe Bool,
+      _tipbDenyList :: Maybe Bool,
+      _tipbInitialSupply :: Maybe TokenAmount,
+      _tipbMintable :: Maybe Bool,
+      _tipbBurnable :: Maybe Bool
+    }
+
+makeLenses ''TokenInitializationParametersBuilder
+
+-- | A 'TokenInitializationParametersBuilder' with no fields initialized.
+emptyTokenInitializationParametersBuilder :: TokenInitializationParametersBuilder
+emptyTokenInitializationParametersBuilder =
+    TokenInitializationParametersBuilder Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+
+orFail :: Maybe a -> b -> Either b a
+orFail Nothing = Left
+orFail (Just v) = const (Right v)
+
+orDefault :: Maybe a -> a -> a
+orDefault Nothing = id
+orDefault (Just a) = const a
+
+buildTokenInitializationParameters :: TokenInitializationParametersBuilder -> Either String TokenInitializationParameters
+buildTokenInitializationParameters TokenInitializationParametersBuilder{..} = do
+    tipName <- _tipbName `orFail` "Missing 'name'"
+    tipMetadata <- _tipbMetadata `orFail` "Missing 'metadata'"
+    let tipAllowList = _tipbAllowList `orDefault` False
+    let tipDenyList = _tipbDenyList `orDefault` False
+    let tipInitialSupply = _tipbInitialSupply
+    let tipMintable = _tipbMintable `orDefault` False
+    let tipBurnable = _tipbBurnable `orDefault` False
+    return TokenInitializationParameters{..}
+
+data MapValueDecoder s a = forall b.
+      MapValueDecoder
+    { mvdDecoder :: Decoder s b,
+      mvdTrySet :: b -> a -> Maybe a
+    }
+
+-- | Given a 'Lens'' for a field in a builder, set the field to the given value if it is not
+--  already present. If a value is already present, then this returns @Nothing@.
+trySet :: Lens' a (Maybe b) -> b -> a -> Maybe a
+trySet l = \v -> l (maybe (Just (Just v)) (const Nothing))
+
+decodeMap :: (Text -> Maybe (MapValueDecoder s builder)) -> (builder -> Either String r) -> builder -> Decoder s r
+decodeMap valDecoder runBuilder emptyBuilder = do
+    builder <-
+        decodeMapLenOrIndef >>= \case
+            Nothing -> decodeIndef emptyBuilder
+            Just len -> decodeDef len emptyBuilder
+    case runBuilder builder of
+        Left e -> fail e
+        Right r -> return r
+  where
+    decodeKV builder = do
+        key <- decodeString
+        case valDecoder key of
+            Nothing -> fail $ "Unexpected key " ++ show key
+            Just MapValueDecoder{..} -> do
+                val <- mvdDecoder
+                case mvdTrySet val builder of
+                    Nothing -> fail $ "Key already set: " ++ show key
+                    Just builder' -> return builder'
+    decodeIndef builder = do
+        decodeBreakOr >>= \case
+            True -> return builder
+            False -> do
+                builder' <- decodeKV builder
+                decodeIndef builder'
+    decodeDef n builder
+        | n > 0 = decodeDef (n - 1) =<< decodeKV builder
+        | otherwise = return builder
+
+decodeDecimalFraction :: Decoder s Scientific
+decodeDecimalFraction = do
+    tag <- decodeTag
+    unless (tag == 4) $ fail $ "Expected decimal fraction (tag 4), but found tag " ++ show tag
+    mLen <- decodeListLenOrIndef
+    forM_ mLen $ \len ->
+        unless (len == 2) $
+            fail $
+                "Expected an array of length 2, but length was " ++ show len
+    exp10 <- decodeInt
+    mantissa <- decodeInteger
+    when (isNothing mLen) $ decodeBreakOr >>= \b -> unless b (fail "Expected end of array")
+    return $ scientific mantissa exp10
+
+decodeTokenAmount :: Decoder s TokenAmount
+decodeTokenAmount = do
+    sci <- decodeDecimalFraction
+    unless (coefficient sci >= 0) $ fail "Unexpected negative token amount"
+    unless (coefficient sci <= fromIntegral (maxBound :: Word64)) $
+        fail "Token amount exceeds expressible bound"
+    unless (base10Exponent sci <= 0) $ fail "Token amount cannot have a positive exponent"
+    unless (base10Exponent sci >= -255) $ fail "Token amount exponent is too small"
+    return
+        TokenAmount
+            { digits = fromIntegral (coefficient sci),
+              nrDecimals = fromIntegral (negate (base10Exponent sci))
+            }
+
+decodeTokenInitializationParameters :: Decoder s TokenInitializationParameters
+decodeTokenInitializationParameters =
+    decodeMap
+        valDecoder
+        buildTokenInitializationParameters
+        emptyTokenInitializationParametersBuilder
+  where
+    valDecoder "name" = Just $ MapValueDecoder decodeString (trySet tipbName)
+    valDecoder "metadata" = Just $ MapValueDecoder decodeString (trySet tipbMetadata)
+    valDecoder "allowList" = Just $ MapValueDecoder decodeBool (trySet tipbAllowList)
+    valDecoder "denyList" = Just $ MapValueDecoder decodeBool (trySet tipbAllowList)
+    valDecoder "initialSupply" = Just $ MapValueDecoder decodeTokenAmount (trySet tipbInitialSupply)
+    valDecoder "mintable" = Just $ MapValueDecoder decodeBool (trySet tipbMintable)
+    valDecoder "burnable" = Just $ MapValueDecoder decodeBool (trySet tipbBurnable)
+    valDecoder _ = Nothing

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ExistentialQuantification #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
@@ -6,7 +5,12 @@
 module Concordium.Types.ProtocolLevelTokens.CBOR where
 
 import Codec.CBOR.Decoding
+import Codec.CBOR.Encoding
+import qualified Codec.CBOR.Write as CBOR
 import Control.Monad
+import qualified Data.ByteString.Lazy as LBS
+import Data.Function
+import qualified Data.Map.Lazy as Map
 import Data.Maybe
 import Data.Scientific
 import Data.Text
@@ -14,6 +18,147 @@ import Data.Word
 import Lens.Micro.Platform
 
 import Concordium.Types.Queries.Tokens
+
+-- * Decoder helpers
+
+-- | A 'MapValueDecoder' consumes a value corresponding to a known key and sets it in the builder.
+--  It should fail if entry in the builder corresponding to the key is already set.
+type MapValueDecoder s builder = builder -> Decoder s builder
+
+-- | Build a 'MapValueDecoder' for a particular key. This enforces that a field cannot be set more
+--  than once.
+mapValueDecoder ::
+    -- | The key being decoded (used for error reporting).
+    Text ->
+    -- | The decoder to use for the value.
+    Decoder s v ->
+    -- | A lens to access the field on the builder.
+    Lens' builder (Maybe v) ->
+    MapValueDecoder s builder
+mapValueDecoder key decodeVal l = \builder -> do
+    val <- decodeVal
+    case builder ^. l of
+        Nothing -> return $ builder & l ?~ val
+        Just _ -> fail $ "Key already set: " ++ show key
+
+-- | Decode a CBOR-encoded map to type @r@. This exclusively supports UTF-8 string keys.
+--  The decoding uses a @builder@ type that is used to progressively decode the map.
+--  The first argument is a function that determines if each key is allowed, and if so,
+--  how the corresponding value should be decoded and added to the builder.
+decodeMap ::
+    -- | Function that determines the 'MapValueDecoder' for a map key.
+    (Text -> Maybe (MapValueDecoder s builder)) ->
+    -- | Function to run the builder and produce a value.
+    (builder -> Either String r) ->
+    -- | The empty builder.
+    builder ->
+    Decoder s r
+decodeMap valDecoder runBuilder emptyBuilder = do
+    builder <-
+        decodeMapLenOrIndef >>= \case
+            Nothing -> decodeIndef emptyBuilder
+            Just len -> decodeDef len emptyBuilder
+    case runBuilder builder of
+        Left e -> fail e
+        Right r -> return r
+  where
+    decodeKV builder = do
+        key <- decodeString
+        case valDecoder key of
+            Nothing -> fail $ "Unexpected key " ++ show key
+            Just decoder -> decoder builder
+    decodeIndef builder = do
+        decodeBreakOr >>= \case
+            True -> return builder
+            False -> do
+                builder' <- decodeKV builder
+                decodeIndef builder'
+    decodeDef n builder
+        | n > 0 = decodeDef (n - 1) =<< decodeKV builder
+        | otherwise = return builder
+
+-- | Decode a CBOR decimal fraction into a 'Scientific'. The result is not normalized.
+decodeDecimalFraction :: Decoder s Scientific
+decodeDecimalFraction = do
+    tag <- decodeTag
+    unless (tag == 4) $ fail $ "Expected decimal fraction (tag 4), but found tag " ++ show tag
+    mLen <- decodeListLenOrIndef
+    forM_ mLen $ \len ->
+        unless (len == 2) $
+            fail $
+                "Expected an array of length 2, but length was " ++ show len
+    exp10 <- decodeInt
+    mantissa <- decodeInteger
+    when (isNothing mLen) $ decodeBreakOr >>= \b -> unless b (fail "Expected end of array")
+    return $ scientific mantissa exp10
+
+-- * Encoding helpers
+
+-- | An 'Encoding' that represents a key in a CBOR map. The 'Ord' instance corresponds to
+--  lexicographic ording of the CBOR encodings, so that these can be used to order keys for
+--  deterministic CBOR encoding.
+data MapKeyEncoding = MapKeyEncoding
+    { meEncoding :: Encoding,
+      meBytes :: LBS.ByteString
+    }
+
+instance Eq MapKeyEncoding where
+    (==) = (==) `on` meBytes
+
+instance Ord MapKeyEncoding where
+    compare = compare `on` meBytes
+
+-- | Convert an 'Encoding' to a 'MapKeyEncoding'
+makeMapKeyEncoding :: Encoding -> MapKeyEncoding
+makeMapKeyEncoding meEncoding = MapKeyEncoding{meBytes = CBOR.toLazyByteString meEncoding, ..}
+
+-- | Encode a map deterministically. Specifically, the map length is definite and the keys are
+--  ordered in bytewise lexicographic order. It is assumed that all encodings in the map are
+--  deterministic.
+encodeMapDeterministic :: Map.Map MapKeyEncoding Encoding -> Encoding
+encodeMapDeterministic m =
+    encodeMapLen (fromIntegral $ Map.size m)
+        <> mconcat [meEncoding k <> v | (k, v) <- Map.toAscList m]
+
+-- * Builder helpers
+
+-- | Convert a 'Maybe' to an 'Either'.
+orFail :: Maybe a -> b -> Either b a
+orFail Nothing = Left
+orFail (Just v) = const (Right v)
+
+-- | Unwrap a 'Maybe' using a supplied default value.
+orDefault :: Maybe a -> a -> a
+orDefault Nothing = id
+orDefault (Just a) = const a
+
+-- * Token amounts
+
+-- | Decode a CBOR-encoded 'TokenAmount'. This limits the number of decimals to the
+--  range @[0..255]@.
+decodeTokenAmount :: Decoder s TokenAmount
+decodeTokenAmount = do
+    sci <- decodeDecimalFraction
+    unless (coefficient sci >= 0) $ fail "Unexpected negative token amount"
+    unless (coefficient sci <= fromIntegral (maxBound :: Word64)) $
+        fail "Token amount exceeds expressible bound"
+    unless (base10Exponent sci <= 0) $ fail "Token amount cannot have a positive exponent"
+    unless (base10Exponent sci >= -255) $ fail "Token amount exponent is too small"
+    return
+        TokenAmount
+            { digits = fromIntegral (coefficient sci),
+              nrDecimals = fromIntegral (negate (base10Exponent sci))
+            }
+
+-- | Encode a 'TokenAmount' as CBOR.
+encodeTokenAmount :: TokenAmount -> Encoding
+encodeTokenAmount TokenAmount{..} =
+    encodeTag 4
+        <> encodeListLen 2
+        <> encodeInteger (-fromIntegral nrDecimals)
+        <> encodeWord64 digits
+
+-- * Initialization parameters
 
 -- | The parsed token-initialization-parameters. These parameters are passed to the token module
 --  to initialize the token.
@@ -35,6 +180,7 @@ data TokenInitializationParameters = TokenInitializationParameters
     }
     deriving (Eq, Show)
 
+-- | Builder for 'TokenInitializationParameters'
 data TokenInitializationParametersBuilder = TokenInitializationParametersBuilder
     { _tipbName :: Maybe Text,
       _tipbMetadata :: Maybe Text,
@@ -52,18 +198,14 @@ emptyTokenInitializationParametersBuilder :: TokenInitializationParametersBuilde
 emptyTokenInitializationParametersBuilder =
     TokenInitializationParametersBuilder Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
-orFail :: Maybe a -> b -> Either b a
-orFail Nothing = Left
-orFail (Just v) = const (Right v)
-
-orDefault :: Maybe a -> a -> a
-orDefault Nothing = id
-orDefault (Just a) = const a
-
-buildTokenInitializationParameters :: TokenInitializationParametersBuilder -> Either String TokenInitializationParameters
+-- | Construct a 'TokenInitializationParameters' from a 'TokenInitializationParametersBuilder'.
+--  This results in @Left err@ (where @err@ describes the failure reason) when a required parameter
+--  is missing. Missing optional parameters are populated with the appropriate default values.
+buildTokenInitializationParameters ::
+    TokenInitializationParametersBuilder -> Either String TokenInitializationParameters
 buildTokenInitializationParameters TokenInitializationParametersBuilder{..} = do
-    tipName <- _tipbName `orFail` "Missing 'name'"
-    tipMetadata <- _tipbMetadata `orFail` "Missing 'metadata'"
+    tipName <- _tipbName `orFail` "Missing \"name\""
+    tipMetadata <- _tipbMetadata `orFail` "Missing \"metadata\""
     let tipAllowList = _tipbAllowList `orDefault` False
     let tipDenyList = _tipbDenyList `orDefault` False
     let tipInitialSupply = _tipbInitialSupply
@@ -71,74 +213,10 @@ buildTokenInitializationParameters TokenInitializationParametersBuilder{..} = do
     let tipBurnable = _tipbBurnable `orDefault` False
     return TokenInitializationParameters{..}
 
-data MapValueDecoder s a = forall b.
-      MapValueDecoder
-    { mvdDecoder :: Decoder s b,
-      mvdTrySet :: b -> a -> Maybe a
-    }
-
--- | Given a 'Lens'' for a field in a builder, set the field to the given value if it is not
---  already present. If a value is already present, then this returns @Nothing@.
-trySet :: Lens' a (Maybe b) -> b -> a -> Maybe a
-trySet l = \v -> l (maybe (Just (Just v)) (const Nothing))
-
-decodeMap :: (Text -> Maybe (MapValueDecoder s builder)) -> (builder -> Either String r) -> builder -> Decoder s r
-decodeMap valDecoder runBuilder emptyBuilder = do
-    builder <-
-        decodeMapLenOrIndef >>= \case
-            Nothing -> decodeIndef emptyBuilder
-            Just len -> decodeDef len emptyBuilder
-    case runBuilder builder of
-        Left e -> fail e
-        Right r -> return r
-  where
-    decodeKV builder = do
-        key <- decodeString
-        case valDecoder key of
-            Nothing -> fail $ "Unexpected key " ++ show key
-            Just MapValueDecoder{..} -> do
-                val <- mvdDecoder
-                case mvdTrySet val builder of
-                    Nothing -> fail $ "Key already set: " ++ show key
-                    Just builder' -> return builder'
-    decodeIndef builder = do
-        decodeBreakOr >>= \case
-            True -> return builder
-            False -> do
-                builder' <- decodeKV builder
-                decodeIndef builder'
-    decodeDef n builder
-        | n > 0 = decodeDef (n - 1) =<< decodeKV builder
-        | otherwise = return builder
-
-decodeDecimalFraction :: Decoder s Scientific
-decodeDecimalFraction = do
-    tag <- decodeTag
-    unless (tag == 4) $ fail $ "Expected decimal fraction (tag 4), but found tag " ++ show tag
-    mLen <- decodeListLenOrIndef
-    forM_ mLen $ \len ->
-        unless (len == 2) $
-            fail $
-                "Expected an array of length 2, but length was " ++ show len
-    exp10 <- decodeInt
-    mantissa <- decodeInteger
-    when (isNothing mLen) $ decodeBreakOr >>= \b -> unless b (fail "Expected end of array")
-    return $ scientific mantissa exp10
-
-decodeTokenAmount :: Decoder s TokenAmount
-decodeTokenAmount = do
-    sci <- decodeDecimalFraction
-    unless (coefficient sci >= 0) $ fail "Unexpected negative token amount"
-    unless (coefficient sci <= fromIntegral (maxBound :: Word64)) $
-        fail "Token amount exceeds expressible bound"
-    unless (base10Exponent sci <= 0) $ fail "Token amount cannot have a positive exponent"
-    unless (base10Exponent sci >= -255) $ fail "Token amount exponent is too small"
-    return
-        TokenAmount
-            { digits = fromIntegral (coefficient sci),
-              nrDecimals = fromIntegral (negate (base10Exponent sci))
-            }
-
+-- | Decode a CBOR-encoded 'TokenInitializationParameters'.
+--  This decoder enforces CBOR-validity (in particular, no duplicate map keys), disallows
+--  extraneous keys, and applies defaults specified by the CDDL schema.  It does not require
+--  deterministic encoding.
 decodeTokenInitializationParameters :: Decoder s TokenInitializationParameters
 decodeTokenInitializationParameters =
     decodeMap
@@ -146,11 +224,44 @@ decodeTokenInitializationParameters =
         buildTokenInitializationParameters
         emptyTokenInitializationParametersBuilder
   where
-    valDecoder "name" = Just $ MapValueDecoder decodeString (trySet tipbName)
-    valDecoder "metadata" = Just $ MapValueDecoder decodeString (trySet tipbMetadata)
-    valDecoder "allowList" = Just $ MapValueDecoder decodeBool (trySet tipbAllowList)
-    valDecoder "denyList" = Just $ MapValueDecoder decodeBool (trySet tipbAllowList)
-    valDecoder "initialSupply" = Just $ MapValueDecoder decodeTokenAmount (trySet tipbInitialSupply)
-    valDecoder "mintable" = Just $ MapValueDecoder decodeBool (trySet tipbMintable)
-    valDecoder "burnable" = Just $ MapValueDecoder decodeBool (trySet tipbBurnable)
+    valDecoder k@"name" = Just $ mapValueDecoder k decodeString tipbName
+    valDecoder k@"metadata" = Just $ mapValueDecoder k decodeString tipbMetadata
+    valDecoder k@"allowList" = Just $ mapValueDecoder k decodeBool tipbAllowList
+    valDecoder k@"denyList" = Just $ mapValueDecoder k decodeBool tipbDenyList
+    valDecoder k@"initialSupply" = Just $ mapValueDecoder k decodeTokenAmount tipbInitialSupply
+    valDecoder k@"mintable" = Just $ mapValueDecoder k decodeBool tipbMintable
+    valDecoder k@"burnable" = Just $ mapValueDecoder k decodeBool tipbBurnable
     valDecoder _ = Nothing
+
+-- | Encode a 'TokenInitializationParameters' as CBOR.
+encodeTokenInitializationParametersNoDefaults :: TokenInitializationParameters -> Encoding
+encodeTokenInitializationParametersNoDefaults TokenInitializationParameters{..} =
+    encodeMapDeterministic $
+        Map.empty
+            & k "name" ?~ encodeString tipName
+            & k "metadata" ?~ encodeString tipMetadata
+            & k "allowList" ?~ encodeBool tipAllowList
+            & k "denyList" ?~ encodeBool tipDenyList
+            & k "initialSupply" .~ (encodeTokenAmount <$> tipInitialSupply)
+            & k "mintable" ?~ encodeBool tipMintable
+            & k "burnable" ?~ encodeBool tipBurnable
+  where
+    k = at . makeMapKeyEncoding . encodeString
+
+-- | Encode a 'TokenInitializationParameters' as CBOR. Keys that hold their default values will
+--  be omitted from the encoding.
+encodeTokenInitializationParametersWithDefaults :: TokenInitializationParameters -> Encoding
+encodeTokenInitializationParametersWithDefaults TokenInitializationParameters{..} =
+    encodeMapDeterministic $
+        Map.empty
+            & k "name" ?~ encodeString tipName
+            & k "metadata" ?~ encodeString tipMetadata
+            & setIfTrue "allowList" tipAllowList
+            & setIfTrue "denyList" tipDenyList
+            & k "initialSupply" .~ (encodeTokenAmount <$> tipInitialSupply)
+            & setIfTrue "mintable" tipMintable
+            & setIfTrue "burnable" tipBurnable
+  where
+    k = at . makeMapKeyEncoding . encodeString
+    setIfTrue _ False = id
+    setIfTrue key True = k key ?~ encodeBool True

--- a/haskell-src/Concordium/Types/Queries/Tokens.hs
+++ b/haskell-src/Concordium/Types/Queries/Tokens.hs
@@ -1,22 +1,16 @@
 -- | Types for protocol level tokens (PLT).
-module Concordium.Types.Queries.Tokens where
+module Concordium.Types.Queries.Tokens (
+    TokenAmount (..),
+    Token (..),
+    TokenAccountState (..),
+) where
 
-import Data.Word
-
-import qualified Concordium.Types as Types
-
--- | The token amount representation.
---  The amount is computed as `amount = digits * 10^(-nrDecimals)`.
-data TokenAmount = TokenAmount
-    { digits :: !Word64,
-      nrDecimals :: !Word32
-    }
-    deriving (Eq, Show)
+import Concordium.Types.Tokens
 
 -- | Protocol level token.
 data Token = Token
     { -- | The unique token identifier.
-      tokenId :: !Types.TokenId,
+      tokenId :: !TokenId,
       -- | The account level state of the token.
       tokenAccountState :: !TokenAccountState
     }

--- a/haskell-src/Concordium/Types/Tokens.hs
+++ b/haskell-src/Concordium/Types/Tokens.hs
@@ -1,0 +1,87 @@
+{-# LANGUAGE DerivingStrategies #-}
+
+-- | Types associated with protocol-level tokens.
+module Concordium.Types.Tokens where
+
+import Control.Monad
+import qualified Data.Aeson as AE
+import qualified Data.Aeson.Types as AE
+import qualified Data.ByteString.Short as BSS
+import Data.Scientific
+import qualified Data.Serialize as S
+import qualified Data.Text.Encoding as T
+import Data.Word
+
+-- | The unique token identifier for a protocol-level token.
+--  This is given as a symbol unique across the whole chain.
+--  The byte string must be at most 255 bytes long and be a valid UTF-8 string.
+newtype TokenId = TokenId {tokenSymbol :: BSS.ShortByteString}
+    deriving newtype (Eq, Ord, Show)
+
+-- | Try to construct a valid 'TokenId' from a 'BSS.ShortByteString'.
+--  This can fail if the string is longer than 255 bytes or is not valid UTF-8.
+--  In the event of a failure @Left err@ is returned, where @err@ describes the failure.
+makeTokenId :: BSS.ShortByteString -> Either String TokenId
+makeTokenId sbs
+    | BSS.length sbs > 255 =
+        Left $ "TokenId length (" ++ show (BSS.length sbs) ++ ") out of bounds."
+    | Left decodeErr <- T.decodeUtf8' (BSS.fromShort sbs) =
+        Left $ "TokenId is not valid UTF-8: " ++ show decodeErr
+    | otherwise = Right $ TokenId sbs
+
+instance S.Serialize TokenId where
+    put (TokenId tid) = do
+        S.putWord8 $ fromIntegral $ BSS.length tid
+        S.putShortByteString tid
+    get = do
+        len <- S.getWord8
+        sbs <- S.getShortByteString (fromIntegral len)
+        case makeTokenId sbs of
+            Left e -> fail e
+            Right tokId -> return tokId
+
+-- | Deserialize a 'TokenId' without checking the invariant that the string is valid UTF-8.
+--  This should only be used where deserializing from a trusted source.
+unsafeGetTokenId :: S.Get TokenId
+unsafeGetTokenId = do
+    len <- S.getWord8
+    sbs <- S.getShortByteString (fromIntegral len)
+    return (TokenId sbs)
+
+instance AE.ToJSON TokenId where
+    -- decodeUtf8 will throw an exception if it fails, but we should be safe since the TokenId
+    -- should enforce valid UTF-8.
+    toJSON TokenId{..} = AE.String $ T.decodeUtf8 $ BSS.fromShort tokenSymbol
+
+instance AE.FromJSON TokenId where
+    parseJSON (AE.String text) = return $ TokenId $ BSS.toShort $ T.encodeUtf8 text
+    parseJSON invalid = AE.prependFailure "parsing TokenId failed" (AE.typeMismatch "String" invalid)
+
+-- | The token amount representation.
+--  The amount is computed as `amount = digits * 10^(-nrDecimals)`.
+data TokenAmount = TokenAmount
+    { digits :: !Word64,
+      nrDecimals :: !Word32
+    }
+    deriving (Eq, Show)
+
+instance AE.ToJSON TokenAmount where
+    toJSON TokenAmount{..} = AE.Number (scientific (fromIntegral digits) (-fromIntegral nrDecimals))
+
+instance AE.FromJSON TokenAmount where
+    parseJSON (AE.Number amt)
+        | coefficient amt < 0 = fail "Token amount must be positive."
+        | base10Exponent amt > 0 = do
+            let digitsInteger = coefficient amt * 10 ^ base10Exponent amt
+            when (digitsInteger > toInteger (maxBound :: Word64)) $
+                fail "Token amount out of bounds."
+            return TokenAmount{digits = fromInteger digitsInteger, nrDecimals = 0}
+        | base10Exponent amt < -255 =
+            fail "Token amount precision is out of range."
+        | otherwise =
+            return
+                TokenAmount
+                    { digits = fromInteger (coefficient amt),
+                      nrDecimals = fromIntegral (-base10Exponent amt)
+                    }
+    parseJSON _ = fail "Token amount should be a number."

--- a/haskell-tests/Spec.hs
+++ b/haskell-tests/Spec.hs
@@ -20,6 +20,7 @@ import qualified Types.AccountEncryptedAmountSpec
 import qualified Types.AddressesSpec
 import qualified Types.AmountFraction
 import qualified Types.AmountSpec
+import qualified Types.CBOR
 import qualified Types.ParametersSpec
 import qualified Types.PayloadSerializationSpec
 import qualified Types.PayloadSpec
@@ -62,3 +63,4 @@ main = hspec $ parallel $ do
     Genesis.ParametersSpec.tests
     Types.ValidName.tests
     Types.TokenIdSpec.tests
+    Types.CBOR.tests

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -1,0 +1,39 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Types.CBOR where
+
+import Codec.CBOR.Read
+
+-- import qualified Data.ByteString as BS
+import Test.HUnit
+import Test.Hspec
+
+import Concordium.Types.ProtocolLevelTokens.CBOR
+import Concordium.Types.Queries.Tokens
+
+tip1 :: TokenInitializationParameters
+tip1 =
+    TokenInitializationParameters
+        { tipName = "ABC token",
+          tipMetadata = "https://abc.token/meta",
+          tipAllowList = False,
+          tipInitialSupply = Just (TokenAmount{digits = 10000, nrDecimals = 5}),
+          tipDenyList = False,
+          tipMintable = False,
+          tipBurnable = False
+        }
+
+testInitializationParameters :: Spec
+testInitializationParameters = describe "token-initialization-parameters decoding" $ do
+    it "example 1 " $
+        assertEqual
+            "Decoded CBOR"
+            (Right ("", tip1))
+            ( deserialiseFromBytes
+                decodeTokenInitializationParameters
+                "\xA4\x64name\x69\
+                \ABC token\x68metadata\x76https://abc.token/meta\x69\
+                \allowList\xF4\x6DinitialSupply\xC4\x82\x24\x19\x27\x10"
+            )
+
+tests = focus $ testInitializationParameters

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -36,4 +36,6 @@ testInitializationParameters = describe "token-initialization-parameters decodin
                 \allowList\xF4\x6DinitialSupply\xC4\x82\x24\x19\x27\x10"
             )
 
-tests = focus $ testInitializationParameters
+tests :: Spec
+tests = describe "CBOR" $ do
+    testInitializationParameters

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -3,14 +3,17 @@
 module Types.CBOR where
 
 import Codec.CBOR.Read
+import Codec.CBOR.Write
+import qualified Data.ByteString.Base16.Lazy as B16L
+import qualified Data.ByteString.Lazy.Char8 as LBS
 
--- import qualified Data.ByteString as BS
 import Test.HUnit
 import Test.Hspec
 
 import Concordium.Types.ProtocolLevelTokens.CBOR
 import Concordium.Types.Queries.Tokens
 
+-- | A test value for 'TokenInitializationParameters'.
 tip1 :: TokenInitializationParameters
 tip1 =
     TokenInitializationParameters
@@ -23,9 +26,10 @@ tip1 =
           tipBurnable = False
         }
 
+-- | Basic tests for CBOR encoding/decoding of 'TokenInitializationParameters'.
 testInitializationParameters :: Spec
 testInitializationParameters = describe "token-initialization-parameters decoding" $ do
-    it "example 1 " $
+    it "example 1" $
         assertEqual
             "Decoded CBOR"
             (Right ("", tip1))
@@ -34,6 +38,44 @@ testInitializationParameters = describe "token-initialization-parameters decodin
                 "\xA4\x64name\x69\
                 \ABC token\x68metadata\x76https://abc.token/meta\x69\
                 \allowList\xF4\x6DinitialSupply\xC4\x82\x24\x19\x27\x10"
+            )
+    it "Missing \"name\"" $
+        assertEqual
+            "Decoded CBOR"
+            (Left (DeserialiseFailure 64 "Missing \"name\""))
+            ( deserialiseFromBytes
+                decodeTokenInitializationParameters
+                "\xA3\x68metadata\x76https://abc.token/meta\x69\
+                \allowList\xF4\x6DinitialSupply\xC4\x82\x24\x19\x27\x10"
+            )
+    it "Duplicate \"name\" key" $
+        assertEqual
+            "Decode result"
+            (Left (DeserialiseFailure 90 "Key already set: \"name\""))
+            ( deserialiseFromBytes
+                decodeTokenInitializationParameters
+                "\xA5\x64name\x69\
+                \ABC token\x68metadata\x76https://abc.token/meta\x69\
+                \allowList\xF4\x6DinitialSupply\xC4\x82\x24\x19\x27\x10\
+                \\x64name\x65token"
+            )
+    it "Encode and decode (no defaults)" $ do
+        -- LBS.putStrLn $ B16L.encode $ toLazyByteString $ encodeTokenInitializationParametersNoDefaults tip1
+        assertEqual
+            "Decode result"
+            (Right ("", tip1))
+            ( deserialiseFromBytes
+                decodeTokenInitializationParameters
+                (toLazyByteString $ encodeTokenInitializationParametersNoDefaults tip1)
+            )
+    it "Encode and decode (with defaults)" $ do
+        LBS.putStrLn $ B16L.encode $ toLazyByteString $ encodeTokenInitializationParametersWithDefaults tip1
+        assertEqual
+            "Decode result"
+            (Right ("", tip1))
+            ( deserialiseFromBytes
+                decodeTokenInitializationParameters
+                (toLazyByteString $ encodeTokenInitializationParametersWithDefaults tip1)
             )
 
 tests :: Spec

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,7 @@ dependencies:
 # be used for everything else.
 - binary >= 0.8
 - bytestring >= 0.10
+- cborg >= 0.2
 - cereal >= 0.5
 - containers >= 0.6
 - cryptonite >= 0.27


### PR DESCRIPTION
## Purpose

Part of NOD-682

This implements CBOR encoding and decoding for the `TokenInitializationParameter` in line with the CDDL specification (https://github.com/Concordium/concordium-base/pull/607). The decoding is permissive (though it does not allow spurious additional map keys, etc.) and the encoding follows deterministic CBOR.

## Changes

- Add `cborg` package dependency.
- Helpers for decoding and encoding types as CBOR maps.
- Encoding and decoding of 'TokenAmount'.
- Encoding and decoding of 'TokenInitializationParameters'.
- Unit tests.
- JSON serialization for `TokenInitializationParameters` and `TokenAmount`.
- Modify the JSON serialization of `CreatePLT` to allow the `initializationParameters` to be given either as a hex-encoded byte string or as JSON-encoded `TokenInitializationParameters`.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
