### PR TITLE
Use Upward construct in Rust CBOR

### DIFF
--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -61,10 +61,20 @@
 //! }
 //! ```
 //!
-//! Each varaint is serialized prefixed with the declared tag (except for the
+//! Each variant is serialized prefixed with the declared tag (except for the
 //! untagged variant).
 //!
 //! All enum variants must be single element tuples.
+//!
+//! ### `CborUpward` type
+//!
+//! In the enum examples above, the type `CborUpward<TestEnum>` will implement
+//! `CborSerialize` and `CborDeserialize`. Wrapping enums in the `CborUpward` types will deserialize known variants to
+//! `CborUpward::Known` and unknown variants to `CborUpward::Unknown`. In the case of deserializing an unknown variant in the map representation,
+//! the value in `CborUpward::Unknown` will be a [`Value::Map`](value::Value::Map) with a single entry. In the case of the tagged representation, the value
+//! in `CborUpward::Unknown` will be a [`Value::Tag`](value::Value::Tag) including the tagged value.
+//! In any case, deserializing to `CborUpward<TestEnum>` and serializing again, will be the identity operation, no
+//! matter if the variant is known or not.
 //!
 //! ### Supported attributes
 //!

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -237,7 +237,7 @@ pub mod __private {
 
     // Types used by macros
     use super::*;
-    /// Like `CborMaybeKnown` by allows specifying residual type
+    /// Like `CborMaybeKnown` but allows specifying residual type
     pub enum MaybeKnown<A, R> {
         Known(A),
         Unknown(R),

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -1420,7 +1420,7 @@ mod test {
 
         let value = CborUpward::Known(TestEnum::Var1(3));
         let cbor = cbor_encode(&value).unwrap();
-        assert_eq!(hex::encode(&cbor), "a1647661723103");
+        assert_eq!(hex::encode(&cbor), "d99c3703");
         let value_decoded: CborUpward<TestEnum> = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
     }

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -233,10 +233,10 @@ use std::{
 #[doc(hidden)]
 pub mod __private {
     // Reexports
-    use crate::common::cbor::{value, CborMaybeKnown};
     pub use anyhow;
 
     // Types used by macros
+    use super::*;
     /// Like `CborMaybeKnown` by allows specifying residual type
     pub enum MaybeKnown<A, R> {
         Known(A),

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -254,6 +254,18 @@ impl<A, R> Upward<A, R> {
             Upward::Known(output) => Ok(output),
         }
     }
+
+    /// Maps an `Upward<A, R>` to `Upward<A, S>` by applying a function to
+    /// the residual value in `Unknown`.
+    pub fn map_unknown<S, F>(self, f: F) -> Upward<A, S>
+    where
+        F: FnOnce(R) -> S,
+    {
+        match self {
+            Self::Known(x) => Upward::Known(x),
+            Self::Unknown(r) => Upward::Unknown(f(r)),
+        }
+    }
 }
 
 pub type CborUpward<A> = Upward<A, value::Value>;

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -825,7 +825,7 @@ mod test {
     /// Test `<Cursor<&mut Vec<u8>> as CursorExt>::advance` for empty `Vec`
     #[test]
     fn test_vec_cursor_advance_empty() {
-        /// Test empty vec
+        // Test empty vec
         let mut vec = Vec::new();
         let mut cursor = Cursor::new(&mut vec);
 
@@ -855,7 +855,7 @@ mod test {
     /// existing content
     #[test]
     fn test_vec_cursor_advance_non_empty() {
-        /// Test empty vec
+        // Test empty vec
         let mut vec = vec![11, 12, 13];
         let mut cursor = Cursor::new(&mut vec);
 

--- a/rust-src/concordium_base/src/common/mod.rs
+++ b/rust-src/concordium_base/src/common/mod.rs
@@ -47,3 +47,4 @@ pub type size_t = usize;
 /// Module that provides a simple API for symmetric encryption in the output
 /// formats used by Concordium.
 pub mod encryption;
+pub mod upward;

--- a/rust-src/concordium_base/src/common/upward.rs
+++ b/rust-src/concordium_base/src/common/upward.rs
@@ -3,6 +3,7 @@ use crate::common::cbor::{
     CborSerialize,
 };
 
+/// Type for forward-compatibility with the Concordium Node API.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Upward<A, R = ()> {
     /// New unknown variant, the structure is not known to the current version
@@ -36,6 +37,8 @@ impl<A, R> Upward<A, R> {
     }
 }
 
+/// Special case where the residual type is a CBOR value, so that CBOR can be deserialized
+/// to an unknown variant in the case that the library version is behind.
 pub type CborUpward<A> = Upward<A, value::Value>;
 
 impl<T: CborSerialize> CborSerialize for CborUpward<T> {

--- a/rust-src/concordium_base/src/common/upward.rs
+++ b/rust-src/concordium_base/src/common/upward.rs
@@ -1,0 +1,60 @@
+use crate::common::cbor::{
+    value, CborDecoder, CborDeserialize, CborEncoder, CborMaybeKnown, CborSerializationResult,
+    CborSerialize,
+};
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum Upward<A, R = ()> {
+    /// New unknown variant, the structure is not known to the current version
+    /// of this library. Consider updating the library if support is needed.
+    Unknown(R),
+    /// Known variant.
+    Known(A),
+}
+
+impl<A, R> Upward<A, R> {
+    pub fn known_or_else<E, F>(self, error: F) -> Result<A, E>
+    where
+        F: FnOnce(R) -> E,
+    {
+        match self {
+            Upward::Unknown(residual) => Err(error(residual)),
+            Upward::Known(output) => Ok(output),
+        }
+    }
+
+    /// Maps an `Upward<A, R>` to `Upward<A, S>` by applying a function to
+    /// the residual value in `Unknown`.
+    pub fn map_unknown<S, F>(self, f: F) -> Upward<A, S>
+    where
+        F: FnOnce(R) -> S,
+    {
+        match self {
+            Self::Known(x) => Upward::Known(x),
+            Self::Unknown(r) => Upward::Unknown(f(r)),
+        }
+    }
+}
+
+pub type CborUpward<A> = Upward<A, value::Value>;
+
+impl<T: CborSerialize> CborSerialize for CborUpward<T> {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> CborSerializationResult<()> {
+        match self {
+            Self::Unknown(value) => value.serialize(encoder),
+            Self::Known(value) => value.serialize(encoder),
+        }
+    }
+}
+
+impl<T: CborDeserialize> CborDeserialize for CborUpward<T> {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Ok(match T::deserialize_maybe_known(decoder)? {
+            CborMaybeKnown::Unknown(r) => Self::Unknown(r),
+            CborMaybeKnown::Known(val) => Self::Known(val),
+        })
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -1,11 +1,11 @@
+use super::{cbor::RawCbor, CborHolderAccount, TokenAmount, TokenId};
+use crate::common::upward::{CborUpward, Upward};
 use crate::{
-    common::cbor::{self, CborSerializationResult, CborUpward, Upward},
+    common::cbor::{self, CborSerializationResult},
     transactions::Memo,
 };
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 use concordium_contracts_common::AccountAddress;
-
-use super::{cbor::RawCbor, CborHolderAccount, TokenAmount, TokenId};
 
 /// An event produced from the effect of a token transaction.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::cbor::{self, value, CborSerializationResult},
+    common::cbor::{self, value, CborSerializationResult, CborUpward},
     protocol_level_tokens::{CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId},
     transactions::Memo,
 };
@@ -135,11 +135,11 @@ impl TokenOperationsPayload {
 #[cbor(transparent)]
 pub struct TokenOperations {
     /// List of protocol level token operations
-    pub operations: Vec<TokenOperation>,
+    pub operations: Vec<CborUpward<TokenOperation>>,
 }
 
-impl FromIterator<TokenOperation> for TokenOperations {
-    fn from_iter<T: IntoIterator<Item = TokenOperation>>(iter: T) -> Self {
+impl FromIterator<CborUpward<TokenOperation>> for TokenOperations {
+    fn from_iter<T: IntoIterator<Item = CborUpward<TokenOperation>>>(iter: T) -> Self {
         Self {
             operations: iter.into_iter().collect(),
         }
@@ -147,7 +147,7 @@ impl FromIterator<TokenOperation> for TokenOperations {
 }
 
 impl TokenOperations {
-    pub fn new(operations: Vec<TokenOperation>) -> Self {
+    pub fn new(operations: Vec<CborUpward<TokenOperation>>) -> Self {
         Self { operations }
     }
 }
@@ -182,11 +182,7 @@ pub enum TokenOperation {
     Pause(TokenPauseDetails),
     /// Operation that unpauses execution of any balance changing operations for
     /// a protocol level token
-    Unpause(TokenPauseDetails),
-    /// Unknow operation. If new types of operations are added that are unknown
-    /// to this enum, they will be decoded to this variant.
-    #[cbor(other)]
-    Unknown(String, value::Value),
+    Unpause(TokenPauseDetails)
 }
 
 /// Details of an operation that changes a protocol level token supply.

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -139,10 +139,10 @@ pub struct TokenOperations {
     pub operations: Vec<CborUpward<TokenOperation>>,
 }
 
-impl FromIterator<CborUpward<TokenOperation>> for TokenOperations {
-    fn from_iter<T: IntoIterator<Item = CborUpward<TokenOperation>>>(iter: T) -> Self {
+impl FromIterator<TokenOperation> for TokenOperations {
+    fn from_iter<T: IntoIterator<Item = TokenOperation>>(iter: T) -> Self {
         Self {
-            operations: iter.into_iter().collect(),
+            operations: iter.into_iter().map(CborUpward::Known).collect(),
         }
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::cbor::{self, value, CborSerializationResult, CborUpward},
+    common::cbor::{self, CborSerializationResult, CborUpward},
     protocol_level_tokens::{CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId},
     transactions::Memo,
 };

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -1,5 +1,6 @@
+use crate::common::upward::CborUpward;
 use crate::{
-    common::cbor::{self, CborSerializationResult, CborUpward},
+    common::cbor::{self, CborSerializationResult},
     protocol_level_tokens::{CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId},
     transactions::Memo,
 };

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -283,7 +283,7 @@ pub enum CborMemo {
 pub mod test {
     use super::*;
     use crate::{
-        common::cbor,
+        common::cbor::{self, value},
         protocol_level_tokens::{token_holder::test_fixtures::ADDRESS, CborHolderAccount},
     };
     use assert_matches::assert_matches;

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
@@ -1,5 +1,6 @@
+use crate::common::upward::{CborUpward, Upward};
 use crate::{
-    common::{cbor, cbor::CborSerializationResult, cbor::CborUpward, cbor::Upward},
+    common::{cbor, cbor::CborSerializationResult},
     protocol_level_tokens::{
         token_holder::CborHolderAccount, RawCbor, TokenAmount, TokenId,
         TokenModuleCborTypeDiscriminator,

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_reject_reason.rs
@@ -1,5 +1,5 @@
 use crate::{
-    common::{cbor, cbor::CborSerializationResult},
+    common::{cbor, cbor::CborSerializationResult, cbor::CborUpward, cbor::Upward},
     protocol_level_tokens::{
         token_holder::CborHolderAccount, RawCbor, TokenAmount, TokenId,
         TokenModuleCborTypeDiscriminator,
@@ -24,29 +24,29 @@ pub struct TokenModuleRejectReason {
 
 impl TokenModuleRejectReason {
     /// Decode reject reason from CBOR
-    pub fn decode_reject_reason(&self) -> CborSerializationResult<TokenModuleRejectReasonType> {
+    pub fn decode_reject_reason(&self) -> CborSerializationResult<Upward<TokenModuleRejectReasonType>> {
         use TokenModuleRejectReasonType::*;
 
         Ok(match self.reason_type.as_ref() {
-            "addressNotFound" => AddressNotFound(cbor::cbor_decode(
+            "addressNotFound" => Upward::Known(AddressNotFound(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            "tokenBalanceInsufficient" => TokenBalanceInsufficient(cbor::cbor_decode(
+            )?)),
+            "tokenBalanceInsufficient" => Upward::Known(TokenBalanceInsufficient(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            "deserializationFailure" => DeserializationFailure(cbor::cbor_decode(
+            )?)),
+            "deserializationFailure" => Upward::Known(DeserializationFailure(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            "unsupportedOperation" => UnsupportedOperation(cbor::cbor_decode(
+            )?)),
+            "unsupportedOperation" => Upward::Known(UnsupportedOperation(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            "operationNotPermitted" => OperationNotPermitted(cbor::cbor_decode(
+            )?)),
+            "operationNotPermitted" => Upward::Known(OperationNotPermitted(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            "mintWouldOverflow" => MintWouldOverflow(cbor::cbor_decode(
+            )?)),
+            "mintWouldOverflow" => Upward::Known(MintWouldOverflow(cbor::cbor_decode(
                 self.details.as_ref().context("no CBOR details")?.as_ref(),
-            )?),
-            _ => Unknown,
+            )?)),
+            _ => Upward::Unknown(()),
         })
     }
 }

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -14,7 +14,7 @@ use crate::{
     },
     common::{
         self,
-        cbor::{CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize},
+        cbor::{CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize, Upward},
         types::{Amount, KeyIndex, KeyPair, Timestamp, TransactionSignature, TransactionTime, *},
         Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, SerdeDeserialize, SerdeSerialize,
         Serial, Serialize,
@@ -2323,15 +2323,15 @@ pub mod construct {
                 .operations
                 .iter()
                 .map(|op| match op {
-                    TokenOperation::Transfer(_) => cost::PLT_TRANSFER,
-                    TokenOperation::Mint(_) => cost::PLT_MINT,
-                    TokenOperation::Burn(_) => cost::PLT_BURN,
-                    TokenOperation::AddAllowList(_)
-                    | TokenOperation::RemoveAllowList(_)
-                    | TokenOperation::AddDenyList(_)
-                    | TokenOperation::RemoveDenyList(_) => cost::PLT_LIST_UPDATE,
-                    TokenOperation::Pause(_) | TokenOperation::Unpause(_) => cost::PLT_PAUSE,
-                    TokenOperation::Unknown(_, _) => Default::default(),
+                    Upward::Known(TokenOperation::Transfer(_)) => cost::PLT_TRANSFER,
+                    Upward::Known(TokenOperation::Mint(_)) => cost::PLT_MINT,
+                    Upward::Known(TokenOperation::Burn(_)) => cost::PLT_BURN,
+                    Upward::Known(TokenOperation::AddAllowList(_))
+                    | Upward::Known(TokenOperation::RemoveAllowList(_))
+                    | Upward::Known(TokenOperation::AddDenyList(_))
+                    | Upward::Known(TokenOperation::RemoveDenyList(_)) => cost::PLT_LIST_UPDATE,
+                    Upward::Known(TokenOperation::Pause(_)) | Upward::Known(TokenOperation::Unpause(_)) => cost::PLT_PAUSE,
+                   Upward::Unknown(_) => Default::default(),
                 })
                 .sum()
     }

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -14,7 +14,10 @@ use crate::{
     },
     common::{
         self,
-        cbor::{CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize, Upward},
+        cbor::{
+            CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize,
+            Upward,
+        },
         types::{Amount, KeyIndex, KeyPair, Timestamp, TransactionSignature, TransactionTime, *},
         Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, SerdeDeserialize, SerdeSerialize,
         Serial, Serialize,
@@ -2330,8 +2333,9 @@ pub mod construct {
                     | Upward::Known(TokenOperation::RemoveAllowList(_))
                     | Upward::Known(TokenOperation::AddDenyList(_))
                     | Upward::Known(TokenOperation::RemoveDenyList(_)) => cost::PLT_LIST_UPDATE,
-                    Upward::Known(TokenOperation::Pause(_)) | Upward::Known(TokenOperation::Unpause(_)) => cost::PLT_PAUSE,
-                   Upward::Unknown(_) => Default::default(),
+                    Upward::Known(TokenOperation::Pause(_))
+                    | Upward::Known(TokenOperation::Unpause(_)) => cost::PLT_PAUSE,
+                    Upward::Unknown(_) => Default::default(),
                 })
                 .sum()
     }

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -14,10 +14,7 @@ use crate::{
     },
     common::{
         self,
-        cbor::{
-            CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize,
-            Upward,
-        },
+        cbor::{CborDecoder, CborDeserialize, CborEncoder, CborSerializationResult, CborSerialize},
         types::{Amount, KeyIndex, KeyPair, Timestamp, TransactionSignature, TransactionTime, *},
         Buffer, Deserial, Get, ParseResult, Put, ReadBytesExt, SerdeDeserialize, SerdeSerialize,
         Serial, Serialize,
@@ -2147,6 +2144,7 @@ pub mod cost {
 /// See also the [send] module above which combines construction with signing.
 pub mod construct {
     use super::*;
+    use crate::common::upward::Upward;
     use crate::{
         common::cbor,
         protocol_level_tokens::{RawCbor, TokenId, TokenOperation, TokenOperations},


### PR DESCRIPTION
## Purpose

Closes the parts of https://linear.app/concordium/issue/COR-1791/use-upward-maybeknown-construct-in-rust-cbor that are needed in concordium-base.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
