### PR TITLE
fix: update cbor and token amount to Derive hash

### DIFF
--- a/rust-src/concordium_base/src/protocol_level_tokens/cbor.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/cbor.rs
@@ -4,7 +4,7 @@ use crate::common;
 ///
 /// Note: There are no checks for whether the bytes represent a valid CBOR
 /// encoding.
-#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq)]
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize, PartialEq, Eq, Hash)]
 #[serde(try_from = "String", into = "String")]
 #[repr(transparent)]
 pub struct RawCbor {

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_amount.rs
@@ -21,7 +21,7 @@ use std::str::FromStr;
 /// make `TokenAmount` self-contained with regard to the numerical value
 /// represented. This enables additional validation, both programmatic and at
 /// user level.
-#[derive(Debug, Clone, Copy, Eq, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, serde::Deserialize, serde::Serialize)]
 #[serde(try_from = "TokenAmountJson", into = "TokenAmountJson")]
 pub struct TokenAmount {
     /// The amount of tokens as an unscaled integer value.


### PR DESCRIPTION
## Purpose

Derive hash for CBOR and token amount

## Changes

Add derive hash to both CBOR and token amount

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

