### PR TITLE
Revise token pause cddl types

### DIFF
--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -130,11 +130,16 @@ token-list-update-details = {
     "target": token-holder
 }
 
-; Pause or unpause the execution of certain token operations. This includes
+; Pause the execution of certain token operations. This (currently) includes
 ; the operations "mint", "burn", and "transfer".
 token-pause = {
-    ; Whether to pause or unpause token operations.
-    "pause": bool
+    "pause": {}
+}
+
+; Unpause the execution of certain token operations, acting as an inverse of `token-pause`.
+; This (currently) includes the operations "mint", "burn", and "transfer".
+token-unpause = {
+    "unpause": {}
 }
 
 ; Chain governance
@@ -174,6 +179,12 @@ metadata-url = {
     * text => any
 }
 
+; The pause state associated with the token. This is left open-ended for future extensibility.
+token-pause-state = {
+    ; Any fields used to describe the details of the pause operation
+    * text => any
+}
+
 ; Token state
 
 ; The Token Module state represents global state information that is maintained by the Token Module,
@@ -201,8 +212,8 @@ token-module-state = {
     ? "mintable": bool,
     ; Whether the token is burnable.
     ? "burnable": bool,
-    ; Whether the execution of certain token operations has been paused.
-    "paused": bool,
+    ; Describes whether the execution of certain token operations has been paused.
+    ? "paused": token-pause-state,
     ; Additional state information may be provided under further text keys, the meaning
     ; of which are not defined in the present specification.
     * text => any
@@ -254,12 +265,11 @@ token-add-deny-list-event = token-list-update-details
 ; This is a token kernel event, and indicates the account was removed from the deny list.
 token-remove-deny-list-event = token-list-update-details
 
-; The details of a token "pause" event, indicating whether the execution of the "mint", "burn",
-; and "transfer" token operations has been paused.
-token-pause-event = {
-    ; Whether the execution of token operations has been paused.
-    "paused": bool
-}
+; The details of a token "pause" event, indicating whether the execution token operations has been paused.
+token-pause-event = token-pause-state
+
+; The details of a token "unpause" event, indicating whether the execution token operations has been paused.
+token-unpause-event = token-pause-state
 
 ; Reject reason details
 

--- a/cbor-schema/plt.cddl
+++ b/cbor-schema/plt.cddl
@@ -130,14 +130,17 @@ token-list-update-details = {
     "target": token-holder
 }
 
-; Pause the execution of certain token operations. This (currently) includes
-; the operations "mint", "burn", and "transfer".
+; Suspend any current or future token operations involving
+; balance changes. If any transaction submitted includes any such operation
+; while the token is in its paused state, the transaction will fail. The
+; suspension lasts until the token is unpaused with the corresponding
+; `token-unpause` operation.
 token-pause = {
     "pause": {}
 }
 
-; Unpause the execution of certain token operations, acting as an inverse of `token-pause`.
-; This (currently) includes the operations "mint", "burn", and "transfer".
+; Unpause the token operations described in the `token-pause` operation,
+; thus acting as an inverse of `token-pause`.
 token-unpause = {
     "unpause": {}
 }
@@ -179,12 +182,6 @@ metadata-url = {
     * text => any
 }
 
-; The pause state associated with the token. This is left open-ended for future extensibility.
-token-pause-state = {
-    ; Any fields used to describe the details of the pause operation
-    * text => any
-}
-
 ; Token state
 
 ; The Token Module state represents global state information that is maintained by the Token Module,
@@ -212,8 +209,8 @@ token-module-state = {
     ? "mintable": bool,
     ; Whether the token is burnable.
     ? "burnable": bool,
-    ; Describes whether the execution of certain token operations has been paused.
-    ? "paused": token-pause-state,
+    ; Whether token operations involving balance changes has been suspended.
+    ? "paused": bool,
     ; Additional state information may be provided under further text keys, the meaning
     ; of which are not defined in the present specification.
     * text => any
@@ -265,11 +262,13 @@ token-add-deny-list-event = token-list-update-details
 ; This is a token kernel event, and indicates the account was removed from the deny list.
 token-remove-deny-list-event = token-list-update-details
 
-; The details of a token "pause" event, indicating whether the execution token operations has been paused.
-token-pause-event = token-pause-state
+; The details of a token "pause" event, indicating whether token operations involving balance
+; changes has been suspended.
+token-pause-event = {}
 
-; The details of a token "unpause" event, indicating whether the execution token operations has been paused.
-token-unpause-event = token-pause-state
+; The details of a token "unpause" event, indicating whether the suspension of token operations
+; involving balance changes has been removed.
+token-unpause-event = {}
 
 ; Reject reason details
 


### PR DESCRIPTION
## Purpose

A revised token-pause type declaration based on https://github.com/Concordium/concordium-base/pull/692#pullrequestreview-2983765665

## Changes

- Changes token-(un)pause to be separate operations
- Allows for future extensibility in the associated token module state
- Allows for future extensibility in associated token-(un)pause events.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.