### PR TITLE
COR-1941: move upward methods from sdk to base

### DIFF
--- a/rust-src/concordium_base/src/common/upward.rs
+++ b/rust-src/concordium_base/src/common/upward.rs
@@ -98,9 +98,12 @@ impl<A, R> Upward<A, R> {
     /// [`Known(v)`]: Upward::Known
     pub fn known_or_else<E, F>(self, error: F) -> Result<A, E>
     where
-        F: FnOnce() -> E,
+        F: FnOnce(R) -> E,
     {
-        Option::from(self).ok_or_else(error)
+        match self {
+            Upward::Unknown(residual) => Err(error(residual)),
+            Upward::Known(output) => Ok(output),
+        }
     }
 
     /// Returns `true` if the Upward is a [`Upward::Known`] and the value inside


### PR DESCRIPTION
This moves the additional methods from the `Upward` definition in the Rust SDK to its counterpart in base.
