### PR TITLE
Base support for P9 in concordium_base rust crate

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased changes
 
-- Publish `get_canonical_address` on `AccountAddress` 
+- Publish `get_canonical_address` on `AccountAddress`
+- Introduce protocol version 9 `ProtocolVersion::P9`
+- Introduce basic types related to protocol level tokens (PLT)
+  - `RawCbor`, `TokenId`, `TokenAmount`, `TokenModuleRef`.
+  - Extend `UpdatePayload` with `CreatePlt` variant.
 
 ## 7.0.0 (2025-02-03)
 

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -446,6 +446,9 @@ pub enum ProtocolVersion {
     #[display(fmt = "P8")]
     /// Protocol `P8` introduces support for suspended validators.
     P8,
+    #[display(fmt = "P9")]
+    /// Protocol `P9` introduces support for protocol level tokens (PLT).
+    P9,
 }
 
 #[derive(Debug, Error, Display)]
@@ -469,6 +472,7 @@ impl TryFrom<u64> for ProtocolVersion {
             6 => Ok(ProtocolVersion::P6),
             7 => Ok(ProtocolVersion::P7),
             8 => Ok(ProtocolVersion::P8),
+            9 => Ok(ProtocolVersion::P9),
             version => Err(UnknownProtocolVersion { version }),
         }
     }
@@ -485,6 +489,7 @@ impl From<ProtocolVersion> for u64 {
             ProtocolVersion::P6 => 6,
             ProtocolVersion::P7 => 7,
             ProtocolVersion::P8 => 8,
+            ProtocolVersion::P9 => 9,
         }
     }
 }

--- a/rust-src/concordium_base/src/lib.rs
+++ b/rust-src/concordium_base/src/lib.rs
@@ -6,6 +6,7 @@ pub mod cis4_types;
 pub mod constants;
 pub mod hashes;
 mod internal;
+pub mod protocol_level_tokens;
 pub mod smart_contracts;
 pub mod transactions;
 pub mod updates;

--- a/rust-src/concordium_base/src/protocol_level_tokens/cbor.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/cbor.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+#[serde(try_from = "String", into = "String")]
+#[repr(transparent)]
+pub struct RawCbor {
+    bytes: Vec<u8>,
+}
+
+impl AsRef<[u8]> for RawCbor {
+    fn as_ref(&self) -> &[u8] { self.bytes.as_ref() }
+}
+
+impl From<RawCbor> for Vec<u8> {
+    fn from(value: RawCbor) -> Self { value.bytes }
+}
+
+impl From<Vec<u8>> for RawCbor {
+    fn from(bytes: Vec<u8>) -> Self { Self { bytes } }
+}
+
+impl std::fmt::Display for RawCbor {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        for byte in self.bytes.iter() {
+            write!(f, "{:02x}", byte)?;
+        }
+        Ok(())
+    }
+}
+
+impl std::str::FromStr for RawCbor {
+    type Err = hex::FromHexError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { Ok(hex::decode(s)?.into()) }
+}
+
+impl TryFrom<String> for RawCbor {
+    type Error = hex::FromHexError;
+
+    fn try_from(value: String) -> Result<Self, Self::Error> { value.as_str().parse() }
+}
+
+impl From<RawCbor> for String {
+    fn from(value: RawCbor) -> Self { value.to_string() }
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
@@ -1,3 +1,5 @@
+//! Types and functions for working with Protocol Level Tokens (PLT).
+
 mod cbor;
 mod token_amount;
 mod token_event;

--- a/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
@@ -1,0 +1,11 @@
+mod cbor;
+mod token_amount;
+mod token_event;
+mod token_id;
+mod token_module_ref;
+
+pub use cbor::*;
+pub use token_amount::*;
+pub use token_event::*;
+pub use token_id::*;
+pub use token_module_ref::*;

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
@@ -9,6 +9,10 @@ pub struct TokenAmount {
 }
 
 impl TokenAmount {
+    /// Construct a [`TokenAmount`] representing an integer amount and zero
+    /// decimals.
+    pub fn from_integer(value: u64) -> Self { Self { value, decimals: 0 } }
+
     /// The number of decimals in the token amount.
     ///
     /// Together with the `raw_value` the token amount can be represented as
@@ -38,28 +42,68 @@ impl std::fmt::Display for TokenAmount {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum TokenAmountParseError {
+    #[error("The number of digits after the decimal point can be at most 255, found {0}")]
+    InvalidNumberOfDecimals(usize),
+    #[error("Unable to parse digits before the decimal point: {0}")]
+    FailedParsingWholeNumber(std::num::ParseIntError),
+    #[error("Unable to parse digits after the decimal point: {0}")]
+    FailedParsingFractionalPart(std::num::ParseIntError),
+}
+
+impl std::str::FromStr for TokenAmount {
+    type Err = TokenAmountParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((integer, fraction)) = s.split_once('.') {
+            let decimals: u8 = fraction
+                .len()
+                .try_into()
+                .map_err(|_| TokenAmountParseError::InvalidNumberOfDecimals(fraction.len()))?;
+            let integer: u64 = integer
+                .parse()
+                .map_err(TokenAmountParseError::FailedParsingWholeNumber)?;
+            let fraction: u64 = fraction
+                .parse()
+                .map_err(TokenAmountParseError::FailedParsingFractionalPart)?;
+            let value = integer * 10u64.pow(decimals.into()) + fraction;
+            Ok(Self { value, decimals })
+        } else {
+            Ok(Self {
+                value:    s
+                    .parse()
+                    .map_err(TokenAmountParseError::FailedParsingWholeNumber)?,
+                decimals: 0,
+            })
+        }
+    }
+}
+
 impl PartialOrd for TokenAmount {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> { Some(self.cmp(other)) }
 }
 
 impl Ord for TokenAmount {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        if self.decimals == other.decimals {
-            self.value.cmp(&other.value)
-        } else {
-            todo!()
+        match self.decimals.cmp(&other.decimals) {
+            std::cmp::Ordering::Equal => self.value.cmp(&other.value),
+            std::cmp::Ordering::Less => {
+                let decimal_diff = other.decimals - self.decimals;
+                let scaled_self = u128::from(self.value) * 10u128.pow(decimal_diff.into());
+                scaled_self.cmp(&u128::from(other.value))
+            }
+            std::cmp::Ordering::Greater => {
+                let decimal_diff = self.decimals - other.decimals;
+                let scaled_other = u128::from(other.value) * 10u128.pow(decimal_diff.into());
+                u128::from(self.value).cmp(&scaled_other)
+            }
         }
     }
 }
 
 impl PartialEq for TokenAmount {
-    fn eq(&self, other: &Self) -> bool {
-        if self.decimals == other.decimals {
-            self.value == other.value
-        } else {
-            todo!()
-        }
-    }
+    fn eq(&self, other: &Self) -> bool { matches!(self.cmp(other), std::cmp::Ordering::Equal) }
 }
 impl Eq for TokenAmount {}
 
@@ -96,7 +140,6 @@ impl TryFrom<TokenAmountJson> for TokenAmount {
 mod test {
     use super::*;
 
-    ///
     #[test]
     fn display_token_amount() {
         let amount = TokenAmount {
@@ -107,29 +150,86 @@ mod test {
     }
 
     #[test]
+    fn parse_token_amount() {
+        let amount = TokenAmount {
+            value:    123456,
+            decimals: 3,
+        };
+        let parsed: TokenAmount = "123.456"
+            .parse()
+            .expect("Parsing token amount should succeed");
+        assert_eq!(amount.value, parsed.value);
+        assert_eq!(amount.decimals, parsed.decimals);
+    }
+
+    #[test]
     fn ord_token_amount() {
+        // Check using same decimals.
+        {
+            let first = TokenAmount {
+                value:    123,
+                decimals: 3,
+            };
+
+            let last = TokenAmount {
+                value:    456,
+                decimals: 3,
+            };
+            // Note that both directions are needed to cover both branches in the
+            // implementation.
+            assert!(first < last);
+            assert!(last > first);
+        }
+
+        // Check using different decimals.
+        // 0.123
         let first = TokenAmount {
             value:    123,
             decimals: 3,
         };
-
+        // 1.23
         let last = TokenAmount {
-            value:    456,
-            decimals: 3,
+            value:    123,
+            decimals: 2,
         };
-        assert!(first < last)
+        // Note that both directions are needed to cover both branches in the
+        // implementation.
+        assert!(first < last);
+        assert!(last > first);
     }
 
     #[test]
     fn eq_token_amount() {
-        let a = TokenAmount {
-            value:    123456,
-            decimals: 3,
-        };
-        let b = TokenAmount {
-            value:    123456,
-            decimals: 3,
-        };
-        assert!(a == b)
+        // Same number of decimals
+        {
+            // 123.456
+            let a = TokenAmount {
+                value:    123456,
+                decimals: 3,
+            };
+            // 123.456
+            let b = TokenAmount {
+                value:    123456,
+                decimals: 3,
+            };
+            assert_eq!(a, b);
+        }
+        // Different number of decimals
+        {
+            // 5.0
+            let a = TokenAmount {
+                value:    50,
+                decimals: 1,
+            };
+            // 5
+            let b = TokenAmount {
+                value:    5,
+                decimals: 0,
+            };
+            // Note that both directions are needed to cover both branches in the
+            // implementation.
+            assert_eq!(a, b);
+            assert_eq!(b, a);
+        }
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
@@ -1,0 +1,135 @@
+/// Protocol level token (PLT) amount representation.
+#[derive(Debug, Clone, Copy, serde::Deserialize, serde::Serialize)]
+#[serde(try_from = "TokenAmountJson", into = "TokenAmountJson")]
+pub struct TokenAmount {
+    /// The amount of tokens without decimal places.
+    pub value:    u64,
+    /// The number of decimals in the token amount.
+    pub decimals: u8,
+}
+
+impl TokenAmount {
+    /// The number of decimals in the token amount.
+    ///
+    /// Together with the `raw_value` the token amount can be represented as
+    /// `raw_value * 10^(-decimals)`
+    pub fn decimals(&self) -> u8 { self.decimals }
+
+    /// The amount of tokens without decimal places.
+    ///
+    /// Together with the `decimals` the token amount can be represented as
+    /// `raw_value * 10^(-decimals)`
+    pub fn raw_value(&self) -> u64 { self.value }
+}
+
+impl std::fmt::Display for TokenAmount {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.decimals == 0 {
+            self.value.fmt(f)
+        } else {
+            let mut value = format!(
+                "{value:0.*}",
+                self.decimals as usize + 1,
+                value = self.value
+            );
+            value.insert(value.len() - self.decimals() as usize, '.');
+            write!(f, "{}", value)
+        }
+    }
+}
+
+impl PartialOrd for TokenAmount {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> { Some(self.cmp(other)) }
+}
+
+impl Ord for TokenAmount {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        if self.decimals == other.decimals {
+            self.value.cmp(&other.value)
+        } else {
+            todo!()
+        }
+    }
+}
+
+impl PartialEq for TokenAmount {
+    fn eq(&self, other: &Self) -> bool {
+        if self.decimals == other.decimals {
+            self.value == other.value
+        } else {
+            todo!()
+        }
+    }
+}
+impl Eq for TokenAmount {}
+
+/// JSON representation of the token amount.
+/// The purpose of this type is to derive the JSON representation matching other
+/// SDKs.
+#[derive(serde::Serialize, serde::Deserialize)]
+struct TokenAmountJson {
+    value:    String,
+    decimals: u8,
+}
+
+impl From<TokenAmount> for TokenAmountJson {
+    fn from(amount: TokenAmount) -> Self {
+        Self {
+            value:    amount.value.to_string(),
+            decimals: amount.decimals,
+        }
+    }
+}
+
+impl TryFrom<TokenAmountJson> for TokenAmount {
+    type Error = std::num::ParseIntError;
+
+    fn try_from(json: TokenAmountJson) -> Result<Self, Self::Error> {
+        Ok(Self {
+            value:    json.value.parse()?,
+            decimals: json.decimals,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    ///
+    #[test]
+    fn display_token_amount() {
+        let amount = TokenAmount {
+            value:    123456,
+            decimals: 3,
+        };
+        assert_eq!(amount.to_string().as_str(), "123.456")
+    }
+
+    #[test]
+    fn ord_token_amount() {
+        let first = TokenAmount {
+            value:    123,
+            decimals: 3,
+        };
+
+        let last = TokenAmount {
+            value:    456,
+            decimals: 3,
+        };
+        assert!(first < last)
+    }
+
+    #[test]
+    fn eq_token_amount() {
+        let a = TokenAmount {
+            value:    123456,
+            decimals: 3,
+        };
+        let b = TokenAmount {
+            value:    123456,
+            decimals: 3,
+        };
+        assert!(a == b)
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -24,6 +24,19 @@ pub struct TokenGovernanceEvent {
     pub details:    RawCbor,
 }
 
+/// Details provided by the token module in the event of rejecting a
+/// transaction.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenModuleRejectReason {
+    /// The unique symbol of the token, which produced this event.
+    pub token_id:   TokenId,
+    /// The type of event produced.
+    pub event_type: TokenEventType,
+    /// The details of the event produced, in the raw byte encoded form.
+    pub details:    Option<RawCbor>,
+}
+
 /// Maximum number of bytes allowed for an encoding of a token event type.
 const TOKEN_EVENT_TYPE_MAX_BYTE_LEN: usize = 255;
 

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -1,17 +1,100 @@
 use super::{cbor::RawCbor, TokenId};
+use crate::common;
 
+/// Event produced from the effect of a token holder transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenHolderEvent {
+    /// The unique symbol of the token, which produced this event.
     pub token_id:   TokenId,
-    pub event_type: String,
+    /// The type of event produced.
+    pub event_type: TokenEventType,
+    /// The details of the event produced, in the raw byte encoded form.
     pub details:    RawCbor,
 }
 
+/// Event produced from the effect of a token governance transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TokenGovernanceEvent {
+    /// The unique symbol of the token, which produced this event.
     pub token_id:   TokenId,
-    pub event_type: String,
+    /// The type of event produced.
+    pub event_type: TokenEventType,
+    /// The details of the event produced, in the raw byte encoded form.
     pub details:    RawCbor,
+}
+
+/// Maximum number of bytes allowed for an encoding of a token event type.
+const TOKEN_EVENT_TYPE_MAX_BYTE_LEN: usize = 255;
+
+/// String representing the type of token event produced.
+///
+/// Limited to 255 bytes in length and must be valid UTF-8.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(try_from = "String", into = "String")]
+#[repr(transparent)]
+pub struct TokenEventType {
+    value: String,
+}
+
+/// Error from converting a string into a [`TokenEventType`].
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "Byte encoding of TokenEventType must be within {TOKEN_EVENT_TYPE_MAX_BYTE_LEN} bytes, \
+     instead got {actual_size}"
+)]
+pub struct TokenEventTypeFromStringError {
+    /// The byte size of the provided string.
+    actual_size: usize,
+}
+
+impl AsRef<str> for TokenEventType {
+    fn as_ref(&self) -> &str { self.value.as_str() }
+}
+
+impl std::str::FromStr for TokenEventType {
+    type Err = TokenEventTypeFromStringError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { s.to_owned().try_into() }
+}
+
+impl TryFrom<String> for TokenEventType {
+    type Error = TokenEventTypeFromStringError;
+
+    fn try_from(event_type: String) -> Result<Self, Self::Error> {
+        let byte_len = event_type.as_bytes().len();
+        if byte_len > TOKEN_EVENT_TYPE_MAX_BYTE_LEN {
+            Err(TokenEventTypeFromStringError {
+                actual_size: byte_len,
+            })
+        } else {
+            Ok(Self { value: event_type })
+        }
+    }
+}
+
+impl From<TokenEventType> for String {
+    fn from(event_type: TokenEventType) -> Self { event_type.value }
+}
+
+impl common::Serial for TokenEventType {
+    fn serial<B: common::Buffer>(&self, out: &mut B) {
+        let bytes = self.value.as_bytes();
+        u8::try_from(bytes.len())
+            .expect("Invariant violation for byte length of TokenEventType")
+            .serial(out);
+        out.write_all(bytes)
+            .expect("Writing TokenEventType bytes to buffer should not fail");
+    }
+}
+
+impl common::Deserial for TokenEventType {
+    fn deserial<R: byteorder::ReadBytesExt>(source: &mut R) -> common::ParseResult<Self> {
+        let len = source.read_u8()?;
+        let mut buf = vec![0u8; len as usize];
+        source.read_exact(&mut buf)?;
+        let value = String::from_utf8(buf)?;
+        Ok(Self { value })
+    }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -1,0 +1,17 @@
+use super::{cbor::RawCbor, TokenId};
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenHolderEvent {
+    pub token_id:   TokenId,
+    pub event_type: String,
+    pub details:    RawCbor,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TokenGovernanceEvent {
+    pub token_id:   TokenId,
+    pub event_type: String,
+    pub details:    RawCbor,
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -1,5 +1,4 @@
 use super::{cbor::RawCbor, TokenId};
-use crate::common;
 
 /// Event produced from the effect of a token holder transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -76,25 +75,4 @@ impl TryFrom<String> for TokenEventType {
 
 impl From<TokenEventType> for String {
     fn from(event_type: TokenEventType) -> Self { event_type.value }
-}
-
-impl common::Serial for TokenEventType {
-    fn serial<B: common::Buffer>(&self, out: &mut B) {
-        let bytes = self.value.as_bytes();
-        u8::try_from(bytes.len())
-            .expect("Invariant violation for byte length of TokenEventType")
-            .serial(out);
-        out.write_all(bytes)
-            .expect("Writing TokenEventType bytes to buffer should not fail");
-    }
-}
-
-impl common::Deserial for TokenEventType {
-    fn deserial<R: byteorder::ReadBytesExt>(source: &mut R) -> common::ParseResult<Self> {
-        let len = source.read_u8()?;
-        let mut buf = vec![0u8; len as usize];
-        source.read_exact(&mut buf)?;
-        let value = String::from_utf8(buf)?;
-        Ok(Self { value })
-    }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
@@ -1,0 +1,50 @@
+/// The limit for the length of the byte encoding of a Token ID.
+pub const TOKEN_ID_MAX_BYTE_LEN: usize = 255;
+
+/// Protocol level token (PLT) ID.
+#[derive(
+    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Deserialize, serde::Serialize, Clone,
+)]
+#[serde(try_from = "String", into = "String")]
+#[repr(transparent)]
+pub struct TokenId {
+    /// Unique symbol identifying the PLT on chain.
+    symbol: String,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum TokenIdFromStringError {
+    #[error(
+        "Byte encoding of TokenID must be within {TOKEN_ID_MAX_BYTE_LEN} bytes, instead got {0}"
+    )]
+    ExceedsMaxByteLength(usize),
+}
+
+impl AsRef<str> for TokenId {
+    fn as_ref(&self) -> &str { self.symbol.as_str() }
+}
+
+impl std::str::FromStr for TokenId {
+    type Err = TokenIdFromStringError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> { s.to_owned().try_into() }
+}
+
+impl TryFrom<String> for TokenId {
+    type Error = TokenIdFromStringError;
+
+    fn try_from(symbol: String) -> Result<Self, Self::Error> {
+        let symbol_byte_len = symbol.as_bytes().len();
+        if symbol_byte_len > TOKEN_ID_MAX_BYTE_LEN {
+            Err(TokenIdFromStringError::ExceedsMaxByteLength(
+                symbol_byte_len,
+            ))
+        } else {
+            Ok(Self { symbol })
+        }
+    }
+}
+
+impl From<TokenId> for String {
+    fn from(value: TokenId) -> Self { value.symbol }
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_ref.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_ref.rs
@@ -1,0 +1,9 @@
+use concordium_contracts_common::hashes::HashBytes;
+
+#[doc(hidden)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+/// Used as a phantom type to indicate a hash is a block hash.
+pub enum TokenModuleReferenceMarker {}
+
+/// A reference to a token module deployed on the chain.
+pub type TokenModuleRef = HashBytes<TokenModuleReferenceMarker>;

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_ref.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_ref.rs
@@ -2,8 +2,9 @@ use concordium_contracts_common::hashes::HashBytes;
 
 #[doc(hidden)]
 #[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
-/// Used as a phantom type to indicate a hash is a block hash.
+/// Used as a phantom type to indicate a hash used for referencing a protocol
+/// level token module.
 pub enum TokenModuleReferenceMarker {}
 
-/// A reference to a token module deployed on the chain.
+/// A reference to a protocol level token module deployed on the chain.
 pub type TokenModuleRef = HashBytes<TokenModuleReferenceMarker>;

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -164,6 +164,11 @@ pub enum TransactionType {
     ConfigureBaker,
     ///  Configure an account's stake delegation.
     ConfigureDelegation,
+    /// Token holder transaction. Introduced in Concordium protocol version 9.
+    TokenHolder,
+    /// Token governance transaction. Introduced in Concordium protocol version
+    /// 9.
+    TokenGovernance,
 }
 
 /// An error that occurs when trying to convert
@@ -198,6 +203,8 @@ impl TryFrom<i32> for TransactionType {
             18 => Self::TransferWithScheduleAndMemo,
             19 => Self::ConfigureBaker,
             20 => Self::ConfigureDelegation,
+            21 => Self::TokenHolder,
+            22 => Self::TokenGovernance,
             n => return Err(TransactionTypeConversionError(n)),
         })
     }

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -716,11 +716,11 @@ pub struct CreatePlt {
 }
 
 impl Serial for CreatePlt {
-    fn serial<B: Buffer>(&self, out: &mut B) { todo!() }
+    fn serial<B: Buffer>(&self, _out: &mut B) { todo!() }
 }
 
 impl Deserial for CreatePlt {
-    fn deserial<R: ReadBytesExt>(source: &mut R) -> ParseResult<Self> { todo!() }
+    fn deserial<R: ReadBytesExt>(_source: &mut R) -> ParseResult<Self> { todo!() }
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, Copy)]

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -698,7 +698,7 @@ pub enum UpdatePayload {
     CreatePlt(CreatePlt),
 }
 
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, common::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CreatePlt {
     /// The symbol of the token.
@@ -713,14 +713,6 @@ pub struct CreatePlt {
     pub decimals:                  u8,
     /// The initialization parameters of the token, encoded in CBOR.
     pub initialization_parameters: protocol_level_tokens::RawCbor,
-}
-
-impl Serial for CreatePlt {
-    fn serial<B: Buffer>(&self, _out: &mut B) { todo!() }
-}
-
-impl Deserial for CreatePlt {
-    fn deserial<R: ReadBytesExt>(_source: &mut R) -> ParseResult<Self> { todo!() }
 }
 
 #[derive(SerdeSerialize, SerdeDeserialize, Debug, Clone, Copy)]


### PR DESCRIPTION
## Purpose
Ref COR-1146.

Introduce basic types for plt in `rust-src/concordium-base`

Relevant PR in rust-sdk: https://github.com/Concordium/concordium-rust-sdk/pull/240 and https://github.com/Concordium/concordium-rust-sdk/pull/243 and https://github.com/Concordium/concordium-rust-sdk/pull/246