### PR TITLE
Plt metadata url rust

### DIFF
--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -4,6 +4,7 @@ use crate::common::cbor::{
 };
 use anyhow::{anyhow, Context};
 use ciborium_ll::simple;
+use concordium_contracts_common::hashes::Hash;
 
 impl<const N: usize> CborSerialize for [u8; N] {
     fn serialize<C: CborEncoder>(&self, encoder: C) -> CborSerializationResult<()> {
@@ -49,6 +50,23 @@ impl CborDeserialize for Bytes {
     where
         Self: Sized, {
         Ok(Bytes(decoder.decode_bytes()?))
+    }
+}
+
+impl CborSerialize for Hash {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> CborSerializationResult<()> {
+        encoder.encode_bytes(self.as_ref())
+    }
+}
+
+impl CborDeserialize for Hash {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized, {
+        let bytes = decoder.decode_bytes()?;
+        let hash = Hash::try_from(bytes.as_slice())
+            .context("CBOR data item not a valid hash")?;
+        Ok(hash)
     }
 }
 

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -64,8 +64,7 @@ impl CborDeserialize for Hash {
     where
         Self: Sized, {
         let bytes = decoder.decode_bytes()?;
-        let hash = Hash::try_from(bytes.as_slice())
-            .context("CBOR data item not a valid hash")?;
+        let hash = Hash::try_from(bytes.as_slice()).context("CBOR data item not a valid hash")?;
         Ok(hash)
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_metadata_url.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_metadata_url.rs
@@ -1,12 +1,14 @@
 use crate::common::cbor::{cbor_decode, cbor_encode, value};
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 use concordium_contracts_common::hashes::Hash;
+use hex::{FromHex, ToHex};
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
-use hex::{FromHex, ToHex};
 
 /// Metadata for a specific protocol level token
-#[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize, serde::Serialize, serde::Deserialize)]
+#[derive(
+    Debug, Clone, PartialEq, CborSerialize, CborDeserialize, serde::Serialize, serde::Deserialize,
+)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataUrl {
     /// A string field representing the URL
@@ -20,7 +22,8 @@ pub struct MetadataUrl {
     )]
     pub checksum_sha_256: Option<Hash>,
 
-    /// Additional fields may be included for future extensibility, e.g. another hash algorithm.
+    /// Additional fields may be included for future extensibility, e.g. another
+    /// hash algorithm.
     #[cbor(other)]
     #[serde(
         serialize_with = "serialize_hex_cbor_map",
@@ -35,8 +38,7 @@ pub struct MetadataUrl {
 /// Serialize `Bytes` as a hex string.
 fn serialize_hex_bytes<S>(bytes: &Option<Hash>, serializer: S) -> Result<S::Ok, S::Error>
 where
-    S: Serializer,
-{
+    S: Serializer, {
     if let Some(bytes) = bytes {
         serializer.serialize_str(&bytes.encode_hex::<String>())
     } else {
@@ -47,8 +49,7 @@ where
 /// Deserialize `Bytes` from a hex string.
 fn deserialize_hex_bytes<'de, D>(deserializer: D) -> Result<Option<Hash>, D::Error>
 where
-    D: Deserializer<'de>,
-{
+    D: Deserializer<'de>, {
     let opt: Option<String> = Option::deserialize(deserializer)?;
     if let Some(hex_str) = opt {
         let bytes = Vec::from_hex(&hex_str).map_err(serde::de::Error::custom)?;
@@ -65,8 +66,7 @@ fn serialize_hex_cbor_map<S>(
     serializer: S,
 ) -> Result<S::Ok, S::Error>
 where
-    S: Serializer,
-{
+    S: Serializer, {
     let mut hex_map = HashMap::new();
     for (key, value) in map {
         let cbor_bytes = cbor_encode(value).map_err(serde::ser::Error::custom)?;
@@ -80,8 +80,7 @@ fn deserialize_hex_cbor_map<'de, D>(
     deserializer: D,
 ) -> Result<HashMap<String, value::Value>, D::Error>
 where
-    D: Deserializer<'de>,
-{
+    D: Deserializer<'de>, {
     let hex_map: HashMap<String, String> = HashMap::deserialize(deserializer)?;
     let mut map = HashMap::new();
     for (key, hex_str) in hex_map {
@@ -95,23 +94,23 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json;
     use hex::FromHex;
+    use serde_json;
     use std::collections::HashMap;
 
-    const TEST_HASH: [u8; 32] = [1;32];
+    const TEST_HASH: [u8; 32] = [1; 32];
 
     #[test]
     fn test_metadata_url_json() {
-        let checksum  = Hash::from(TEST_HASH);
+        let checksum = Hash::from(TEST_HASH);
         let mut additional = HashMap::new();
         additional.insert("key".to_string(), value::Value::Text("value".to_string()));
         additional.insert("another".to_string(), value::Value::Positive(40));
 
         let metadata_url = MetadataUrl {
-            url: "https://example.com".to_string(),
+            url:              "https://example.com".to_string(),
             checksum_sha_256: Some(checksum),
-            other: additional,
+            other:            additional,
         };
 
         let serialized = serde_json::to_string(&metadata_url).unwrap();
@@ -129,9 +128,9 @@ mod tests {
         assert_eq!(actual, expected);
 
         let metadata_url = MetadataUrl {
-            url: "https://example.com".to_string(),
+            url:              "https://example.com".to_string(),
             checksum_sha_256: None,
-            other: HashMap::new(),
+            other:            HashMap::new(),
         };
 
         let serialized = serde_json::to_string(&metadata_url).unwrap();
@@ -144,9 +143,9 @@ mod tests {
         assert_eq!(actual, expected);
 
         let metadata_url = MetadataUrl {
-            url: "https://example.com".to_string(),
+            url:              "https://example.com".to_string(),
             checksum_sha_256: Some(checksum),
-            other: HashMap::new(),
+            other:            HashMap::new(),
         };
 
         let serialized = serde_json::to_string(&metadata_url).unwrap();
@@ -162,15 +161,15 @@ mod tests {
 
     #[test]
     fn test_cbor_serialize_metadata_url() {
-        let checksum  = Hash::from(TEST_HASH);
+        let checksum = Hash::from(TEST_HASH);
         let mut additional = HashMap::new();
         additional.insert("key".to_string(), value::Value::Text("value".to_string()));
         additional.insert("another".to_string(), value::Value::Positive(40));
 
         let metadata_url = MetadataUrl {
-            url: "https://example.com".to_string(),
+            url:              "https://example.com".to_string(),
             checksum_sha_256: Some(checksum),
-            other: additional,
+            other:            additional,
         };
 
         let cbor_encoded = cbor_encode(&metadata_url).unwrap();

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_metadata_url.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_metadata_url.rs
@@ -1,16 +1,158 @@
-use crate::common::cbor::{value, Bytes};
+use crate::common::cbor::{cbor_decode, cbor_encode, value, Bytes};
 use concordium_base_derive::{CborDeserialize, CborSerialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
+use hex::{FromHex, ToHex};
 
 /// Metadata for a specific protocol level token
-#[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize)]
+#[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MetadataUrl {
     /// A string field representing the URL
-    pub url:              String,
+    pub url: String,
+
     /// An optional sha256 checksum value tied to the content of the URL
+    #[serde(
+        serialize_with = "serialize_hex_bytes",
+        deserialize_with = "deserialize_hex_bytes",
+        skip_serializing_if = "Option::is_none"
+    )]
     pub checksum_sha_256: Option<Bytes>,
-    /// Additional fields may be included for future extensibility, e.g. another
-    /// hash algorithm.
+
+    /// Additional fields may be included for future extensibility, e.g. another hash algorithm.
     #[cbor(other)]
-    pub other:            HashMap<String, value::Value>,
+    #[serde(
+        serialize_with = "serialize_hex_cbor_map",
+        deserialize_with = "deserialize_hex_cbor_map",
+        default,
+        skip_serializing_if = "HashMap::is_empty"
+    )]
+    #[serde(rename = "_additional")]
+    pub other: HashMap<String, value::Value>,
+}
+
+/// Serialize `Bytes` as a hex string.
+fn serialize_hex_bytes<S>(bytes: &Option<Bytes>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    if let Some(bytes) = bytes {
+        serializer.serialize_str(&bytes.encode_hex::<String>())
+    } else {
+        serializer.serialize_none()
+    }
+}
+
+/// Deserialize `Bytes` from a hex string.
+fn deserialize_hex_bytes<'de, D>(deserializer: D) -> Result<Option<Bytes>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let opt: Option<String> = Option::deserialize(deserializer)?;
+    if let Some(hex_str) = opt {
+        let bytes = Vec::from_hex(&hex_str).map_err(serde::de::Error::custom)?;
+        Ok(Some(Bytes(bytes)))
+    } else {
+        Ok(None)
+    }
+}
+
+/// Serialize a `HashMap<String, value::Value>` as hex-encoded CBOR.
+fn serialize_hex_cbor_map<S>(
+    map: &HashMap<String, value::Value>,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let mut hex_map = HashMap::new();
+    for (key, value) in map {
+        let cbor_bytes = cbor_encode(value).map_err(serde::ser::Error::custom)?;
+        hex_map.insert(key, cbor_bytes.encode_hex::<String>());
+    }
+    hex_map.serialize(serializer)
+}
+
+/// Deserialize a `HashMap<String, value::Value>` from hex-encoded CBOR.
+fn deserialize_hex_cbor_map<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, value::Value>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let hex_map: HashMap<String, String> = HashMap::deserialize(deserializer)?;
+    let mut map = HashMap::new();
+    for (key, hex_str) in hex_map {
+        let cbor_bytes = Vec::from_hex(&hex_str).map_err(serde::de::Error::custom)?;
+        let value = cbor_decode(&cbor_bytes).map_err(serde::de::Error::custom)?;
+        map.insert(key, value);
+    }
+    Ok(map)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json;
+    use hex::FromHex;
+    use std::collections::HashMap;
+
+    #[test]
+    fn test_metadata_url_json() {
+        let checksum: Bytes = Bytes(Vec::from_hex("4d2c6df2364db5cc9e5c1f5b8dd7ccab").unwrap());
+        let mut additional = HashMap::new();
+        additional.insert("key1".to_string(), value::Value::Text("value".to_string()));
+        additional.insert("key2".to_string(), value::Value::Positive(40));
+
+        let metadata_url = MetadataUrl {
+            url: "https://example.com/metadata".to_string(),
+            checksum_sha_256: Some(checksum.clone()),
+            other: additional,
+        };
+
+        let serialized = serde_json::to_string(&metadata_url).unwrap();
+        let expected_json = r#"{
+            "url": "https://example.com/metadata",
+            "checksumSha256": "4d2c6df2364db5cc9e5c1f5b8dd7ccab",
+            "_additional": {
+                "key1": "6576616c7565",
+                "key2": "1828"
+            }
+        }"#;
+
+        let expected: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        let actual: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(actual, expected);
+
+        let metadata_url = MetadataUrl {
+            url: "https://example.com/metadata".to_string(),
+            checksum_sha_256: None,
+            other: HashMap::new(),
+        };
+
+        let serialized = serde_json::to_string(&metadata_url).unwrap();
+        let expected_json = r#"{
+            "url": "https://example.com/metadata"
+        }"#;
+
+        let expected: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        let actual: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(actual, expected);
+
+        let metadata_url = MetadataUrl {
+            url: "https://example.com/metadata".to_string(),
+            checksum_sha_256: Some(checksum),
+            other: HashMap::new(),
+        };
+
+        let serialized = serde_json::to_string(&metadata_url).unwrap();
+        let expected_json = r#"{
+            "url": "https://example.com/metadata",
+            "checksumSha256": "4d2c6df2364db5cc9e5c1f5b8dd7ccab"
+        }"#;
+
+        let expected: serde_json::Value = serde_json::from_str(expected_json).unwrap();
+        let actual: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(actual, expected);
+    }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
@@ -46,8 +46,12 @@ impl TokenModuleState {
 
 #[cfg(test)]
 mod test {
+
     use super::*;
-    use crate::common::{cbor, cbor::Bytes};
+    use concordium_contracts_common::hashes::Hash;
+    use crate::common::cbor;
+
+    const TEST_HASH: [u8; 32] = [1;32];
 
     #[test]
     fn test_token_module_state_cbor() {
@@ -55,7 +59,7 @@ mod test {
             name:       "TK1".to_string(),
             metadata:   MetadataUrl {
                 url:              "https://tokenurl1".to_string(),
-                checksum_sha_256: Some(Bytes(vec![0x01; 32])),
+                checksum_sha_256: Some(Hash::from(TEST_HASH)),
                 other:            Default::default(),
             },
             allow_list: Some(true),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
@@ -48,10 +48,10 @@ impl TokenModuleState {
 mod test {
 
     use super::*;
-    use concordium_contracts_common::hashes::Hash;
     use crate::common::cbor;
+    use concordium_contracts_common::hashes::Hash;
 
-    const TEST_HASH: [u8; 32] = [1;32];
+    const TEST_HASH: [u8; 32] = [1; 32];
 
     #[test]
     fn test_token_module_state_cbor() {


### PR DESCRIPTION
## Purpose

Adds `serde` to `TokenMetadataUrl` in accordance with the implementation done in https://github.com/Concordium/concordium-base/pull/657

## Changes

- Changes `TokenMetadataUrl.checksum_sha_256` to type `Option<Hash>` as this is more precise.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
