### PR TITLE
Use extendable tokenHolder types in plt events (COR-1506)

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -904,9 +904,9 @@ tokenHolderEventToProto TokenBurn{..} = Right . Proto.make $ do
             )
 tokenHolderEventToProto _ = Left ()
 
-instance ToProto TokenHolderEvent where
-    type Output TokenHolderEvent = Proto.TokenHolder
-    toProto (HolderAccountEvent addr) = Proto.make $ PLTFields.account .= toProto addr
+instance ToProto TokenHolder where
+    type Output TokenHolder = Proto.TokenHolder
+    toProto (HolderAccount addr) = Proto.make $ PLTFields.account .= toProto addr
 
 instance ToProto Updates.ProtocolUpdate where
     type Output Updates.ProtocolUpdate = Proto.ProtocolUpdate

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -881,8 +881,8 @@ tokenHolderEventToProto TokenTransfer{..} = Right . Proto.make $ do
     PLTFields.transferEvent
         .= Proto.make
             ( do
-                PLTFields.from .= Proto.make (PLTFields.account .= toProto ettFrom)
-                PLTFields.to .= Proto.make (PLTFields.account .= toProto ettTo)
+                PLTFields.from .= toProto ettFrom
+                PLTFields.to .= toProto ettTo
                 PLTFields.amount .= toProto ettAmount
                 PLTFields.maybe'memo .= fmap toProto ettMemo
             )
@@ -891,7 +891,7 @@ tokenHolderEventToProto TokenMint{..} = Right . Proto.make $ do
     PLTFields.mintEvent
         .= Proto.make
             ( do
-                PLTFields.target .= Proto.make (PLTFields.account .= toProto etmTarget)
+                PLTFields.target .= toProto etmTarget
                 PLTFields.amount .= toProto etmAmount
             )
 tokenHolderEventToProto TokenBurn{..} = Right . Proto.make $ do
@@ -899,10 +899,14 @@ tokenHolderEventToProto TokenBurn{..} = Right . Proto.make $ do
     PLTFields.burnEvent
         .= Proto.make
             ( do
-                PLTFields.target .= Proto.make (PLTFields.account .= toProto etbTarget)
+                PLTFields.target .= toProto etbTarget
                 PLTFields.amount .= toProto etbAmount
             )
 tokenHolderEventToProto _ = Left ()
+
+instance ToProto TokenHolderEvent where
+    type Output TokenHolderEvent = Proto.TokenHolder
+    toProto (HolderAccountEvent addr) = Proto.make $ PLTFields.account .= toProto addr
 
 instance ToProto Updates.ProtocolUpdate where
     type Output Updates.ProtocolUpdate = Proto.ProtocolUpdate

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -182,7 +182,7 @@ module Concordium.Types (
 
     -- * Protocol-level tokens
     TokenId (..),
-    TokenHolderEvent (HolderAccountEvent),
+    TokenHolder (HolderAccount),
     makeTokenId,
     unsafeGetTokenId,
     TokenParameter (..),
@@ -413,44 +413,44 @@ instance AE.FromJSON UrlText where
 emptyUrlText :: UrlText
 emptyUrlText = UrlText ""
 
-newtype TokenHolderEvent
-    = HolderAccountEvent AccountAddress
+newtype TokenHolder
+    = HolderAccount AccountAddress
     deriving (Eq)
 
-instance Show TokenHolderEvent where
-    show (HolderAccountEvent addr) =
+instance Show TokenHolder where
+    show (HolderAccount addr) =
         show addr
 
-instance AE.ToJSON TokenHolderEvent where
-    toJSON (HolderAccountEvent address) = do
+instance AE.ToJSON TokenHolder where
+    toJSON (HolderAccount address) = do
         AE.object
             [ -- Tag with type of `account`.
               "type" AE..= AE.String "account",
               "address" AE..= address
             ]
 
-instance AE.FromJSON TokenHolderEvent where
-    parseJSON = AE.withObject "TokenHolderEvent" $ \o -> do
+instance AE.FromJSON TokenHolder where
+    parseJSON = AE.withObject "TokenHolder" $ \o -> do
         type_string <- o AE..: "type"
         case (type_string :: String) of
             "account" -> do
                 address <- o AE..: "address"
-                return (HolderAccountEvent address)
-            _ -> fail ("Unknown TokenHolderEvent type " ++ type_string)
+                return (HolderAccount address)
+            _ -> fail ("Unknown TokenHolder type " ++ type_string)
 
-instance S.Serialize TokenHolderEvent where
+instance S.Serialize TokenHolder where
     get = getHolderAccount
     put = putHolderAccount
 
-getHolderAccount :: S.Get TokenHolderEvent
+getHolderAccount :: S.Get TokenHolder
 getHolderAccount =
     S.getWord8 >>= \case
         0 -> do
-            HolderAccountEvent <$> S.get
-        n -> fail $ "Unrecognized TokenHolderEvent tag: " ++ show n
+            HolderAccount <$> S.get
+        n -> fail $ "Unrecognized TokenHolder tag: " ++ show n
 
-putHolderAccount :: S.Putter TokenHolderEvent
-putHolderAccount (HolderAccountEvent address) =
+putHolderAccount :: S.Putter TokenHolder
+putHolderAccount (HolderAccount address) =
     S.putWord8 0
         <> S.put address
 

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -413,7 +413,13 @@ instance AE.FromJSON UrlText where
 emptyUrlText :: UrlText
 emptyUrlText = UrlText ""
 
-newtype TokenHolder = HolderAccount {thAccount :: AccountAddress}
+-- | An entity that can hold PLTs (protocol level tokens).
+-- The type is used in the `TokenTransfer`, `TokenMint`, and `TokenBurn` events.
+-- Currently, this can only be a Concordium account address.
+-- The type can be extended to e.g. support smart contracts in the future.
+-- This type shouldn't be confused with the `CborTokenHolder` type that in contrast is used
+-- in the transaction payload, in reject reasons, and in the `TokenModuleEvent`.
+newtype TokenHolder = HolderAccount {haAccount :: AccountAddress}
     deriving (Eq)
 
 instance Show TokenHolder where
@@ -437,6 +443,8 @@ instance AE.FromJSON TokenHolder where
                 return (HolderAccount address)
             _ -> fail ("Unknown TokenHolder type " ++ type_string)
 
+-- Serialization instance for the `TokenHolder` type. A `Word8` tag is used
+-- to allow future extensions, such as supporting smart contract token holders.
 instance S.Serialize TokenHolder where
     get = getHolderAccount
     put = putHolderAccount

--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -182,7 +182,7 @@ module Concordium.Types (
 
     -- * Protocol-level tokens
     TokenId (..),
-    TokenHolder (HolderAccount),
+    TokenHolder (..),
     makeTokenId,
     unsafeGetTokenId,
     TokenParameter (..),
@@ -413,8 +413,7 @@ instance AE.FromJSON UrlText where
 emptyUrlText :: UrlText
 emptyUrlText = UrlText ""
 
-newtype TokenHolder
-    = HolderAccount AccountAddress
+newtype TokenHolder = HolderAccount {thAccount :: AccountAddress}
     deriving (Eq)
 
 instance Show TokenHolder where

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1414,9 +1414,9 @@ data Event' (supplemented :: Bool)
         { -- | The unique token identifier.
           ettTokenId :: !TokenId,
           -- | The source of the transfer.
-          ettFrom :: !TokenHolderEvent,
+          ettFrom :: !TokenHolder,
           -- | The target of the transfer.
-          ettTo :: !TokenHolderEvent,
+          ettTo :: !TokenHolder,
           -- | The amount transferred.
           ettAmount :: !TokenAmount,
           -- | An optional memo for the transfer.
@@ -1427,7 +1427,7 @@ data Event' (supplemented :: Bool)
         { -- | The unique token identifier.
           etmTokenId :: !TokenId,
           -- | The account receiving the minted tokens.
-          etmTarget :: !TokenHolderEvent,
+          etmTarget :: !TokenHolder,
           -- | The amount minted.
           etmAmount :: !TokenAmount
         }
@@ -1436,7 +1436,7 @@ data Event' (supplemented :: Bool)
         { -- | The unique token identifier.
           etbTokenId :: !TokenId,
           -- | The account from which the tokens are burned.
-          etbTarget :: !TokenHolderEvent,
+          etbTarget :: !TokenHolder,
           -- | The amount burned.
           etbAmount :: !TokenAmount
         }

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -595,14 +595,14 @@ instance AE.ToJSON CborTokenHolder where
                 ++ ["coininfo" AE..= coinInfo | coinInfo <- toList holderAccountCoinInfo]
 
 instance AE.FromJSON CborTokenHolder where
-    parseJSON = AE.withObject "TokenReceiver" $ \o -> do
+    parseJSON = AE.withObject "CborTokenHolder" $ \o -> do
         type_string <- o AE..: "type"
         case (type_string :: String) of
             "account" -> do
                 holderAccountAddress <- o AE..: "address"
                 holderAccountCoinInfo <- o AE..:? "coininfo"
                 return HolderAccount{..}
-            _ -> fail ("Unknown TokenReceiver type " ++ type_string)
+            _ -> fail ("Unknown CborTokenHolder type " ++ type_string)
 
 -- | Create a 'HolderAccount' from an 'AccountAddress'. The address type will be present in the
 --  CBOR encoding.

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -83,8 +83,8 @@ genAggregationVerifyKeyAndProof = do
 genAccountAddress :: Gen AccountAddress
 genAccountAddress = AccountAddress . FBS.pack <$> vector accountAddressSize
 
-genTokenHolderEvent :: Gen TokenHolderEvent
-genTokenHolderEvent = HolderAccountEvent <$> genAccountAddress
+genTokenHolder :: Gen TokenHolder
+genTokenHolder = HolderAccount <$> genAccountAddress
 
 genAccountAliases :: AccountAddress -> Gen AccountAddress
 genAccountAliases (AccountAddress addr) = do
@@ -814,12 +814,12 @@ genEvent spv =
             [ TokenModuleEvent <$> genTokenId <*> genTokenEventType <*> genTokenEventDetails,
               TokenTransfer
                 <$> genTokenId
-                <*> genTokenHolderEvent
-                <*> genTokenHolderEvent
+                <*> genTokenHolder
+                <*> genTokenHolder
                 <*> genTokenAmount
                 <*> liftArbitrary genMemo,
-              TokenMint <$> genTokenId <*> genTokenHolderEvent <*> genTokenAmount,
-              TokenBurn <$> genTokenId <*> genTokenHolderEvent <*> genTokenAmount,
+              TokenMint <$> genTokenId <*> genTokenHolder <*> genTokenAmount,
+              TokenBurn <$> genTokenId <*> genTokenHolder <*> genTokenAmount,
               TokenCreated <$> genCreatePLT
             ]
         | otherwise = []

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -83,6 +83,9 @@ genAggregationVerifyKeyAndProof = do
 genAccountAddress :: Gen AccountAddress
 genAccountAddress = AccountAddress . FBS.pack <$> vector accountAddressSize
 
+genTokenHolderEvent :: Gen TokenHolderEvent
+genTokenHolderEvent = HolderAccountEvent <$> genAccountAddress
+
 genAccountAliases :: AccountAddress -> Gen AccountAddress
 genAccountAliases (AccountAddress addr) = do
     suffix <- vector 3
@@ -811,12 +814,12 @@ genEvent spv =
             [ TokenModuleEvent <$> genTokenId <*> genTokenEventType <*> genTokenEventDetails,
               TokenTransfer
                 <$> genTokenId
-                <*> genAccountAddress
-                <*> genAccountAddress
+                <*> genTokenHolderEvent
+                <*> genTokenHolderEvent
                 <*> genTokenAmount
                 <*> liftArbitrary genMemo,
-              TokenMint <$> genTokenId <*> genAccountAddress <*> genTokenAmount,
-              TokenBurn <$> genTokenId <*> genAccountAddress <*> genTokenAmount,
+              TokenMint <$> genTokenId <*> genTokenHolderEvent <*> genTokenAmount,
+              TokenBurn <$> genTokenId <*> genTokenHolderEvent <*> genTokenAmount,
               TokenCreated <$> genCreatePLT
             ]
         | otherwise = []

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -78,8 +78,8 @@ genTokenTransfer = do
     ttMemo <- oneof [pure Nothing, Just <$> genTaggableMemo]
     return TokenTransferBody{..}
 
--- | Generator for `TokenHolder`
-genTokenHolder :: Gen TokenHolder
+-- | Generator for `CborTokenHolder`
+genTokenHolder :: Gen CborTokenHolder
 genTokenHolder =
     oneof
         [ HolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -332,8 +332,8 @@ tops1 =
                       ttAmount = TokenAmount{taValue = 12345, taDecimals = 5},
                       ttRecipient =
                         CborHolderAccount
-                            { cthAccount = AccountAddress $ FBS.pack [0x1, 0x1],
-                              cthCoinInfo = Just CoinInfoConcordium
+                            { chaAccount = AccountAddress $ FBS.pack [0x1, 0x1],
+                              chaCoinInfo = Just CoinInfoConcordium
                             },
                       ttMemo = Just $ UntaggedMemo $ Memo $ BSS.pack [0x1, 0x2, 0x3, 0x4]
                     }

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -82,8 +82,8 @@ genTokenTransfer = do
 genCborTokenHolder :: Gen CborTokenHolder
 genCborTokenHolder =
     oneof
-        [ Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),
-          Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount <$> genAccountAddress <*> pure Nothing
+        [ CborHolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),
+          CborHolderAccount <$> genAccountAddress <*> pure Nothing
         ]
 
 -- | Generator for `TaggableMemo`
@@ -331,9 +331,9 @@ tops1 =
                     { -- Use a token amount that is not modified by "normalization". Normalization may be removed entirely, but for now, work around it like this
                       ttAmount = TokenAmount{taValue = 12345, taDecimals = 5},
                       ttRecipient =
-                        Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount
-                            { holderAccountAddress = AccountAddress $ FBS.pack [0x1, 0x1],
-                              holderAccountCoinInfo = Just CoinInfoConcordium
+                        CborHolderAccount
+                            { cthAccount = AccountAddress $ FBS.pack [0x1, 0x1],
+                              cthCoinInfo = Just CoinInfoConcordium
                             },
                       ttMemo = Just $ UntaggedMemo $ Memo $ BSS.pack [0x1, 0x2, 0x3, 0x4]
                     }

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -82,8 +82,8 @@ genTokenTransfer = do
 genCborTokenHolder :: Gen CborTokenHolder
 genCborTokenHolder =
     oneof
-        [ HolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),
-          HolderAccount <$> genAccountAddress <*> pure Nothing
+        [ Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),
+          Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount <$> genAccountAddress <*> pure Nothing
         ]
 
 -- | Generator for `TaggableMemo`
@@ -331,7 +331,7 @@ tops1 =
                     { -- Use a token amount that is not modified by "normalization". Normalization may be removed entirely, but for now, work around it like this
                       ttAmount = TokenAmount{taValue = 12345, taDecimals = 5},
                       ttRecipient =
-                        HolderAccount
+                        Concordium.Types.ProtocolLevelTokens.CBOR.HolderAccount
                             { holderAccountAddress = AccountAddress $ FBS.pack [0x1, 0x1],
                               holderAccountCoinInfo = Just CoinInfoConcordium
                             },

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -74,13 +74,13 @@ genTokenInitializationParameters = do
 genTokenTransfer :: Gen TokenTransferBody
 genTokenTransfer = do
     ttAmount <- genTokenAmount
-    ttRecipient <- genTokenHolder
+    ttRecipient <- genCborTokenHolder
     ttMemo <- oneof [pure Nothing, Just <$> genTaggableMemo]
     return TokenTransferBody{..}
 
 -- | Generator for `CborTokenHolder`
-genTokenHolder :: Gen CborTokenHolder
-genTokenHolder =
+genCborTokenHolder :: Gen CborTokenHolder
+genCborTokenHolder =
     oneof
         [ HolderAccount <$> genAccountAddress <*> pure (Just CoinInfoConcordium),
           HolderAccount <$> genAccountAddress <*> pure Nothing
@@ -106,10 +106,10 @@ genTokenGovernanceOperation =
     oneof
         [ TokenMint <$> genTokenAmount,
           TokenBurn <$> genTokenAmount,
-          TokenAddAllowList <$> genTokenHolder,
-          TokenRemoveAllowList <$> genTokenHolder,
-          TokenAddDenyList <$> genTokenHolder,
-          TokenRemoveDenyList <$> genTokenHolder
+          TokenAddAllowList <$> genCborTokenHolder,
+          TokenRemoveAllowList <$> genCborTokenHolder,
+          TokenAddDenyList <$> genCborTokenHolder,
+          TokenRemoveDenyList <$> genCborTokenHolder
         ]
 
 -- | Generator for 'TokenGovernanceOperation'.
@@ -193,22 +193,22 @@ genTokenModuleAccountStateWithAdditional = do
 genTokenEvent :: Gen TokenEvent
 genTokenEvent =
     oneof
-        [ AddAllowListEvent <$> genTokenHolder,
-          RemoveAllowListEvent <$> genTokenHolder,
-          AddDenyListEvent <$> genTokenHolder,
-          RemoveDenyListEvent <$> genTokenHolder
+        [ AddAllowListEvent <$> genCborTokenHolder,
+          RemoveAllowListEvent <$> genCborTokenHolder,
+          AddDenyListEvent <$> genCborTokenHolder,
+          RemoveDenyListEvent <$> genCborTokenHolder
         ]
 
 -- | Generator for 'TokenRejectReason'.
 genTokenRejectReason :: Gen TokenRejectReason
 genTokenRejectReason =
     oneof
-        [ AddressNotFound <$> arbitrary <*> genTokenHolder,
+        [ AddressNotFound <$> arbitrary <*> genCborTokenHolder,
           TokenBalanceInsufficient <$> arbitrary <*> genTokenAmount <*> genTokenAmount,
           DeserializationFailure <$> liftArbitrary genText,
           UnsupportedOperation <$> arbitrary <*> genText <*> liftArbitrary genText,
           MintWouldOverflow <$> arbitrary <*> genTokenAmount <*> genTokenAmount <*> genTokenAmount,
-          OperationNotPermitted <$> arbitrary <*> liftArbitrary genTokenHolder <*> liftArbitrary genText
+          OperationNotPermitted <$> arbitrary <*> liftArbitrary genCborTokenHolder <*> liftArbitrary genText
         ]
 
 -- | A test value for 'TokenInitializationParameters'.

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -96,8 +96,7 @@ pub struct TokenListUpdateEventDetails {
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
 pub enum TokenHolder {
-    #[serde(rename = "account")]
-    HolderAccount { address: AccountAddress },
+    Account { address: AccountAddress },
 }
 
 /// An event emitted when a transfer of tokens from `from` to `to` is performed.
@@ -186,13 +185,13 @@ mod test {
     use super::*;
     use crate::{
         common::cbor,
-        protocol_level_tokens::{token_holder, HolderAccount},
+        protocol_level_tokens::{token_holder, CborHolderAccount},
     };
 
     #[test]
     fn test_decode_add_allow_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -214,7 +213,7 @@ mod test {
     #[test]
     fn test_decode_remove_allow_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -236,7 +235,7 @@ mod test {
     #[test]
     fn test_decode_add_deny_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -258,7 +257,7 @@ mod test {
     #[test]
     fn test_decode_remove_deny_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -3,8 +3,9 @@ use crate::{
     transactions::Memo,
 };
 use concordium_base_derive::{CborDeserialize, CborSerialize};
+use concordium_contracts_common::AccountAddress;
 
-use super::{cbor::RawCbor, TokenAmount, TokenHolder, TokenId};
+use super::{cbor::RawCbor, TokenAmount, TokenHolder as CborTokenHolder, TokenId};
 
 /// An event produced from the effect of a token transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -89,7 +90,14 @@ pub enum TokenModuleEventType {
 #[serde(rename_all = "camelCase")]
 pub struct TokenListUpdateEventDetails {
     /// The account that was added or removed from an allow or deny list
-    pub target: TokenHolder,
+    pub target: CborTokenHolder,
+}
+
+#[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum TokenHolderEvent {
+    #[serde(rename = "account")]
+    HolderAccountEvent { address: AccountAddress },
 }
 
 /// An event emitted when a transfer of tokens from `from` to `to` is performed.
@@ -97,9 +105,9 @@ pub struct TokenListUpdateEventDetails {
 #[serde(rename_all = "camelCase")]
 pub struct TokenTransferEvent {
     /// The token holder from which the tokens are transferred.
-    pub from:   TokenHolder,
+    pub from:   TokenHolderEvent,
     /// The token holder to which the tokens are transferred.
-    pub to:     TokenHolder,
+    pub to:     TokenHolderEvent,
     /// The amount of tokens transferred.
     pub amount: TokenAmount,
     /// An optional memo field that can be used to attach a message to the token
@@ -113,7 +121,7 @@ pub struct TokenTransferEvent {
 #[serde(rename_all = "camelCase")]
 pub struct TokenSupplyUpdateEvent {
     /// The token holder the balance update is performed on.
-    pub target: TokenHolder,
+    pub target: TokenHolderEvent,
     /// The balance difference to be applied to the target.
     pub amount: TokenAmount,
 }
@@ -184,7 +192,7 @@ mod test {
     #[test]
     fn test_decode_add_allow_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -206,7 +214,7 @@ mod test {
     #[test]
     fn test_decode_remove_allow_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -228,7 +236,7 @@ mod test {
     #[test]
     fn test_decode_add_deny_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -250,7 +258,7 @@ mod test {
     #[test]
     fn test_decode_remove_deny_list_event_cbor() {
         let variant = TokenListUpdateEventDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -93,6 +93,13 @@ pub struct TokenListUpdateEventDetails {
     pub target: CborTokenHolder,
 }
 
+/// An entity that can hold PLTs (protocol level tokens).
+/// The type is used in the `TokenTransfer`, `TokenMint`, and `TokenBurn`
+/// events. Currently, this can only be a Concordium account address.
+/// The type can be extended to e.g. support smart contracts in the future.
+/// This type shouldn't be confused with the `CborTokenHolder` type that in
+/// contrast is used in the transaction payload, in reject reasons, and in the
+/// `TokenModuleEvent`.
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
 pub enum TokenHolder {

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -5,7 +5,7 @@ use crate::{
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 use concordium_contracts_common::AccountAddress;
 
-use super::{cbor::RawCbor, TokenAmount, TokenHolder as CborTokenHolder, TokenId};
+use super::{cbor::RawCbor, CborTokenHolder, TokenAmount, TokenId};
 
 /// An event produced from the effect of a token transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -95,9 +95,9 @@ pub struct TokenListUpdateEventDetails {
 
 #[derive(Debug, Eq, PartialEq, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type")]
-pub enum TokenHolderEvent {
+pub enum TokenHolder {
     #[serde(rename = "account")]
-    HolderAccountEvent { address: AccountAddress },
+    HolderAccount { address: AccountAddress },
 }
 
 /// An event emitted when a transfer of tokens from `from` to `to` is performed.
@@ -105,9 +105,9 @@ pub enum TokenHolderEvent {
 #[serde(rename_all = "camelCase")]
 pub struct TokenTransferEvent {
     /// The token holder from which the tokens are transferred.
-    pub from:   TokenHolderEvent,
+    pub from:   TokenHolder,
     /// The token holder to which the tokens are transferred.
-    pub to:     TokenHolderEvent,
+    pub to:     TokenHolder,
     /// The amount of tokens transferred.
     pub amount: TokenAmount,
     /// An optional memo field that can be used to attach a message to the token
@@ -121,7 +121,7 @@ pub struct TokenTransferEvent {
 #[serde(rename_all = "camelCase")]
 pub struct TokenSupplyUpdateEvent {
     /// The token holder the balance update is performed on.
-    pub target: TokenHolderEvent,
+    pub target: TokenHolder,
     /// The balance difference to be applied to the target.
     pub amount: TokenAmount,
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
@@ -24,10 +24,11 @@ const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
     CborSerialize,
     CborDeserialize,
 )]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type")]
 #[cbor(tagged)]
 pub enum CborTokenHolder {
     #[cbor(peek_tag = ACCOUNT_HOLDER_TAG)]
+    #[serde(rename = "account")]
     HolderAccount(HolderAccount),
 }
 

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
@@ -12,8 +12,12 @@ const COIN_INFO_TAG: u64 = 40305;
 /// Concordiums listing in https://github.com/satoshilabs/slips/blob/master/slip-0044.md
 const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
 
-/// A destination that can receive and hold protocol level tokens.
+/// An entity that can receive and hold protocol level tokens.
 /// Currently, this can only be a Concordium account address.
+/// The type is used in the transaction payload, in reject reasons, and in the
+/// `TokenModuleEvent`. This type shouldn't be confused with the `TokenHolder`
+/// type that in contrast is used in the `TokenTransfer`, `TokenMint`, and
+/// `TokenBurn` events.
 #[derive(
     Debug,
     Eq,

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
@@ -26,7 +26,7 @@ const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
 )]
 #[serde(rename_all = "camelCase")]
 #[cbor(tagged)]
-pub enum TokenHolder {
+pub enum CborTokenHolder {
     #[cbor(peek_tag = ACCOUNT_HOLDER_TAG)]
     HolderAccount(HolderAccount),
 }
@@ -138,7 +138,7 @@ mod test {
 
     #[test]
     fn test_token_holder_cbor_no_coin_info() {
-        let token_holder = TokenHolder::HolderAccount(HolderAccount {
+        let token_holder = CborTokenHolder::HolderAccount(HolderAccount {
             address:   ADDRESS,
             coin_info: None,
         });
@@ -148,20 +148,20 @@ mod test {
             hex::encode(&cbor),
             "d99d73a10358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
         );
-        let token_holder_decoded: TokenHolder = cbor::cbor_decode(&cbor).unwrap();
+        let token_holder_decoded: CborTokenHolder = cbor::cbor_decode(&cbor).unwrap();
         assert_eq!(token_holder_decoded, token_holder);
     }
 
     #[test]
     fn test_token_holder_cbor() {
-        let token_holder = TokenHolder::HolderAccount(HolderAccount {
+        let token_holder = CborTokenHolder::HolderAccount(HolderAccount {
             address:   ADDRESS,
             coin_info: Some(CoinInfo::CCD),
         });
 
         let cbor = cbor::cbor_encode(&token_holder).unwrap();
         assert_eq!(hex::encode(&cbor), "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
-        let token_holder_decoded: TokenHolder = cbor::cbor_decode(&cbor).unwrap();
+        let token_holder_decoded: CborTokenHolder = cbor::cbor_decode(&cbor).unwrap();
         assert_eq!(token_holder_decoded, token_holder);
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_holder.rs
@@ -28,8 +28,7 @@ const CONCORDIUM_SLIP_0044_CODE: u64 = 919;
 #[cbor(tagged)]
 pub enum CborTokenHolder {
     #[cbor(peek_tag = ACCOUNT_HOLDER_TAG)]
-    #[serde(rename = "account")]
-    HolderAccount(HolderAccount),
+    Account(CborHolderAccount),
 }
 
 /// Account address that holds protocol level tokens
@@ -45,7 +44,7 @@ pub enum CborTokenHolder {
 )]
 #[serde(rename_all = "camelCase")]
 #[cbor(tag = ACCOUNT_HOLDER_TAG)]
-pub struct HolderAccount {
+pub struct CborHolderAccount {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[cbor(key = 1)]
     pub coin_info: Option<CoinInfo>,
@@ -139,7 +138,7 @@ mod test {
 
     #[test]
     fn test_token_holder_cbor_no_coin_info() {
-        let token_holder = CborTokenHolder::HolderAccount(HolderAccount {
+        let token_holder = CborTokenHolder::Account(CborHolderAccount {
             address:   ADDRESS,
             coin_info: None,
         });
@@ -155,7 +154,7 @@ mod test {
 
     #[test]
     fn test_token_holder_cbor() {
-        let token_holder = CborTokenHolder::HolderAccount(HolderAccount {
+        let token_holder = CborTokenHolder::Account(CborHolderAccount {
             address:   ADDRESS,
             coin_info: Some(CoinInfo::CCD),
         });

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -4,7 +4,7 @@ use crate::{
         cbor::{value, CborSerializationResult},
     },
     protocol_level_tokens::{
-        token_holder::CborTokenHolder, CoinInfo, HolderAccount, RawCbor, TokenAmount, TokenId,
+        token_holder::CborTokenHolder, CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId,
     },
     transactions::Memo,
 };
@@ -28,7 +28,7 @@ pub mod operations {
     pub fn transfer_tokens(receiver: AccountAddress, amount: TokenAmount) -> TokenOperation {
         TokenOperation::Transfer(TokenTransfer {
             amount,
-            recipient: CborTokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   receiver,
             }),
@@ -44,7 +44,7 @@ pub mod operations {
     ) -> TokenOperation {
         TokenOperation::Transfer(TokenTransfer {
             amount,
-            recipient: CborTokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   receiver,
             }),
@@ -65,7 +65,7 @@ pub mod operations {
     /// Construct operation to add target to protocol level token allow list.
     pub fn add_token_allow_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::AddAllowList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -75,7 +75,7 @@ pub mod operations {
     /// Construct operation to remove target from protocol level token allow.
     pub fn remove_token_allow_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -85,7 +85,7 @@ pub mod operations {
     /// Construct operation to add target to protocol level token deny list.
     pub fn add_token_deny_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::AddDenyList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -96,7 +96,7 @@ pub mod operations {
     /// list.
     pub fn remove_token_deny_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -274,7 +274,7 @@ pub mod test {
     use super::*;
     use crate::{
         common::cbor,
-        protocol_level_tokens::{token_holder::test_fixtures::ADDRESS, HolderAccount},
+        protocol_level_tokens::{token_holder::test_fixtures::ADDRESS, CborHolderAccount},
     };
     use assert_matches::assert_matches;
 
@@ -300,7 +300,7 @@ pub mod test {
         let operations = TokenOperations {
             operations: vec![TokenOperation::Transfer(TokenTransfer {
                 amount:    TokenAmount::from_raw(12300, 3),
-                recipient: CborTokenHolder::HolderAccount(HolderAccount {
+                recipient: CborTokenHolder::Account(CborHolderAccount {
                     address:   ADDRESS,
                     coin_info: None,
                 }),
@@ -318,7 +318,7 @@ pub mod test {
     fn test_token_operation_cbor_transfer() {
         let operation = TokenOperation::Transfer(TokenTransfer {
             amount:    TokenAmount::from_raw(12300, 3),
-            recipient: CborTokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::Account(CborHolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -364,7 +364,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_add_allow_list() {
         let operation = TokenOperation::AddAllowList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -379,7 +379,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_remove_allow_list() {
         let operation = TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -394,7 +394,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_add_deny_list() {
         let operation = TokenOperation::AddDenyList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -409,7 +409,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_remove_deny_list() {
         let operation = TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-            target: CborTokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::Account(CborHolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -4,7 +4,7 @@ use crate::{
         cbor::{value, CborSerializationResult},
     },
     protocol_level_tokens::{
-        token_holder::TokenHolder, CoinInfo, HolderAccount, RawCbor, TokenAmount, TokenId,
+        token_holder::CborTokenHolder, CoinInfo, HolderAccount, RawCbor, TokenAmount, TokenId,
     },
     transactions::Memo,
 };
@@ -28,7 +28,7 @@ pub mod operations {
     pub fn transfer_tokens(receiver: AccountAddress, amount: TokenAmount) -> TokenOperation {
         TokenOperation::Transfer(TokenTransfer {
             amount,
-            recipient: TokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   receiver,
             }),
@@ -44,7 +44,7 @@ pub mod operations {
     ) -> TokenOperation {
         TokenOperation::Transfer(TokenTransfer {
             amount,
-            recipient: TokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   receiver,
             }),
@@ -65,7 +65,7 @@ pub mod operations {
     /// Construct operation to add target to protocol level token allow list.
     pub fn add_token_allow_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::AddAllowList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -75,7 +75,7 @@ pub mod operations {
     /// Construct operation to remove target from protocol level token allow.
     pub fn remove_token_allow_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -85,7 +85,7 @@ pub mod operations {
     /// Construct operation to add target to protocol level token deny list.
     pub fn add_token_deny_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::AddDenyList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -96,7 +96,7 @@ pub mod operations {
     /// list.
     pub fn remove_token_deny_list(target: AccountAddress) -> TokenOperation {
         TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 coin_info: Some(CoinInfo::CCD),
                 address:   target,
             }),
@@ -223,7 +223,7 @@ pub struct TokenSupplyUpdateDetails {
 #[serde(rename_all = "camelCase")]
 pub struct TokenListUpdateDetails {
     /// Account that is added to or removed from a list
-    pub target: TokenHolder,
+    pub target: CborTokenHolder,
 }
 
 /// Protocol level token transfer
@@ -242,7 +242,7 @@ pub struct TokenTransfer {
     /// The amount of tokens to transfer.
     pub amount:    TokenAmount,
     /// The recipient account.
-    pub recipient: TokenHolder,
+    pub recipient: CborTokenHolder,
     /// An optional memo.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub memo:      Option<CborMemo>,
@@ -300,7 +300,7 @@ pub mod test {
         let operations = TokenOperations {
             operations: vec![TokenOperation::Transfer(TokenTransfer {
                 amount:    TokenAmount::from_raw(12300, 3),
-                recipient: TokenHolder::HolderAccount(HolderAccount {
+                recipient: CborTokenHolder::HolderAccount(HolderAccount {
                     address:   ADDRESS,
                     coin_info: None,
                 }),
@@ -318,7 +318,7 @@ pub mod test {
     fn test_token_operation_cbor_transfer() {
         let operation = TokenOperation::Transfer(TokenTransfer {
             amount:    TokenAmount::from_raw(12300, 3),
-            recipient: TokenHolder::HolderAccount(HolderAccount {
+            recipient: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -364,7 +364,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_add_allow_list() {
         let operation = TokenOperation::AddAllowList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -379,7 +379,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_remove_allow_list() {
         let operation = TokenOperation::RemoveAllowList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -394,7 +394,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_add_deny_list() {
         let operation = TokenOperation::AddDenyList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),
@@ -409,7 +409,7 @@ pub mod test {
     #[test]
     fn test_token_operation_cbor_remove_deny_list() {
         let operation = TokenOperation::RemoveDenyList(TokenListUpdateDetails {
-            target: TokenHolder::HolderAccount(HolderAccount {
+            target: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   ADDRESS,
                 coin_info: None,
             }),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
@@ -208,7 +208,7 @@ mod test {
     use super::*;
     use crate::{
         common::cbor,
-        protocol_level_tokens::{token_holder, HolderAccount},
+        protocol_level_tokens::{token_holder, CborHolderAccount},
     };
     use std::str::FromStr;
 
@@ -216,7 +216,7 @@ mod test {
     fn test_address_not_found_reject_reason_cbor() {
         let variant = AddressNotFoundRejectReason {
             index:   3,
-            address: CborTokenHolder::HolderAccount(HolderAccount {
+            address: CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -304,7 +304,7 @@ mod test {
     fn test_operation_not_permitted_reject_reason_cbor() {
         let variant = OperationNotPermittedRejectReason {
             index:   0,
-            address: Some(CborTokenHolder::HolderAccount(HolderAccount {
+            address: Some(CborTokenHolder::Account(CborHolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             })),

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
@@ -1,7 +1,8 @@
 use crate::{
     common::{cbor, cbor::CborSerializationResult},
     protocol_level_tokens::{
-        token_holder::TokenHolder, RawCbor, TokenAmount, TokenId, TokenModuleCborTypeDiscriminator,
+        token_holder::CborTokenHolder, RawCbor, TokenAmount, TokenId,
+        TokenModuleCborTypeDiscriminator,
     },
 };
 use anyhow::Context;
@@ -87,7 +88,7 @@ pub struct AddressNotFoundRejectReason {
     /// The index in the list of operations of the failing operation.
     pub index:   usize,
     /// The address that could not be resolved.
-    pub address: TokenHolder,
+    pub address: CborTokenHolder,
 }
 
 /// The balance of tokens on the sender account is insufficient
@@ -174,7 +175,7 @@ pub struct OperationNotPermittedRejectReason {
     pub index:   usize,
     /// (Optionally) the address that does not have the necessary permissions to
     /// perform the operation.
-    pub address: Option<TokenHolder>,
+    pub address: Option<CborTokenHolder>,
     /// The reason why the operation is not permitted.
     pub reason:  Option<String>,
 }
@@ -215,7 +216,7 @@ mod test {
     fn test_address_not_found_reject_reason_cbor() {
         let variant = AddressNotFoundRejectReason {
             index:   3,
-            address: TokenHolder::HolderAccount(HolderAccount {
+            address: CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             }),
@@ -303,7 +304,7 @@ mod test {
     fn test_operation_not_permitted_reject_reason_cbor() {
         let variant = OperationNotPermittedRejectReason {
             index:   0,
-            address: Some(TokenHolder::HolderAccount(HolderAccount {
+            address: Some(CborTokenHolder::HolderAccount(HolderAccount {
                 address:   token_holder::test_fixtures::ADDRESS,
                 coin_info: None,
             })),

--- a/rust-src/concordium_base/src/updates.rs
+++ b/rust-src/concordium_base/src/updates.rs
@@ -780,7 +780,7 @@ pub enum UpdateType {
     UpdateValidatorScoreParameters,
     /// Create a new protocol level token. Only applies to
     /// protocol version [`P9`](ProtocolVersion::P9) and up.
-    CreatePlt,
+    UpdateCreatePLT,
 }
 
 impl UpdatePayload {
@@ -812,7 +812,7 @@ impl UpdatePayload {
                 UpdateFinalizationCommitteeParameters
             }
             UpdatePayload::ValidatorScoreParametersCPV3(_) => UpdateValidatorScoreParameters,
-            UpdatePayload::CreatePlt(_) => CreatePlt,
+            UpdatePayload::CreatePlt(_) => UpdateCreatePLT,
         }
     }
 }


### PR DESCRIPTION
## Purpose

We want to ensure the Protocol-level token (PLT) events (transfer, mint and burn) are structured in a forward-compatible way, such that we can expand the events in the future, with minimal breakage in the ecosystem. Specifically adding new token holder entities as there are already discussions on adding smart contract support. Here we need to consider the additional context as well, since memos might not be relevant for smart contracts, but instead a receive-hook name with some parsed input parameters would be needed in the events.

https://linear.app/concordium/issue/COR-1506/align-json-serialization-of-plt-events-across-rusthaskell-and-adhere

Related PRs:
https://github.com/Concordium/concordium-client/pull/382
https://github.com/Concordium/concordium-node/pull/1402
https://github.com/Concordium/concordium-rust-sdk/pull/275
https://github.com/Concordium/concordium-transaction-logger/pull/34
https://github.com/Concordium/concordium-wallet-proxy/pull/132

## Changes

- Clearly separate between the `CborTokenHolder` type (used in the transaction payload, in reject reasons, and in the `TokenModuleEvent`) from the `TokenHolder` type (emitted by the plt mint/burn/transfer events as defined in the proto buffer definition).


- The  plt mint/burn/transfer events are extendable now with additional optional fields in the future and the `tokenHolder` type can be extended to e.g. smart contracts. The event `add/remove account address from allow/deny list` (`TokenModuleEvent`) is not extendable but as `TokenModuleEvents` itself can be extended as their `details` part can be any cbor encoded future event that trade-off seems reasonable.


- Add a bitmask to each plt mint/burn/transfer event, so that we can toggle on/off the optional `memo` field and introduce additional optional fields in the future for smart contract token holder support.


- Align JSON serialization of the `TokenHolder` type emitted by the plt mint/burn/transfer event across the `haskell/rust` code base. Align `CborTokenHolder` type. Align `updateCreatePLT` transaction tag across the code base.

