### PR TITLE
Ar/cor 1970 identity credential attributes prover and verifier copied

### DIFF
--- a/rust-src/concordium_base/src/id/account_holder.rs
+++ b/rust-src/concordium_base/src/id/account_holder.rs
@@ -486,11 +486,11 @@ fn generate_pio_common<'a, P: Pairing, C: Curve<Scalar = P::ScalarField>, R: ran
 /// Convenient data structure to collect data related to a single AR
 pub struct SingleArData<'a, C: Curve> {
     pub ar: &'a ArInfo<C>,
-    share: Value<C>,
+    pub share: Value<C>,
     pub encrypted_share: Cipher<C>,
-    encryption_randomness: crate::elgamal::Randomness<C>,
+    pub encryption_randomness: crate::elgamal::Randomness<C>,
     pub cmm_to_share: Commitment<C>,
-    randomness_cmm_to_share: PedersenRandomness<C>,
+    pub randomness_cmm_to_share: PedersenRandomness<C>,
 }
 
 type SharingData<'a, C> = (

--- a/rust-src/concordium_base/src/id/mod.rs
+++ b/rust-src/concordium_base/src/id/mod.rs
@@ -5,12 +5,12 @@ pub mod account_holder;
 pub mod anonymity_revoker;
 pub mod chain;
 pub mod constants;
-pub mod credential_attribute_commitment;
 #[cfg(feature = "ffi")]
 mod ffi;
 pub mod id_proof_types;
 pub mod id_prover;
 pub mod id_verifier;
+pub mod identity_attributes;
 pub mod identity_provider;
 pub mod secret_sharing;
 pub mod types;
@@ -38,4 +38,3 @@ pub use crate::ps_sig;
 #[cfg(any(test, feature = "internal-test-helpers"))]
 #[doc(hidden)]
 pub mod test;
-

--- a/rust-src/concordium_base/src/id/mod.rs
+++ b/rust-src/concordium_base/src/id/mod.rs
@@ -5,6 +5,7 @@ pub mod account_holder;
 pub mod anonymity_revoker;
 pub mod chain;
 pub mod constants;
+pub mod credential_attribute_commitment;
 #[cfg(feature = "ffi")]
 mod ffi;
 pub mod id_proof_types;
@@ -37,3 +38,4 @@ pub use crate::ps_sig;
 #[cfg(any(test, feature = "internal-test-helpers"))]
 #[doc(hidden)]
 pub mod test;
+

--- a/rust-src/concordium_base/src/id/types.rs
+++ b/rust-src/concordium_base/src/id/types.rs
@@ -2703,9 +2703,9 @@ impl<C: Curve> HasAttributeRandomness<C> for SystemAttributeRandomness {
     }
 }
 
-/// The commitments produce by credential attribute commitment
+/// The commitments produced by identity attribute commitments created from identity credential
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, SerdeSerialize, SerdeDeserialize)]
-pub struct CredentialAttributeCommitments<C: Curve> {
+pub struct IdentityAttributesCommitments<C: Curve> {
     /// commitment to the prf key
     #[serde(rename = "cmmPrf")]
     pub cmm_prf: PedersenCommitment<C>,
@@ -2731,12 +2731,12 @@ pub struct CredentialAttributeCommitments<C: Curve> {
 }
 
 /// Randomness that is generated to commit to attributes when
-/// proving credential attributes commitment.
+/// proving identity attribute commitments.
 /// This randomness is needed later on if the user wishes to do
 /// something with those commitments, for example reveal the commited value, or
 /// prove a property of the value.
 #[derive(SerdeSerialize, SerdeDeserialize)]
-pub struct CredentialAttributeCommitmentRandomness<C: Curve> {
+pub struct IdentityAttributesCommitmentRandomness<C: Curve> {
     #[serde(rename = "idCredSecRand")]
     /// Randomness of the commitment to idCredSec.
     pub id_cred_sec_rand: PedersenRandomness<C>,
@@ -2758,9 +2758,10 @@ pub struct CredentialAttributeCommitmentRandomness<C: Curve> {
     pub attributes_rand: HashMap<AttributeTag, PedersenRandomness<C>>,
 }
 
-/// This structure contains all proofs, which are required to prove credential attribute commitment.
+/// This structure contains all proofs, which are required to prove identity attributes commitments created
+/// from identity credential.
 #[derive(Debug, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
-pub struct CredentialAttributeCommitmentProofs<P: Pairing, C: Curve<Scalar = P::ScalarField>> {
+pub struct IdentityAttributesCommitmentProofs<P: Pairing, C: Curve<Scalar = P::ScalarField>> {
     /// (Blinded) Signature derived from the signature on the pre-identity
     /// object by the IP
     #[serde(
@@ -2775,7 +2776,7 @@ pub struct CredentialAttributeCommitmentProofs<P: Pairing, C: Curve<Scalar = P::
         serialize_with = "base16_encode",
         deserialize_with = "base16_decode"
     )]
-    pub commitments: CredentialAttributeCommitments<C>,
+    pub commitments: IdentityAttributesCommitments<C>,
     /// Challenge used for all of the proofs.
     #[serde(
         rename = "challenge",
@@ -2818,9 +2819,9 @@ pub struct CredentialAttributeCommitmentProofs<P: Pairing, C: Curve<Scalar = P::
     pub cred_counter_less_than_max_accounts: RangeProof<C>,
 }
 
-/// Values (as opposed to proofs) in credential attribute commitment.
+/// Values (as opposed to proofs) in identity attribute commitments created from identity credential.
 #[derive(Debug, PartialEq, Eq, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
-pub struct CredentialAttributeCommitmentValues<C: Curve, AttributeType: Attribute<C::Scalar>> {
+pub struct IdentityAttributesCommitmentValues<C: Curve, AttributeType: Attribute<C::Scalar>> {
     /// Credential keys (i.e. account holder keys).
     #[serde(rename = "credentialPublicKeys")]
     pub cred_key_info: CredentialPublicKeys,
@@ -2850,18 +2851,18 @@ pub struct CredentialAttributeCommitmentValues<C: Curve, AttributeType: Attribut
     pub policy: Policy<C, AttributeType>,
 }
 
-/// A credential with attributes, public keys, and proofs that it is
+/// Identity attributes commitments created from identity credential, and proofs that it is
 /// well-formed.
 #[derive(Debug, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
-pub struct CredentialAttributeCommitmentInfo<
+pub struct IdentityAttributesCommitmentInfo<
     P: Pairing,
     C: Curve<Scalar = P::ScalarField>,
     AttributeType: Attribute<C::Scalar>,
 > {
     #[serde(flatten)]
-    pub values: CredentialAttributeCommitmentValues<C, AttributeType>,
+    pub values: IdentityAttributesCommitmentValues<C, AttributeType>,
     #[serde(rename = "proofs")]
-    pub proofs: CredentialAttributeCommitmentProofs<P, C>,
+    pub proofs: IdentityAttributesCommitmentProofs<P, C>,
 }
 
 /// A request for recovering an identity

--- a/rust-src/concordium_base/src/id/types.rs
+++ b/rust-src/concordium_base/src/id/types.rs
@@ -2703,6 +2703,167 @@ impl<C: Curve> HasAttributeRandomness<C> for SystemAttributeRandomness {
     }
 }
 
+/// The commitments produce by credential attribute commitment
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, SerdeSerialize, SerdeDeserialize)]
+pub struct CredentialAttributeCommitments<C: Curve> {
+    /// commitment to the prf key
+    #[serde(rename = "cmmPrf")]
+    pub cmm_prf: PedersenCommitment<C>,
+    /// commitment to credential counter
+    #[serde(rename = "cmmCredCounter")]
+    pub cmm_cred_counter: PedersenCommitment<C>,
+    /// commitment to the max account number.
+    #[serde(rename = "cmmMaxAccounts")]
+    pub cmm_max_accounts: PedersenCommitment<C>,
+    /// List of commitments to the attributes that are not revealed.
+    /// For the purposes of checking signatures, the commitments to those
+    /// that are revealed as part of the policy are going to be computed by the
+    /// verifier.
+    #[map_size_length = 2]
+    #[serde(rename = "cmmAttributes")]
+    pub cmm_attributes: BTreeMap<AttributeTag, PedersenCommitment<C>>,
+    /// commitments to the coefficients of the polynomial
+    /// used to share id_cred_sec
+    /// S + b1 X + b2 X^2...
+    /// where S is id_cred_sec
+    #[serde(rename = "cmmIdCredSecSharingCoeff")]
+    pub cmm_id_cred_sec_sharing_coeff: Vec<PedersenCommitment<C>>,
+}
+
+/// Randomness that is generated to commit to attributes when
+/// proving credential attributes commitment.
+/// This randomness is needed later on if the user wishes to do
+/// something with those commitments, for example reveal the commited value, or
+/// prove a property of the value.
+#[derive(SerdeSerialize, SerdeDeserialize)]
+pub struct CredentialAttributeCommitmentRandomness<C: Curve> {
+    #[serde(rename = "idCredSecRand")]
+    /// Randomness of the commitment to idCredSec.
+    pub id_cred_sec_rand: PedersenRandomness<C>,
+    #[serde(rename = "prfRand")]
+    /// Randomness of the commitment to the PRF key.
+    pub prf_rand: PedersenRandomness<C>,
+    #[serde(rename = "credCounterRand")]
+    /// Randomness of the commitment to the credential nonce. This nonce is the
+    /// number that is used to ensure that only a limited number of credentials
+    /// can be created from a given identity object.
+    pub cred_counter_rand: PedersenRandomness<C>,
+    #[serde(rename = "maxAccountsRand")]
+    /// Randomness of the commitment to the maximum number of accounts the user
+    /// may create from the identity object.
+    pub max_accounts_rand: PedersenRandomness<C>,
+    #[serde(rename = "attributesRand")]
+    /// Randomness, if any, used to commit to user-chosen attributes, such as
+    /// country of nationality.
+    pub attributes_rand: HashMap<AttributeTag, PedersenRandomness<C>>,
+}
+
+/// This structure contains all proofs, which are required to prove credential attribute commitment.
+#[derive(Debug, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
+pub struct CredentialAttributeCommitmentProofs<P: Pairing, C: Curve<Scalar = P::ScalarField>> {
+    /// (Blinded) Signature derived from the signature on the pre-identity
+    /// object by the IP
+    #[serde(
+        rename = "sig",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub sig: crate::ps_sig::BlindedSignature<P>,
+    /// list of  commitments to the attributes .
+    #[serde(
+        rename = "commitments",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub commitments: CredentialAttributeCommitments<C>,
+    /// Challenge used for all of the proofs.
+    #[serde(
+        rename = "challenge",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub challenge: Challenge,
+    /// Responses in the proof that the computed commitment to the share
+    /// contains the same value as the encryption
+    /// the commitment to the share is not sent but computed from
+    /// the commitments to the sharing coefficients
+    #[serde(rename = "proofIdCredPub")]
+    #[map_size_length = 4]
+    pub proof_id_cred_pub: BTreeMap<ArIdentity, com_enc_eq::Response<C>>,
+    /// Responses in the proof of knowledge of signature of Identity Provider on
+    /// the list
+    ///
+    /// - `(idCredSec, prfKey, attributes[0], attributes[1], ..., attributes[n],
+    ///   AR[1], ..., AR[m])`
+    #[serde(
+        rename = "proofIpSig",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub proof_ip_sig: com_eq_sig::Response<P, C>,
+    /// Proof that reg_id = prf_K(x). Also establishes that reg_id is computed
+    /// from the prf key signed by the identity provider.
+    #[serde(
+        rename = "proofRegId",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub proof_reg_id: com_mult::Response<C>,
+    /// Proof that cred_counter is less than or equal to max_accounts
+    #[serde(
+        rename = "credCounterLessThanMaxAccounts",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub cred_counter_less_than_max_accounts: RangeProof<C>,
+}
+
+/// Values (as opposed to proofs) in credential attribute commitment.
+#[derive(Debug, PartialEq, Eq, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
+pub struct CredentialAttributeCommitmentValues<C: Curve, AttributeType: Attribute<C::Scalar>> {
+    /// Credential keys (i.e. account holder keys).
+    #[serde(rename = "credentialPublicKeys")]
+    pub cred_key_info: CredentialPublicKeys,
+    /// Credential registration id of the credential.
+    #[serde(
+        rename = "credId",
+        serialize_with = "base16_encode",
+        deserialize_with = "base16_decode"
+    )]
+    pub cred_id: CredId<C>,
+    /// Identity of the identity provider who signed the identity object from
+    /// which this credential is derived.
+    #[serde(rename = "ipIdentity")]
+    pub ip_identity: IpIdentity,
+    /// Anonymity revocation threshold. Must be <= length of ar_data.
+    #[serde(rename = "revocationThreshold")]
+    pub threshold: Threshold,
+    /// Anonymity revocation data. List of anonymity revokers which can revoke
+    /// identity. NB: The order is important since it is the same order as that
+    /// signed by the identity provider, and permuting the list will invalidate
+    /// the signature from the identity provider.
+    #[map_size_length = 2]
+    #[serde(rename = "arData", deserialize_with = "deserialize_ar_data")]
+    pub ar_data: BTreeMap<ArIdentity, ChainArData<C>>,
+    /// Policy of this credential object.
+    #[serde(rename = "policy")]
+    pub policy: Policy<C, AttributeType>,
+}
+
+/// A credential with attributes, public keys, and proofs that it is
+/// well-formed.
+#[derive(Debug, Serialize, SerdeSerialize, SerdeDeserialize, Clone)]
+pub struct CredentialAttributeCommitmentInfo<
+    P: Pairing,
+    C: Curve<Scalar = P::ScalarField>,
+    AttributeType: Attribute<C::Scalar>,
+> {
+    #[serde(flatten)]
+    pub values: CredentialAttributeCommitmentValues<C, AttributeType>,
+    #[serde(rename = "proofs")]
+    pub proofs: CredentialAttributeCommitmentProofs<P, C>,
+}
+
 /// A request for recovering an identity
 #[derive(SerdeSerialize, SerdeDeserialize)]
 #[serde(bound(serialize = "C: Curve", deserialize = "C: Curve"))]


### PR DESCRIPTION
## Purpose

Implement first (very) naive version of proving identity attribute commitments. 
It should just be a copy of the credential deployment prover and verifier.

The idea is to create a baseline, such that further changes can be compared with the existing credential deployment.

## Changes

Copied `account_holder::create_credential` and `chain::verify_cdi` and the associated types.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
