### PR TITLE
Bump GHC version to 9.8.4 (lts-23.27).

### DIFF
--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -143,7 +143,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - ghc: 9.6.6 # used as cache key only; stack uses the one specified in stack.yaml
+        - ghc: 9.8.4 # used as cache key only; stack uses the one specified in stack.yaml
           rust: 1.82
 
     steps:

--- a/.github/workflows/release-identity-provider-service.yaml
+++ b/.github/workflows/release-identity-provider-service.yaml
@@ -9,7 +9,7 @@ jobs:
     with:
       SERVICE_NAME: "identity-provider-service"
       BUILD_ARGS: |
-        base_image_tag=rust-1.82_ghc-9.6.6-2
+        base_image_tag=rust-1.82_ghc-9.8.4
       DOCKER_FILE_PATH: scripts/identity-provider-service.Dockerfile
       CARGO_FILE_PATH: identity-provider-service/Cargo.toml
     secrets: inherit

--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -138,6 +138,7 @@ library
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -201,6 +202,7 @@ executable generate-update-keys
       QuickCheck >=2.12
     , aeson >=1.4.2
     , aeson-pretty >=0.8
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -262,6 +264,7 @@ executable genesis
       QuickCheck >=2.12
     , aeson >=1.4.2
     , aeson-pretty >=0.8
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -354,6 +357,7 @@ test-suite test
       HUnit >=1.6
     , QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -416,6 +420,7 @@ benchmark bls-perf
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -475,6 +480,7 @@ benchmark ed25519-perf
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -534,6 +540,7 @@ benchmark ed25519dlog-perf
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -593,6 +600,7 @@ benchmark sha256-perf
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0
@@ -652,6 +660,7 @@ benchmark verify-credential-perf
   build-depends:
       QuickCheck >=2.12
     , aeson >=1.4.2
+    , attoparsec-aeson
     , base >=4.7 && <5
     , base16-bytestring >=0.1.1.6
     , base64-bytestring >=1.1.0.0

--- a/haskell-src/Concordium/Common/Amount.hs
+++ b/haskell-src/Concordium/Common/Amount.hs
@@ -41,7 +41,7 @@ instance HashableTo Hash.Hash Amount where
 
 instance (Monad m) => MHashableTo m Hash.Hash Amount
 
--- | Converts an amount to GTU decimal representation.
+-- | Converts an amount to CCD decimal representation.
 amountToString :: Amount -> String
 amountToString (Amount amount) =
     let
@@ -51,12 +51,12 @@ amountToString (Amount amount) =
     in
         high ++ "." ++ pad ++ low
 
--- | Parse an amount from GTU decimal representation.
+-- | Parse an amount from CCD decimal representation.
 amountFromString :: String -> Maybe Amount
-amountFromString s =
-    if length s == 0 || length parsed /= 1
-        then Nothing
-        else Just $ Amount (fst (head parsed))
+amountFromString "" = Nothing
+amountFromString s = case parsed of
+    [(amount, _)] -> Just $ Amount amount
+    _ -> Nothing
   where
     parsed = RP.readP_to_S amountParser s
 

--- a/haskell-src/Concordium/Types/Accounts.hs
+++ b/haskell-src/Concordium/Types/Accounts.hs
@@ -187,7 +187,7 @@ instance Serialize BakerPoolInfo where
 makeClassy ''BakerPoolInfo
 
 -- | Helper function for defining 'ToJSON'.
-bakerPoolInfoV1Pairs :: (KeyValue kv) => BakerPoolInfo -> [kv]
+bakerPoolInfoV1Pairs :: (KeyValue e kv) => BakerPoolInfo -> [kv]
 bakerPoolInfoV1Pairs BakerPoolInfo{..} =
     [ "openStatus" .= _poolOpenStatus,
       "metadataUrl" .= _poolMetadataUrl,
@@ -683,7 +683,7 @@ toAccountStakingInfoP4 =
     toAccountStakingInfo
         (error "Epoch conversion is not used for account staking info in this protocol version")
 
-pendingChangeToJSON :: (KeyValue kv) => StakePendingChange' UTCTime -> [kv]
+pendingChangeToJSON :: (KeyValue e kv) => StakePendingChange' UTCTime -> [kv]
 pendingChangeToJSON NoChange = []
 pendingChangeToJSON (ReduceStake amt eff) =
     [ "pendingChange"
@@ -696,7 +696,7 @@ pendingChangeToJSON (RemoveStake eff) =
             ["change" .= String "RemoveStake", "effectiveTime" .= eff]
     ]
 
-accountStakingInfoToJSON :: (KeyValue kv) => AccountStakingInfo -> [kv]
+accountStakingInfoToJSON :: (KeyValue e kv) => AccountStakingInfo -> [kv]
 accountStakingInfoToJSON AccountStakingNone = []
 accountStakingInfoToJSON AccountStakingBaker{..} = ["accountBaker" .= bi]
   where
@@ -803,7 +803,7 @@ data AccountInfo = AccountInfo
     deriving (Eq, Show)
 
 -- | Helper function for 'ToJSON' instance for 'AccountInfo'.
-accountInfoPairs :: (KeyValue kv) => AccountInfo -> [kv]
+accountInfoPairs :: (KeyValue e kv) => AccountInfo -> [kv]
 {-# INLINE accountInfoPairs #-}
 accountInfoPairs AccountInfo{..} =
     [ "accountNonce" .= aiAccountNonce,

--- a/haskell-src/Concordium/Utils/Encryption.hs
+++ b/haskell-src/Concordium/Utils/Encryption.hs
@@ -12,6 +12,7 @@ import Control.Monad.Except
 import Data.Aeson ((.:), (.=))
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as AEMap
+
 import qualified Data.Aeson.Parser as AE
 import qualified Data.Aeson.Types as AE
 import Data.ByteString (ByteString)

--- a/haskell-src/Concordium/Wasm.hs
+++ b/haskell-src/Concordium/Wasm.hs
@@ -906,7 +906,7 @@ data InstanceInfo
     deriving (Eq, Show)
 
 -- | Helper function for JSON encoding an 'InstanceInfo'.
-instancePairs :: (AE.KeyValue kv) => InstanceInfo -> [kv]
+instancePairs :: (AE.KeyValue e kv) => InstanceInfo -> [kv]
 {-# INLINE instancePairs #-}
 instancePairs InstanceInfoV0{..} =
     [ "model" AE..= iiModel,

--- a/haskell-tests/Types/AddressesSpec.hs
+++ b/haskell-tests/Types/AddressesSpec.hs
@@ -26,7 +26,7 @@ genCorrupt :: AccountAddress -> Gen AccountAddress
 genCorrupt (AccountAddress addr) = do
     place <- choose (0, 31)
     let res = splitAt place (FBS.unpack addr) -- since we split at most at 31 there is at least one element of the tail
-    let (start, rest) = (fst res, tail $ snd res)
+    let (start, rest) = (fst res, drop 1 $ snd res)
     new <- arbitrary
     return $ AccountAddress . FBS.pack $ (start ++ new : rest)
 

--- a/haskell-tests/Types/PayloadSerializationSpec.hs
+++ b/haskell-tests/Types/PayloadSerializationSpec.hs
@@ -144,8 +144,9 @@ genInvalidPayloadConfigureBaker pv =
         return $
             modifyPayloadBitmap (if doSetSuspendBit then setSuspendBit else id) $
                 S.runPut $
-                    putPayload $
-                        p{cbSuspend = Just b}
+                    putPayload $ case p of
+                        ConfigureBaker{} -> p{cbSuspend = Just b}
+                        _ -> p -- This cannot happen.
     suspendBitmask = Bit.shiftL 1 9
     setSuspendBit bm = suspendBitmask Bit..|. bm
 

--- a/package.yaml
+++ b/package.yaml
@@ -50,6 +50,7 @@ flags:
 
 dependencies:
 - aeson >= 1.4.2
+- attoparsec-aeson
 - base >= 4.7 && < 5
 - base16-bytestring >= 0.1.1.6
 - base64-bytestring >= 1.1.0.0

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
 #
-resolver: lts-22.39
+resolver: lts-23.27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.
@@ -42,13 +42,13 @@ extra-lib-dirs:
     - ./lib/
 
 extra-deps:
-  - proto-lens-setup-0.4.0.7@sha256:acca0b04e033ea0a017f809d91a7dbc942e025ec6bc275fa21647352722c74cc,3122
-  - proto-lens-protoc-0.8.0.0@sha256:a146ee8c9af9e445ab05651e688deb0ff849357d320657d6cea5be33cb54b960,2235
-  - ghc-source-gen-0.4.4.0@sha256:8499f23c5989c295f3b002ad92784ca5fed5260fd4891dc816f17d30c5ba9cd9,4236
-  # Cabal-3.10.3.0 (from the lts-22.39 snapshot) breaks linking on Windows, but this should be
-  # fixed in newer versions.  This should be removed once we update to an lts that uses a new
-  # enough version of Cabal.
-  - Cabal-3.10.1.0
+# lts-23.27 uses Cabal-3.10.3.0, which includes a fix (https://github.com/haskell/cabal/pull/9554)
+# that unfortunately breaks linking on Windows by adding -rpath linker flags. It appears this
+# is fixed as of Cabal-3.12.1.0 (and maybe 3.12.0.0), and this seems to be compatible with our
+# other dependencies, so we use it. Once we update to an lts that uses a new enough version of
+# Cabal, we should remove this dependency (which shadows the one from the snapshot).
+- Cabal-3.12.1.0
+- Cabal-syntax-3.12.1.0
 
 # Override default flag values for local packages and extra-deps
 # flags: {}


### PR DESCRIPTION
## Purpose

Part of [COR-1558](https://linear.app/concordium/issue/COR-1558/upgrade-haskell-ghc-to-=-967)

Bump GHC version to 9.8.4 (lts-23.27).

## Changes

- Bump the LTS version
- Bump the GHC version
- Remove some pinned dependencies that are now available in the LTS snapshot
- Bump the version of the Cabal library used for compatibility
- Minor fixes

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [X] (If necessary) I have updated the CHANGELOG.
