### PR TITLE
Ar/cor 1678 cbor decoding fails on empty string rust

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added PLT `TokenModuleInitializationParameters` CBOR type
 - Support empty structs with `CborSerialize` derive macro
 - Support CBOR decoding maps and arrays of indefinite length
+- Fix bug where CBOR decoding would fail on empty text strings
 
 ## 8.0.0-alpha.2 (2025-07-14)
 

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -952,7 +952,7 @@ mod test {
     }
 
     #[test]
-    fn test_struct_as_map_empty() {
+    fn test_struct_as_map_derived_empty() {
         #[derive(Debug, Eq, PartialEq, CborSerialize, CborDeserialize)]
         struct TestStruct {}
 
@@ -973,6 +973,19 @@ mod test {
 
         let cbor = cbor_encode(&value).unwrap();
         assert_eq!(hex::encode(&cbor), "82036461626364");
+        let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+    }
+
+    #[test]
+    fn test_struct_as_array_derived_empty() {
+        #[derive(Debug, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct TestStruct();
+
+        let value = TestStruct();
+
+        let cbor = cbor_encode(&value).unwrap();
+        assert_eq!(hex::encode(&cbor), "80");
         let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
     }
@@ -1283,6 +1296,16 @@ mod test {
     }
 
     #[test]
+    fn test_vec_empty() {
+        let vec: Vec<u64> = vec![];
+
+        let cbor = cbor_encode(&vec).unwrap();
+        assert_eq!(hex::encode(&cbor), "80");
+        let bytes_decoded: Vec<u64> = cbor_decode(&cbor).unwrap();
+        assert_eq!(bytes_decoded, vec);
+    }
+
+    #[test]
     fn test_vec_indefinite_length() {
         let vec = vec![1, 2];
 
@@ -1297,6 +1320,16 @@ mod test {
 
         let cbor = cbor_encode(&map).unwrap();
         assert_eq!(hex::encode(&cbor), "a201020304");
+        let bytes_decoded: HashMap<u64, u64> = cbor_decode(&cbor).unwrap();
+        assert_eq!(bytes_decoded, map);
+    }
+
+    #[test]
+    fn test_map_empty() {
+        let map: HashMap<u64, u64> = [].into_iter().collect();
+
+        let cbor = cbor_encode(&map).unwrap();
+        assert_eq!(hex::encode(&cbor), "a0");
         let bytes_decoded: HashMap<u64, u64> = cbor_decode(&cbor).unwrap();
         assert_eq!(bytes_decoded, map);
     }

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -2,7 +2,7 @@ use crate::common::cbor::{
     CborArrayDecoder, CborDecoder, CborDeserialize, CborMapDecoder, CborSerializationError,
     CborSerializationResult, DataItemHeader, DataItemType, SerializationOptions,
 };
-use anyhow::{anyhow, Context};
+use anyhow::anyhow;
 use ciborium_ll::Header;
 use std::{fmt::Display, io::Read};
 

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -237,7 +237,7 @@ impl<R: Read> Decoder<R> {
             return Err(anyhow!("must have at least one segment").into());
         };
 
-        segment.pull(dest)?.context("no data in segment")?;
+        segment.pull(dest)?;
         if segment.left() != 0 {
             return Err(anyhow!("remaining data in segment").into());
         }

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -414,6 +414,16 @@ mod test {
     }
 
     #[test]
+    fn test_bytes_empty() {
+        let bytes = Bytes(vec![]);
+
+        let cbor = cbor_encode(&bytes).unwrap();
+        assert_eq!(hex::encode(&cbor), "40");
+        let bytes_decoded: Bytes = cbor_decode(&cbor).unwrap();
+        assert_eq!(bytes_decoded, bytes);
+    }
+
+    #[test]
     fn test_bytes_exact_length() {
         let bytes: [u8; 5] = [1, 2, 3, 4, 5];
 
@@ -443,6 +453,16 @@ mod test {
 
         let cbor = cbor_encode(&text).unwrap();
         assert_eq!(hex::encode(&cbor), "6461626364");
+        let text_decoded: String = cbor_decode(&cbor).unwrap();
+        assert_eq!(text_decoded, text);
+    }
+
+    #[test]
+    fn test_text_empty() {
+        let text = "";
+
+        let cbor = cbor_encode(&text).unwrap();
+        assert_eq!(hex::encode(&cbor), "60");
         let text_decoded: String = cbor_decode(&cbor).unwrap();
         assert_eq!(text_decoded, text);
     }


### PR DESCRIPTION
## Purpose

Fix CBOR decoding empty string

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
