### PR TITLE
PLT Reject Reasons CBOR

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -738,6 +738,7 @@ instance ToProto RejectReason where
         PoolWouldBecomeOverDelegated -> Proto.make $ ProtoFields.poolWouldBecomeOverDelegated .= Proto.defMessage
         PoolClosed -> Proto.make $ ProtoFields.poolClosed .= Proto.defMessage
         NonExistentTokenId tokenId -> Proto.make $ ProtoFields.nonExistentTokenId .= toProto tokenId
+        TokenHolderTransactionFailed reason -> Proto.make $ ProtoFields.tokenHolderTransactionFailed .= toProto reason
 
 -- | Attempt to convert the node's TransactionStatus type into the protobuf BlockItemStatus type.
 --   The protobuf type is better structured and removes the need for handling impossible cases.

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -1158,6 +1158,7 @@ instance S.Serialize TokenEventDetails where
         S.putShortByteString parameter
 
 -- | Token event type string.
+--  Must be at most 255 bytes and a valid UTF-8 string.
 newtype TokenEventType = TokenEventType {tokenEventTypeBytes :: BSS.ShortByteString}
     deriving newtype (Eq, Show)
 
@@ -1239,7 +1240,7 @@ instance AE.FromJSON TokenEvent where
 
 -- | Details provided by the token module in the event of rejecting a transaction.
 data TokenModuleRejectReason = TokenModuleRejectReason
-    { -- | The tokens symbol.
+    { -- | The token symbol.
       tmrrTokenSymbol :: !TokenId,
       -- | The type of the reject reason. At most 255 bytes.
       tmrrType :: !TokenEventType,

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -189,11 +189,12 @@ module Concordium.Types (
     TokenEventDetails (..),
     TokenEventType (..),
     TokenEvent (..),
-    TokenModuleRejectReason (..),
     teSymbol,
     teType,
     teDetails,
     makeTokenEventType,
+    TokenModuleRejectReason (..),
+    makeTokenModuleRejectReason,
     CreatePLT (..),
     cpltTokenSymbol,
     cpltTokenModule,
@@ -1158,14 +1159,18 @@ instance S.Serialize TokenEventDetails where
         S.putShortByteString parameter
 
 -- | Token event type string.
---  Must be at most 255 bytes and a valid UTF-8 string.
+--  MUST be at most 255 bytes and SHOULD BE a valid UTF-8 string.
+--
+--  Serialization does not require or check for UTF-8 validity.
+--  Converting to JSON will replace invalid UTF-8 bytes with the unicode replacement character,
+--  which means that converting to JSON and back is only the identity for valid UTF-8.
 newtype TokenEventType = TokenEventType {tokenEventTypeBytes :: BSS.ShortByteString}
     deriving newtype (Eq, Show)
 
 instance AE.ToJSON TokenEventType where
     -- decodeUtf8 will throw an exception if it fails, but we should be safe since the TokenEventType
     -- should enforce valid UTF-8.
-    toJSON TokenEventType{..} = AE.String $ T.decodeUtf8 $ BSS.fromShort tokenEventTypeBytes
+    toJSON TokenEventType{..} = AE.String $ T.decodeUtf8Lenient $ BSS.fromShort tokenEventTypeBytes
 
 instance AE.FromJSON TokenEventType where
     parseJSON (AE.String text) = return $ TokenEventType $ BSS.toShort $ T.encodeUtf8 text
@@ -1189,9 +1194,7 @@ instance S.Serialize TokenEventType where
     get = do
         len <- S.getWord8
         sbs <- S.getShortByteString (fromIntegral len)
-        case makeTokenEventType sbs of
-            Left e -> fail e
-            Right eventTypeString -> return eventTypeString
+        return $ TokenEventType sbs
 
 -- | Event produced from a token module
 -- This is used for both token holder transactions and for token governance transactions.
@@ -1274,6 +1277,16 @@ instance AE.FromJSON TokenModuleRejectReason where
         tmrrType <- o AE..: "type"
         tmrrDetails <- o AE..:? "details"
         return TokenModuleRejectReason{..}
+
+-- | Make a 'TokenModuleRejectReason' given a 'TokenId' and an 'CBOR.EncodedTokenRejectReason'.
+--  If the type is longer than 255 bytes, it is truncated. This potentially violates the
+makeTokenModuleRejectReason :: TokenId -> CBOR.EncodedTokenRejectReason -> TokenModuleRejectReason
+makeTokenModuleRejectReason tmrrTokenSymbol CBOR.EncodedTokenRejectReason{..} =
+    TokenModuleRejectReason
+        { tmrrType = TokenEventType (BSS.take 255 etrrType),
+          tmrrDetails = TokenEventDetails <$> etrrDetails,
+          ..
+        }
 
 -- | A wrapper type for (de)-serializing an CBOR-encoded initialization parameter to/from JSON.
 --  This can parse either an JSON object representation of 'TokenInitializationParameters'

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -1279,7 +1279,9 @@ instance AE.FromJSON TokenModuleRejectReason where
         return TokenModuleRejectReason{..}
 
 -- | Make a 'TokenModuleRejectReason' given a 'TokenId' and an 'CBOR.EncodedTokenRejectReason'.
---  If the type is longer than 255 bytes, it is truncated. This potentially violates the
+--  If the type is longer than 255 bytes, it is truncated. It is not checked that the type
+--  is UTF-8 encoded, and the truncation can also break UTF-8 validity (if it truncates in the
+--  middle of a multi-byte character).
 makeTokenModuleRejectReason :: TokenId -> CBOR.EncodedTokenRejectReason -> TokenModuleRejectReason
 makeTokenModuleRejectReason tmrrTokenSymbol CBOR.EncodedTokenRejectReason{..} =
     TokenModuleRejectReason

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -2627,8 +2627,10 @@ data RejectReason
       PoolWouldBecomeOverDelegated
     | -- | The pool is not open to delegators.
       PoolClosed
-    | -- | Token ID does not exists.
+    | -- | Token ID does not exist.
       NonExistentTokenId !TokenId
+    | -- | The token-holder transaction was rejected.
+      TokenHolderTransactionFailed !TokenModuleRejectReason
     deriving (Show, Eq, Generic)
 
 wasmRejectToRejectReasonInit :: Wasm.ContractExecutionFailure -> RejectReason
@@ -2701,6 +2703,7 @@ instance S.Serialize RejectReason where
         PoolWouldBecomeOverDelegated -> S.putWord8 53
         PoolClosed -> S.putWord8 54
         NonExistentTokenId tokenId -> S.putWord8 55 <> S.put tokenId
+        TokenHolderTransactionFailed reason -> S.putWord8 56 <> S.put reason
 
     get =
         S.getWord8 >>= \case
@@ -2769,6 +2772,7 @@ instance S.Serialize RejectReason where
             53 -> return PoolWouldBecomeOverDelegated
             54 -> return PoolClosed
             55 -> NonExistentTokenId <$> S.get
+            56 -> TokenHolderTransactionFailed <$> S.get
             n -> fail $ "Unrecognized RejectReason tag: " ++ show n
 
 instance AE.ToJSON RejectReason

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -660,14 +660,14 @@ data TokenHolderFailure
     = -- | The recipient address was not valid.
       RecipientNotFound
         { -- | The index in the list of operations of the failing operation.
-          thfTransactionIndex :: !Word64,
+          thfOperationIndex :: !Word64,
           -- | The recipient address that could not be resolved.
           thfRecipient :: !TokenReceiver
         }
     | -- | The balance of tokens on the sender account is insufficient to perform the operation.
       TokenBalanceInsufficient
         { -- | The index in the list of operations of the failing operation.
-          thfTransactionIndex :: !Word64,
+          thfOperationIndex :: !Word64,
           -- | The available balance of the sender.
           thfAvailableBalance :: !TokenAmount,
           -- | The minimum required balance to perform the operation.
@@ -698,7 +698,7 @@ emptyRecipientNotFoundBuilder = RecipientNotFoundBuilder Nothing Nothing
 --  is missing.
 buildRecipientNotFound :: RecipientNotFoundBuilder -> Either String TokenHolderFailure
 buildRecipientNotFound RecipientNotFoundBuilder{..} = do
-    thfTransactionIndex <- _rnfbTransactionIndex `orFail` "Missing \"index\""
+    thfOperationIndex <- _rnfbTransactionIndex `orFail` "Missing \"index\""
     thfRecipient <- _rnfbRecipient `orFail` "Missing \"recipient\""
     return RecipientNotFound{..}
 
@@ -721,7 +721,7 @@ emptyTokenBalanceInsufficientBuilder = TokenBalanceInsufficientBuilder Nothing N
 --  is missing.
 buildTokenBalanceInsufficient :: TokenBalanceInsufficientBuilder -> Either String TokenHolderFailure
 buildTokenBalanceInsufficient TokenBalanceInsufficientBuilder{..} = do
-    thfTransactionIndex <- _tbibTransactionIndex `orFail` "Missing \"index\""
+    thfOperationIndex <- _tbibTransactionIndex `orFail` "Missing \"index\""
     thfAvailableBalance <- _tbibAvailableBalance `orFail` "Missing \"availableBalance\""
     thfRequiredBalance <- _tbibRequiredBalance `orFail` "Missing \"requiredBalance\""
     return TokenBalanceInsufficient{..}
@@ -754,7 +754,7 @@ encodeTokenHolderFailure RecipientNotFound{..} =
           etrrDetails =
             Just . BSS.toShort . CBOR.toStrictByteString . encodeMapDeterministic $
                 Map.empty
-                    & k "index" ?~ encodeWord64 thfTransactionIndex
+                    & k "index" ?~ encodeWord64 thfOperationIndex
                     & k "recipient" ?~ encodeTokenReceiver thfRecipient
         }
   where
@@ -765,7 +765,7 @@ encodeTokenHolderFailure TokenBalanceInsufficient{..} =
           etrrDetails =
             Just . BSS.toShort . CBOR.toStrictByteString . encodeMapDeterministic $
                 Map.empty
-                    & k "index" ?~ encodeWord64 thfTransactionIndex
+                    & k "index" ?~ encodeWord64 thfOperationIndex
                     & k "availableBalance" ?~ encodeTokenAmount thfAvailableBalance
                     & k "requiredBalance" ?~ encodeTokenAmount thfRequiredBalance
         }


### PR DESCRIPTION
## Purpose

Part of COR-683
Depends on https://github.com/Concordium/concordium-grpc-api/pull/92
Required by https://github.com/Concordium/concordium-node/pull/1379

This PR supports the implementation of token-holder transactions in the Token Module. In particular, it adds reject reasons (with CBOR-coding) for token-holder transactions. (These are not yet schematised in CDDL, and could easily change, so are provisional for now.)

## Changes

- `tokenHolderTransactionFromBytes` and `tokenHolderTransactionToBytes` - convenience functions required by the token module implementation.
- `EncodedTokenRejectReason` - a pair of a `type` indicator and optional CBOR-encoded details.
- `TokenHolderFailure` - a sum type for failure reasons that can be generated by the token-holder transaction.
- Encoding and decoding `TokenHolderFailure` to/from `EncodedTokenRejectReason`.
- Add a new `RejectReason`: `TokenHolderTransactionFailed`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
