### PR TITLE
Failure case for invalid token module ref

### DIFF
--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -53,7 +53,7 @@ ccd-coininfo = {
 token-update-transaction = [ * token-operation ]
 
 ; A token operation. This can be transfer, mint, burn or update-list-operation.
-; All token-holder operations are represented as single-entry maps where the key determines
+; All token operations are represented as single-entry maps where the key determines
 ; the type of the operation.
 token-operation = token-transfer
     / token-mint
@@ -229,19 +229,19 @@ token-module-account-state = {
 ; for protocol-level tokens are defined separately and are not subject to CBOR encoding.
 
 ; The details of a token "addAllowList" event.
-; This is a token kernel event, and indicates the account was added to the allow list.
+; This indicates the account was added to the allow list.
 token-add-allow-list-event = token-list-update-details
 
 ; The details of a token "removeAllowList" event.
-; This is a token kernel event, and indicates the account was removed from the allow list.
+; This indicates the account was removed from the allow list.
 token-remove-allow-list-event = token-list-update-details
 
 ; The details of a token "addDenyList" event.
-; This is a token kernel event, and indicates the account was added to the deny list.
+; This indicates the account was added to the deny list.
 token-add-deny-list-event = token-list-update-details
 
 ; The details of a token "removeDenyList" event.
-; This is a token kernel event, and indicates the account was removed from the deny list.
+; This indicates the account was removed from the deny list.
 token-remove-deny-list-event = token-list-update-details
 
 ; Reject reason details

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -3007,6 +3007,8 @@ data FailureKind
       DuplicateTokenId !TokenId
     | -- | The token module encountered an error when initializing the protocol-level token.
       TokenInitializeFailure !String
+    | -- | The token module reference is unknown or invalid.
+      InvalidTokenModuleRef !TokenModuleRef
     deriving (Eq, Show)
 
 data TxResult = TxValid !TransactionSummary | TxInvalid !FailureKind


### PR DESCRIPTION
## Purpose

Part of [COR-1553](https://linear.app/concordium/issue/COR-1553/require-tokenmoduleref-to-match-defined-value)

This introduces an failure case for an invalid token module reference when creating a PLT.

## Changes

- Add `FailureKind` `InvalidTokenModuleRef`
- (Incidental) clean up some wording in CDDL schema.


## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
