### PR TITLE
COR-1665 Token client validate transfer test

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Support empty structs with `CborSerialize` derive macro
 - Support CBOR decoding maps and arrays of indefinite length
 - Fix bug where CBOR decoding would fail on empty text strings
+- Adding Clone derive for `AccountCredentialWithoutProofs`.
 
 ## 8.0.0-alpha.2 (2025-07-14)
 

--- a/rust-src/concordium_base/src/id/types.rs
+++ b/rust-src/concordium_base/src/id/types.rs
@@ -1691,7 +1691,7 @@ pub enum CredentialType {
 /// Account credential with values and commitments, but without proofs.
 /// Serialization must match the serializaiton of `AccountCredential` in
 /// Haskell.
-#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Eq)]
+#[derive(SerdeSerialize, SerdeDeserialize, Debug, PartialEq, Eq, Clone)]
 #[serde(tag = "type", content = "contents")]
 #[serde(bound(
     serialize = "C: Curve, AttributeType: Attribute<C::Scalar> + SerdeSerialize",


### PR DESCRIPTION
## Purpose

Adding `#[derive(Clone)]` for `AccountCredentialWithoutProofs` for the unit tests of the `TokenClient's`  `validate_transfer` method.

## Changes

- Added `#[derive(Clone)]` for `AccountCredentialWithoutProofs`

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance
By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
