### PR TITLE
Add token-pause operation to plt.cddl

### DIFF
--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -201,7 +201,7 @@ token-module-state = {
     ; Whether the token is burnable.
     ? "burnable": bool,
     ; Whether the execution of certain token operations has been paused.
-    ? "paused": bool,
+    "paused": bool,
     ; Additional state information may be provided under further text keys, the meaning
     ; of which are not defined in the present specification.
     * text => any

--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -25,7 +25,7 @@ token-holder = tagged-holder-account
 ; https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-009-address.md
 tagged-holder-account = #6.40307(holder-account)
 
-holder-account = { 
+holder-account = {
     ; If the info (1) field is present, it must indicate CCD.
     ? 1: tagged-ccd-coininfo,
     ; We do not support the type (2) field.
@@ -37,10 +37,10 @@ holder-account = {
 ; https://github.com/BlockchainCommons/Research/blob/master/papers/bcr-2020-007-hdkey.md
 tagged-ccd-coininfo = #6.40305(ccd-coininfo)
 
-ccd-coininfo = { 
+ccd-coininfo = {
     ; The type (1) field is the [SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md)
     ; code for Concordium
-    1: 919 
+    1: 919
     ; The network (2) field is not supported.
 }
 
@@ -93,7 +93,7 @@ token-supply-update-details = {
 }
 
 ; Update an allow or a deny list by adding or removing an account from it.
-token-update-list = 
+token-update-list =
     token-add-allow-list
     / token-remove-allow-list
     / token-add-deny-list
@@ -129,12 +129,19 @@ token-list-update-details = {
     "target": token-holder
 }
 
+; Pause or unpause the execution of certain token operations. This includes
+; the operations "mint", "burn", and "transfer".
+token-pause = {
+    ; Whether to pause or unpause token operations.
+    "pause": bool
+}
+
 ; Chain governance
 
 ; These parameters are passed to the token module to initialize the token.
 ; The token initialization update will also include the ticker symbol,
 ; number of decimals, and a reference to the token module implementation.
-token-initialization-parameters = { 
+token-initialization-parameters = {
     ; The name of the token
     "name": text,
     ; A URL pointing to the token metadata
@@ -193,6 +200,8 @@ token-module-state = {
     ? "mintable": bool,
     ; Whether the token is burnable.
     ? "burnable": bool,
+    ; Whether the execution of certain token operations has been paused.
+    ? "paused": bool,
     ; Additional state information may be provided under further text keys, the meaning
     ; of which are not defined in the present specification.
     * text => any

--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -52,13 +52,14 @@ ccd-coininfo = {
 
 token-update-transaction = [ * token-operation ]
 
-; A token operation. This can be transfer, mint, burn or update-list-operation.
+; A token operation. This can be transfer, mint, burn, any update-list-operation, or pause.
 ; All token-holder operations are represented as single-entry maps where the key determines
 ; the type of the operation.
 token-operation = token-transfer
     / token-mint
     / token-burn
     / token-update-list
+    / token-pause
 
 ; A token transfer operation. This transfers a specified amount of tokens from the sender account
 ; (implicit) to the recipient account.

--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -253,6 +253,13 @@ token-add-deny-list-event = token-list-update-details
 ; This is a token kernel event, and indicates the account was removed from the deny list.
 token-remove-deny-list-event = token-list-update-details
 
+; The details of a token "pause" event, indicating whether the execution of the "mint", "burn",
+; and "transfer" token operations has been paused.
+token-pause-event = {
+    ; Whether the execution of token operations has been paused.
+    "paused": bool
+}
+
 ; Reject reason details
 
 ; A token-update-transaction may be rejected for various reasons.


### PR DESCRIPTION
Adds the `token-pause` along with a corresponding field on `token-module-state` operation to `plt.cddl`.

One important thing to note here, is that I did not include a reject reason specifically for this. My thought is that it would be fine to use the existing "reject-details-unsupported-operation" for this based on the assumption that it is not intended only for signalling operations being **permanently unsupported**.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
