### PR TITLE
use unsigned decimal fraction for token amount

### DIFF
--- a/rust-src/concordium_base/src/common/cbor/composites.rs
+++ b/rust-src/concordium_base/src/common/cbor/composites.rs
@@ -4,7 +4,7 @@ use concordium_base_derive::{CborDeserialize, CborSerialize};
 const DECIMAL_FRACTION_TAG: u64 = 4;
 
 /// Decimal fraction consisting of exponent `e` and mantissa `m`, see <https://www.rfc-editor.org/rfc/rfc8949.html#name-decimal-fractions-and-bigfl>.
-/// It represents the value `m * 10^e`.
+/// It represents the numerical value `m * 10^e`.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, CborSerialize, CborDeserialize)]
 #[cbor(tag = DECIMAL_FRACTION_TAG)]
 pub struct DecimalFraction(i64, i64);
@@ -15,6 +15,20 @@ impl DecimalFraction {
     pub fn exponent(self) -> i64 { self.0 }
 
     pub fn mantissa(self) -> i64 { self.1 }
+}
+
+/// Unsigned decimal fraction consisting of exponent `e` and non-negative mantissa `m`, see <https://www.rfc-editor.org/rfc/rfc8949.html#name-decimal-fractions-and-bigfl>.
+/// It represents the numerical value `m * 10^e`.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, CborSerialize, CborDeserialize)]
+#[cbor(tag = DECIMAL_FRACTION_TAG)]
+pub struct UnsignedDecimalFraction(i64, u64);
+
+impl UnsignedDecimalFraction {
+    pub fn new(exponent: i64, mantissa: u64) -> Self { Self(exponent, mantissa) }
+
+    pub fn exponent(self) -> i64 { self.0 }
+
+    pub fn mantissa(self) -> u64 { self.1 }
 }
 
 #[cfg(test)]
@@ -28,6 +42,45 @@ mod test {
         let cbor = cbor_encode(&value).unwrap();
         assert_eq!(hex::encode(&cbor), "c48222193039");
         let value_decoded: DecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value = DecimalFraction::new(3, 12345);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c48203193039");
+        let value_decoded: DecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value = DecimalFraction::new(3, -12345);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c48203393038");
+        let value_decoded: DecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+    }
+
+    #[test]
+    fn test_unsigned_decimal_fraction() {
+        let value = UnsignedDecimalFraction::new(0, 0);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c4820000");
+        let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value = UnsignedDecimalFraction::new(3, 12345);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c48203193039");
+        let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value = UnsignedDecimalFraction::new(-3, 12345);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c48222193039");
+        let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value = UnsignedDecimalFraction::new(-3, u64::MAX);
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "c482221bffffffffffffffff");
+        let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
     }
 }


### PR DESCRIPTION
## Purpose

Use decimal fraction with `u64` mantissa to CBOR encode token amounts. This way, the type used for CBOR encoding can fully contain the token amount range

## Changes

Implemented decimal fraction with `u64` mantissa and changed `TokenAmount` to use this for CBOR encoding

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
