### PR TITLE
COR-1787: Adding Git Actions release script for Concordium-Base

### DIFF
--- a/.github/workflows/release-concordium-base.yaml
+++ b/.github/workflows/release-concordium-base.yaml
@@ -1,0 +1,50 @@
+name: Relase Concordium Base
+
+on:
+
+  workflow_dispach: 
+  
+  push:
+    tags:
+      - releases/concordium-base/*
+  
+
+env:
+  TAG: ${{ github.ref_name }}
+
+jobs:
+  concordium-base-release:
+    name: concordium-base:release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust-src/concordium_base
+    environment: release
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: validate tag version has correct matching tag
+      run: |
+        echo "Validating tag version $TAG matches expected version from Cargo.toml"
+        EXPECTED_VERSION_FROM_CARGO=$(yq .package.version ./Cargo.toml)
+        TAG_VERSION_NUMBER=${TAG##releases/concordium_base/}
+
+        # Check if the tag version number matches the expected version from Cargo.toml
+        if [ "$TAG_VERSION_NUMBER" != "$EXPECTED_VERSION_FROM_CARGO" ]; then
+          echo "version tagged: $TAG_VERSION_NUMBER  does not match cargo version: $EXPECTED_VERSION_FROM_CARGO. Exiting."
+          exit 1
+        else
+          echo "Tag version number matches expected version from Cargo.toml. Proceeding with release."
+        fi
+
+    - name: Publish to crate.io
+      env:
+        CARGO_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          echo "Publishing Concordium Base to crates.io for version: $TAG_VERSION"
+          cargo publish --token $CARGO_TOKEN --locked
+  


### PR DESCRIPTION
## Purpose

Adding the release script for concordium-base

## Changes

- The release script `release-concordium-base.yaml` is added at `.github/workflows/`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
