### PR TITLE
upgrade ubuntu base image

### DIFF
--- a/scripts/identity-provider-service.Dockerfile
+++ b/scripts/identity-provider-service.Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /build/identity-provider-service
 RUN cargo build --release
 
 # Collect build artifacts in fresh image.
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 RUN apt-get update && \
     apt-get -y install \
       libssl-dev \


### PR DESCRIPTION
## Purpose

Change base images from Ubuntu 20.04 to 24.04 since. The former is deprecated https://github.com/actions/runner-images/issues/11101

## Changes

Changed relevant base images

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.