### PR TITLE
Ar/cor 1647 support cbor bignums rust

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Support empty structs with `CborSerialize` derive macro
 - Support CBOR decoding maps and arrays of indefinite length
 - Fix bug where CBOR decoding would fail on empty text strings
+- Support decoding unsigned and negative CBOR bignums to fixed-size machine integers (`i8`, ..., `i64`, `u8`, ..., `u64`)
 
 ## 8.0.0-alpha.2 (2025-07-14)
 

--- a/rust-src/concordium_base/src/common/cbor/composites.rs
+++ b/rust-src/concordium_base/src/common/cbor/composites.rs
@@ -83,4 +83,13 @@ mod test {
         let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
     }
+
+    /// Tests decoding tag 2 bignums into decimal fraction
+    #[test]
+    fn test_unsigned_decimal_fraction_bignum() {
+        let cbor = hex::decode("c48203C24105").unwrap();
+        let value_decoded: UnsignedDecimalFraction = cbor_decode(&cbor).unwrap();
+        let expected_value = UnsignedDecimalFraction::new(3, 5);
+        assert_eq!(value_decoded, expected_value);
+    }
 }

--- a/rust-src/concordium_base/src/common/cbor/contracts_common_types.rs
+++ b/rust-src/concordium_base/src/common/cbor/contracts_common_types.rs
@@ -1,7 +1,7 @@
 use crate::common::cbor::{
     CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize,
 };
-use concordium_contracts_common::AccountAddress;
+use concordium_contracts_common::{constants::SHA256, hashes::Hash, AccountAddress};
 
 impl CborSerialize for AccountAddress {
     fn serialize<C: CborEncoder>(&self, encoder: C) -> CborSerializationResult<()> {
@@ -14,5 +14,20 @@ impl CborDeserialize for AccountAddress {
     where
         Self: Sized, {
         Ok(Self(CborDeserialize::deserialize(decoder)?))
+    }
+}
+
+impl CborSerialize for Hash {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> CborSerializationResult<()> {
+        self.as_ref().serialize(encoder)
+    }
+}
+
+impl CborDeserialize for Hash {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized, {
+        let bytes = <[u8; SHA256]>::deserialize(decoder)?;
+        Ok(Hash::from(bytes))
     }
 }

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -480,7 +480,6 @@ mod test {
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
-    // assert_eq!(hex::encode(&bytes), "");
     /// Test skipping data items during decode
     #[test]
     fn test_skip_data_item() {

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -342,7 +342,7 @@ fn decode_ne_bytes_to_u64(bytes: &[u8]) -> CborSerializationResult<u64> {
 
     let bytes_in_range = &bytes[bytes.len() - bytes.len().min(8)..];
     let mut u64bytes = [0u8; 8];
-    u64bytes[8 - bytes_in_range.len()..].copy_from_slice(&bytes_in_range);
+    u64bytes[8 - bytes_in_range.len()..].copy_from_slice(bytes_in_range);
 
     Ok(u64::from_be_bytes(u64bytes))
 }

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -430,6 +430,7 @@ mod test {
         let value_decoded: u64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0x01000000000000001);
 
+        // test max value
         let cbor = hex::decode("C248FFFFFFFFFFFFFFFF").unwrap();
         let value_decoded: u64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0xFFFFFFFFFFFFFFFF);
@@ -464,6 +465,7 @@ mod test {
         let value_decoded: u8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0x01);
 
+        // test max value
         let cbor = hex::decode("C241FF").unwrap();
         let value_decoded: u8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0xFF);
@@ -599,10 +601,12 @@ mod test {
         let value_decoded: i64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, -0x02);
 
+        // max value
         let cbor = hex::decode("C2487FFFFFFFFFFFFFFF").unwrap();
         let value_decoded: i64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0x7FFFFFFFFFFFFFFF);
 
+        // min value
         let cbor = hex::decode("C3487FFFFFFFFFFFFFFF").unwrap();
         let value_decoded: i64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, -0x8000000000000000);
@@ -641,10 +645,12 @@ mod test {
         let value_decoded: i8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, -0x01);
 
+        // max value
         let cbor = hex::decode("C2417F").unwrap();
         let value_decoded: i8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0x7F);
 
+        // min value
         let cbor = hex::decode("C3417F").unwrap();
         let value_decoded: i8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, -0x80);

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -400,7 +400,7 @@ mod test {
         assert_eq!(value_decoded, value);
     }
 
-    /// Tests decoding tag 2 bignums into https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+    /// Tests decoding tag 2 bignums into u64
     #[test]
     fn test_u64_bignum() {
         let cbor = hex::decode("C240").unwrap();
@@ -454,7 +454,7 @@ mod test {
         );
     }
 
-    /// Tests decoding tag 2 bignums into https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+    /// Tests decoding tag 2 bignums into u8
     #[test]
     fn test_u8_bignum() {
         let cbor = hex::decode("C24100").unwrap();
@@ -582,7 +582,7 @@ mod test {
         assert_eq!(value_decoded, value);
     }
 
-    /// Tests decoding tag 2 bignums into https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+    /// Tests decoding tag 2 and 3 bignums into i64
     #[test]
     fn test_i64_bignum() {
         let cbor = hex::decode("C240").unwrap();
@@ -630,7 +630,7 @@ mod test {
         );
     }
 
-    /// Tests decoding tag 2 bignums into https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml
+    /// Tests decoding tag 2 and 3 bignums into i8
     #[test]
     fn test_i8_bignum() {
         let cbor = hex::decode("C24100").unwrap();

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -102,10 +102,10 @@ macro_rules! serialize_deserialize_unsigned_integer {
                     }
                     DataItemHeader::Positive(_) => decoder.decode_positive()?,
                     header => {
-                        return Err(anyhow!(format!(
+                        return Err(anyhow!(
                             "data item {:?} cannot be decoded to positive integer",
                             header.to_type()
-                        ))
+                        )
                         .into())
                     }
                 };
@@ -148,17 +148,17 @@ macro_rules! serialize_deserialize_signed_integer {
             fn deserialize<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self>
             where
                 Self: Sized, {
-                let convert_positive = |value: u64| -> anyhow::Result<$t> {
+                fn convert_positive(value: u64) -> anyhow::Result<$t> {
                     <$t>::try_from(value).context(concat!("convert positive to ", stringify!($t)))
-                };
+                }
 
-                let convert_negative = |value: u64| -> anyhow::Result<$t> {
+                fn convert_negative(value: u64) -> anyhow::Result<$t> {
                     <$t>::try_from(value)
                         .ok()
                         .and_then(|val| val.checked_neg())
                         .and_then(|val| val.checked_sub(1))
                         .context(concat!("convert negative to ", stringify!($t)))
-                };
+                }
 
                 match decoder.peek_data_item_header()? {
                     DataItemHeader::Positive(_) => {
@@ -176,10 +176,10 @@ macro_rules! serialize_deserialize_signed_integer {
                         Ok(convert_negative(decode_negative_bignum_to_u64(decoder)?)?)
                     }
                     header => {
-                        return Err(anyhow!(format!(
+                        return Err(anyhow!(
                             "data item {:?} cannot be decoded to positive or negative integer",
                             header.to_type()
-                        ))
+                        )
                         .into())
                     }
                 }

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -425,9 +425,23 @@ mod test {
         let value_decoded: u64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0x01);
 
+        // if we are within range, it is ok that the bignum is more than 8 bytes
+        let cbor = hex::decode("C24A00001000000000000001").unwrap();
+        let value_decoded: u64 = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, 0x01000000000000001);
+
         let cbor = hex::decode("C248FFFFFFFFFFFFFFFF").unwrap();
         let value_decoded: u64 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, 0xFFFFFFFFFFFFFFFF);
+
+        // value outside range
+        let cbor = hex::decode("C249FF0000000000000000").unwrap();
+        let error = cbor_decode::<u64>(&cbor).unwrap_err();
+        assert!(
+            error.to_string().contains("bignum out of u64 range"),
+            "message: {}",
+            error
+        );
 
         // value outside range
         let cbor = hex::decode("C24AFF000000000000000000").unwrap();


### PR DESCRIPTION
## Purpose

Support decoding CBOR bignums into decimal fractions when the value is within the supported range of the type. It is required since our PLT CBOR specification allows bignums and so does the node.

## Changes

Implemented decoding to the primitive integers, which decimal faction, among others, is composed of.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
