### PR TITLE
CBOR encoding of token-holder transactions

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -88,6 +88,7 @@ library
       Concordium.Types.HashableTo
       Concordium.Types.IdentityProviders
       Concordium.Types.InvokeContract
+      Concordium.Types.Memo
       Concordium.Types.Migration
       Concordium.Types.Parameters
       Concordium.Types.ProtocolLevelTokens.CBOR

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -219,6 +219,7 @@ import qualified Concordium.Crypto.VRF as VRF
 import Concordium.ID.Types
 import Concordium.Types.Block
 import Concordium.Types.HashableTo
+import Concordium.Types.Memo
 import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 import Concordium.Types.ProtocolVersion
 import Concordium.Types.SmartContracts
@@ -803,50 +804,6 @@ instance S.Serialize Nonce where
 
 minNonce :: Nonce
 minNonce = 1
-
--- | Data type for memos that can be added to transfers.
---  Max length of 'maxMemoSize' is assumed.
---  Create new values with 'memoFromBSS' to ensure assumed properties.
---
---  Note that the ToJSON instance of this type is derived, based on hex encoding.
---  The FromJSON instance is manually implemented to ensure length limits.
-newtype Memo = Memo BSS.ShortByteString
-    deriving (Eq)
-    deriving (AE.ToJSON, Show) via BSH.ByteStringHex
-
--- | Maximum size for 'Memo'.
-maxMemoSize :: Int
-maxMemoSize = 256
-
-tooBigErrorString :: String -> Int -> Int -> String
-tooBigErrorString name len maxSize = "Size of the " ++ name ++ " (" ++ show len ++ " bytes) exceeds maximum allowed size (" ++ show maxSize ++ " bytes)."
-
--- | Construct 'Memo' from a 'BSS.ShortByteString'.
---  Fails if the length exceeds 'maxMemoSize'.
-memoFromBSS :: (MonadError String m) => BSS.ShortByteString -> m Memo
-memoFromBSS bss =
-    if len <= maxMemoSize
-        then return . Memo $ bss
-        else throwError $ tooBigErrorString "memo" len maxMemoSize
-  where
-    len = BSS.length bss
-
-instance S.Serialize Memo where
-    put (Memo bss) = do
-        S.putWord16be . fromIntegral . BSS.length $ bss
-        S.putShortByteString bss
-
-    get = G.label "Memo" $ do
-        l <- fromIntegral <$> S.getWord16be
-        unless (l <= maxMemoSize) $ fail $ tooBigErrorString "memo" l maxMemoSize
-        Memo <$> S.getShortByteString l
-
-instance AE.FromJSON Memo where
-    parseJSON v = do
-        (BSH.ByteStringHex bss) <- AE.parseJSON v
-        case memoFromBSS bss of
-            Left err -> fail err
-            Right rd -> return rd
 
 -- | Data type for registering data on chain.
 --  Max length of 'maxRegisteredDataSize' is assumed.

--- a/haskell-src/Concordium/Types/Memo.hs
+++ b/haskell-src/Concordium/Types/Memo.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DerivingVia #-}
+
+-- | This module defines the 'Memo' type and associated functionality.
+module Concordium.Types.Memo where
+
+import Control.Monad
+import Control.Monad.Except
+
+import qualified Concordium.Crypto.ByteStringHelpers as BSH
+import qualified Data.Aeson as AE
+import qualified Data.ByteString.Short as BSS
+import qualified Data.Serialize as S
+
+-- | Helper function to render an error when a bytestring value is too large.
+tooBigErrorString ::
+    -- | Name
+    String ->
+    -- | Actual size
+    Int ->
+    -- | Maximum size
+    Int ->
+    String
+tooBigErrorString name len maxSize =
+    "Size of the "
+        ++ name
+        ++ " ("
+        ++ show len
+        ++ " bytes) exceeds maximum allowed size ("
+        ++ show maxSize
+        ++ " bytes)."
+
+-- | Data type for memos that can be added to transfers.
+--  Max length of 'maxMemoSize' is assumed.
+--  Create new values with 'memoFromBSS' to ensure assumed properties.
+--
+--  Note that the ToJSON instance of this type is derived, based on hex encoding.
+--  The FromJSON instance is manually implemented to ensure length limits.
+newtype Memo = Memo BSS.ShortByteString
+    deriving (Eq)
+    deriving (AE.ToJSON, Show) via BSH.ByteStringHex
+
+-- | Maximum size for 'Memo'.
+maxMemoSize :: Int
+maxMemoSize = 256
+
+-- | Construct 'Memo' from a 'BSS.ShortByteString'.
+--  Fails if the length exceeds 'maxMemoSize'.
+memoFromBSS :: (MonadError String m) => BSS.ShortByteString -> m Memo
+memoFromBSS bss =
+    if len <= maxMemoSize
+        then return . Memo $ bss
+        else throwError $ tooBigErrorString "memo" len maxMemoSize
+  where
+    len = BSS.length bss
+
+instance S.Serialize Memo where
+    put (Memo bss) = do
+        S.putWord16be . fromIntegral . BSS.length $ bss
+        S.putShortByteString bss
+
+    get = S.label "Memo" $ do
+        l <- fromIntegral <$> S.getWord16be
+        unless (l <= maxMemoSize) $ fail $ tooBigErrorString "memo" l maxMemoSize
+        Memo <$> S.getShortByteString l
+
+instance AE.FromJSON Memo where
+    parseJSON v = do
+        (BSH.ByteStringHex bss) <- AE.parseJSON v
+        case memoFromBSS bss of
+            Left err -> fail err
+            Right rd -> return rd

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -417,7 +417,7 @@ encodeAccountAddress (AccountAddress (FBS.FixedByteString ba)) =
 -- | A destination that can receive and hold protocol-level tokens.
 --  Currently, this can only be a Concordium account address.
 data TokenReceiver = ReceiverAccount
-    { -- | THe account address.
+    { -- | The account address.
       receiverAccountAddress :: !AccountAddress,
       -- | Although the account can only be a Concordium address, this specifies whether the
       --  address type should be explicit in the CBOR encoding.


### PR DESCRIPTION
## Purpose

Part of COR-677

This defines the CBOR encoding and decoding of token-holder transactions.

## Changes

- Refactor `Memo` to a separate module to avoid cyclic dependencies.
- Slight refactoring of `decodeMap` to allow reuse of helpers for sequences.
- Define types, decoders and encoders related to token-holder transactions.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
