### PR TITLE
Small json serialization fix (COR 1536)

### DIFF
--- a/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
@@ -16,6 +16,7 @@ pub struct TokenModuleRejectReason {
     /// The unique symbol of the token, which produced this event.
     pub token_id:    TokenId,
     /// The type of the reject reason.
+    #[serde(rename = "type")]
     pub reason_type: TokenModuleCborTypeDiscriminator,
     /// (Optional) CBOR-encoded details.
     pub details:     Option<RawCbor>,


### PR DESCRIPTION
## Purpose

Related to:
https://github.com/Concordium/concordium-rust-sdk/pull/277

PLT transactions with reject reasons are not aligned in their JSON serialization. In case a user generated a plt transaction that rejects (unhappy path), this leads to that the historical transaction history cannot be parsed correctly in the `wallet-proxy` and cannot be displayed in the wallet for that user. Fix serializations issues in rejected plt transactions.

## Changes
