### PR TITLE
fix: bump cargo version for concordium base derive to test release gi…

### DIFF
--- a/identity-provider-service/Cargo.lock
+++ b/identity-provider-service/Cargo.lock
@@ -522,7 +522,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 dependencies = [
  "convert_case 0.8.0",
  "darling",

--- a/idiss/Cargo.lock
+++ b/idiss/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 dependencies = [
  "convert_case 0.8.0",
  "darling",

--- a/mobile_wallet/Cargo.lock
+++ b/mobile_wallet/Cargo.lock
@@ -449,7 +449,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 dependencies = [
  "convert_case 0.8.0",
  "darling",

--- a/rust-bins/Cargo.lock
+++ b/rust-bins/Cargo.lock
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 dependencies = [
  "convert_case 0.8.0",
  "darling",

--- a/rust-src/Cargo.lock
+++ b/rust-src/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 dependencies = [
  "convert_case 0.8.0",
  "darling",

--- a/rust-src/concordium_base/Cargo.toml
+++ b/rust-src/concordium_base/Cargo.toml
@@ -70,7 +70,7 @@ features = ["derive-serde"]
 
 # Local dependencies
 [dependencies.concordium_base_derive]
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 path = "../concordium_base_derive"
 
 [features]

--- a/rust-src/concordium_base_derive/Cargo.toml
+++ b/rust-src/concordium_base_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "concordium_base_derive"
-version = "1.1.0"
+version = "1.1.0-alpha.3"
 authors = ["Concordium AG <developers@concordium.com>"]
 edition = "2021"
 license-file = "../../LICENSE"


### PR DESCRIPTION


## Purpose

bump concordium base derive cargo version for release git action test

## Changes

bump cargo version

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


