### PR TITLE
Add function for decoding the token module reject reason details

### DIFF
--- a/haskell-src/Concordium/Types.hs
+++ b/haskell-src/Concordium/Types.hs
@@ -192,6 +192,7 @@ module Concordium.Types (
     makeTokenEventType,
     TokenModuleRejectReason (..),
     makeTokenModuleRejectReason,
+    decodeTokenModuleRejectReason,
     CreatePLT (..),
     cpltTokenId,
     cpltTokenModule,
@@ -1237,6 +1238,15 @@ makeTokenModuleRejectReason tmrrTokenId CBOR.EncodedTokenRejectReason{..} =
           tmrrDetails = TokenEventDetails <$> etrrDetails,
           ..
         }
+
+-- | Decode a 'TokenRejectReason' from an 'TokenModuleRejectReason'.
+decodeTokenModuleRejectReason :: TokenModuleRejectReason -> Either String CBOR.TokenRejectReason
+decodeTokenModuleRejectReason moduleReason =
+    CBOR.decodeTokenRejectReason
+        CBOR.EncodedTokenRejectReason
+            { etrrType = tokenEventTypeBytes $ tmrrType moduleReason,
+              etrrDetails = tokenEventDetailsBytes <$> tmrrDetails moduleReason
+            }
 
 -- | A wrapper type for (de)-serializing a CBOR-encoded initialization parameter to/from JSON.
 --  This can parse either a JSON object representation of 'TokenInitializationParameters'

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1542,7 +1542,7 @@ decodeTokenRejectReasonDetails "operationNotPermitted" =
 decodeTokenRejectReasonDetails unknownType =
     fail $ "token-reject-reason: unsupported reject reason: " ++ show unknownType
 
---  | Decode a 'TokenRejectReason' from an 'EncodedTokenRejectReason'.
+-- | Decode a 'TokenRejectReason' from an 'EncodedTokenRejectReason'.
 decodeTokenRejectReason :: EncodedTokenRejectReason -> Either String TokenRejectReason
 decodeTokenRejectReason EncodedTokenRejectReason{..} = case etrrDetails of
     Nothing ->


### PR DESCRIPTION
## Purpose

https://linear.app/concordium/issue/COR-1384/improve-cbor-decoding-of-plt-events
concordium-client PR: https://github.com/Concordium/concordium-client/pull/395

## Changes

Add function for decoding reject reason details fro mthe token module reject reason.
