### PR TITLE
PSR-52: Adding tests

### DIFF
--- a/haskell-src/Concordium/Types/Queries/Tokens.hs
+++ b/haskell-src/Concordium/Types/Queries/Tokens.hs
@@ -172,12 +172,14 @@ instance Serialize TokenState where
         put tsTokenModuleRef
         put tsDecimals
         put tsTotalSupply
-        put tsModuleState
+        putWord32be (fromIntegral (BS.length tsModuleState))
+        putByteString tsModuleState
     get = do
         tsTokenModuleRef <- get
         tsDecimals <- get
         tsTotalSupply <- get
-        tsModuleState <- get
+        moduleStateLen <- getWord32be
+        tsModuleState <- getByteString (fromIntegral moduleStateLen)
         return TokenState{..}
 
 -- | The global info about a protocol-level token.

--- a/haskell-src/Concordium/Types/Queries/Tokens.hs
+++ b/haskell-src/Concordium/Types/Queries/Tokens.hs
@@ -21,6 +21,7 @@ import Concordium.Crypto.ByteStringHelpers
 import Concordium.Types
 import qualified Concordium.Types.ProtocolLevelTokens.CBOR as CBOR
 import Concordium.Types.Tokens
+import Concordium.Utils.Serialization
 
 -- | Protocol level token.
 data Token = Token
@@ -105,10 +106,21 @@ instance FromJSON TokenAccountState where
 instance Serialize TokenAccountState where
     put TokenAccountState{..} = do
         put balance
-        put moduleAccountState
+        case moduleAccountState of
+            Nothing -> do
+                putBool False
+            Just moduleAccountState' -> do
+                putBool True
+                putWord32be (fromIntegral (BS.length moduleAccountState'))
+                putByteString moduleAccountState'
     get = do
         balance <- get
-        moduleAccountState <- get
+        moduleAccountStatePresent <- getBool
+        moduleAccountState <- case moduleAccountStatePresent of
+            False -> return Nothing
+            True -> do
+                moduleAccountStateLen <- getWord32be
+                Just <$> getByteString (fromIntegral moduleAccountStateLen)
         return TokenAccountState{..}
 
 -- | The global token state.

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -45,11 +45,13 @@ import Concordium.Types
 import Concordium.Types.Conditionally
 import Concordium.Types.Execution
 import Concordium.Types.Parameters
+import qualified Concordium.Types.Queries.Tokens as QueryTokenTypes
 import Concordium.Types.Tokens
 import Concordium.Types.Transactions
 import Concordium.Types.Updates
 import qualified Concordium.Wasm as Wasm
 import qualified Data.FixedByteString as FBS
+import Concordium.Types.Queries.Tokens
 
 genAmount :: Gen Amount
 genAmount = Amount <$> arbitrary
@@ -1204,6 +1206,33 @@ genTokenEventDetails :: Gen TokenEventDetails
 genTokenEventDetails = do
     len <- chooseBoundedIntegral (0, 1000)
     TokenEventDetails . BSS.pack <$> genUtf8String len
+
+genTokenAccountState :: Gen QueryTokenTypes.TokenAccountState
+genTokenAccountState = do
+    balance <- genTokenAmount
+    moduleAccountState <- Just <$> Generators.genByteString
+    return QueryTokenTypes.TokenAccountState{..}
+
+-- | Generate an arbitrary 'Token'
+genToken :: Gen QueryTokenTypes.Token
+genToken = do
+    tokenId <- genTokenId
+    tokenAccountState <- genTokenAccountState
+    return QueryTokenTypes.Token{..}
+
+genQueryTypeTokenState :: Gen QueryTokenTypes.TokenState
+genQueryTypeTokenState = do
+    tsTokenModuleRef <- genTokenModuleRef
+    tsDecimals <- chooseBoundedIntegral (0, 255)
+    tsTotalSupply <- genTokenAmount
+    tsModuleState <- Generators.genByteString
+    return QueryTokenTypes.TokenState{..}
+
+genTokenInfo :: Gen QueryTokenTypes.TokenInfo
+genTokenInfo = do
+    tiTokenId <- genTokenId
+    tiTokenState <- genQueryTypeTokenState
+    return QueryTokenTypes.TokenInfo{..}
 
 -- | Generate an arbitrary 'CreatePLT' chain update, consisting of:
 --   * Random token symbol up to 255 bytes valid UTF-8.

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -51,7 +51,6 @@ import Concordium.Types.Transactions
 import Concordium.Types.Updates
 import qualified Concordium.Wasm as Wasm
 import qualified Data.FixedByteString as FBS
-import Concordium.Types.Queries.Tokens
 
 genAmount :: Gen Amount
 genAmount = Amount <$> arbitrary
@@ -1210,7 +1209,7 @@ genTokenEventDetails = do
 genTokenAccountState :: Gen QueryTokenTypes.TokenAccountState
 genTokenAccountState = do
     balance <- genTokenAmount
-    moduleAccountState <- Just <$> Generators.genByteString
+    moduleAccountState <- oneof [pure Nothing, Just <$> Generators.genByteString]
     return QueryTokenTypes.TokenAccountState{..}
 
 -- | Generate an arbitrary 'Token'

--- a/haskell-tests/Types/TokensSpec.hs
+++ b/haskell-tests/Types/TokensSpec.hs
@@ -151,6 +151,25 @@ testTokenAmountEncodeDecode :: Property
 testTokenAmountEncodeDecode = forAll genTokenAmount $ \a ->
     decodeFull get (encode a) == Right a
 
+-- | Test the binary serialization and deserialization of 'Token'.
+testTokenEncodeDecode :: Property
+testTokenEncodeDecode = forAll genToken $ \a ->
+    decodeFull get (encode a) == Right a
+
+-- | Test the binary serialization and deserialization of 'TokenInfo'.
+testTokenInfoEncodeDecode :: Property
+testTokenInfoEncodeDecode = forAll genTokenInfo $ \a ->
+    decodeFull get (encode a) == Right a
+
+-- | Test the binary serialization and deserialization of 'TokenInfo'.
+testTokenStateEncodeDecode :: Property
+testTokenStateEncodeDecode = forAll genQueryTypeTokenState $ \a ->
+    decodeFull get (encode a) == Right a
+
+-- | Test the binary serialization and deserialization of 'TokenAcountState'.
+testTokenAccuntStateEncodeDecode :: Property
+testTokenAccuntStateEncodeDecode = forAll genTokenAccountState $ \a ->
+    decodeFull get (encode a) == Right a
 -- | Tests for token types.
 tests :: Spec
 tests = parallel $ do
@@ -170,3 +189,6 @@ tests = parallel $ do
         testTokenAmountJSONDecodeCases
         it "Binary Serialization and deserialization of valid TokenAmounts" $
             withMaxSuccess 10000 testTokenAmountEncodeDecode
+    describe "TokenAccountState" $ do
+        it "Binary Serialization and deserialization of valid TokenAccountState" $
+            withMaxSuccess 10000 testTokenAccuntStateEncodeDecode

--- a/haskell-tests/Types/TokensSpec.hs
+++ b/haskell-tests/Types/TokensSpec.hs
@@ -19,6 +19,7 @@ import Test.Hspec
 import Test.QuickCheck as QuickCheck hiding ((.&.))
 
 import Concordium.Types
+import Concordium.Types.Queries.Tokens
 import Concordium.Types.Tokens
 import Generators
 
@@ -161,15 +162,104 @@ testTokenInfoEncodeDecode :: Property
 testTokenInfoEncodeDecode = forAll genTokenInfo $ \a ->
     decodeFull get (encode a) == Right a
 
--- | Test the binary serialization and deserialization of 'TokenInfo'.
+-- | Test the binary serialization and deserialization of 'TokenState'.
 testTokenStateEncodeDecode :: Property
 testTokenStateEncodeDecode = forAll genQueryTypeTokenState $ \a ->
     decodeFull get (encode a) == Right a
 
--- | Test the binary serialization and deserialization of 'TokenAcountState'.
-testTokenAccuntStateEncodeDecode :: Property
-testTokenAccuntStateEncodeDecode = forAll genTokenAccountState $ \a ->
+-- | Test the binary serialization and deserialization of 'TokenAccountState'.
+testTokenAccountStateEncodeDecode :: Property
+testTokenAccountStateEncodeDecode = forAll genTokenAccountState $ \a ->
     decodeFull get (encode a) == Right a
+
+-- | Binary serialization examples for 'TokenAccountState'.
+testTokenAccountStateSerializationExamples :: Spec
+testTokenAccountStateSerializationExamples =
+    describe "TokenAccountState binary serialization examples" $ do
+        it "encodes and decodes fixture value with module state" $ do
+            let value = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Just moduleStateFixture}
+                expected = BS.pack [0x64, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
+            encode value `shouldBe` expected
+            decodeFull get expected `shouldBe` Right value
+
+        it "encodes and decodes fixture value without module state" $ do
+            let value = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Nothing}
+                expected = BS.pack [0x64, 0x0a, 0x00]
+            encode value `shouldBe` expected
+            decodeFull get expected `shouldBe` Right value
+  where
+    tokenAmountFixture = TokenAmount 100 10
+    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+
+-- | Binary serialization examples for 'Token'.
+testTokenSerializationExamples :: Spec
+testTokenSerializationExamples =
+    describe "Token binary serialization examples" $ do
+        it "encodes and decodes fixture value" $ do
+            let value =
+                    Token
+                        { tokenId = tokenIdFixture,
+                          tokenAccountState = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Just moduleStateFixture}
+                        }
+                expected = BS.pack [0x05, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x64, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
+            encode value `shouldBe` expected
+            decodeFull get expected `shouldBe` Right value
+  where
+    tokenIdFixture = TokenId "token"
+    tokenAmountFixture = TokenAmount 100 10
+    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+
+-- | Binary serialization examples for 'TokenState'.
+testTokenStateSerializationExamples :: Spec
+testTokenStateSerializationExamples =
+    describe "TokenState binary serialization examples" $ do
+        it "encodes and decodes fixture value" $ do
+            let value =
+                    TokenState
+                        { tsTokenModuleRef = tokenModuleRefFixture,
+                          tsDecimals = 10,
+                          tsTotalSupply = tokenAmountFixture,
+                          tsModuleState = moduleStateFixture
+                        }
+                expected = BS.pack (replicate 32 0x01 ++ [0x0a, 0x64, 0x0a, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03])
+            encode value `shouldBe` expected
+            decodeFull get expected `shouldBe` Right value
+  where
+    tokenAmountFixture = TokenAmount 100 10
+    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+    tokenModuleRefFixture =
+        case decode (BS.pack (replicate 32 0x01)) of
+            Right r -> r
+            Left e -> error ("Failed to decode token module ref fixture: " ++ e)
+
+-- | Binary serialization examples for 'TokenInfo'.
+testTokenInfoSerializationExamples :: Spec
+testTokenInfoSerializationExamples =
+    describe "TokenInfo binary serialization examples" $ do
+        it "encodes and decodes fixture value" $ do
+            let value =
+                    TokenInfo
+                        { tiTokenId = tokenIdFixture,
+                          tiTokenState =
+                            TokenState
+                                { tsTokenModuleRef = tokenModuleRefFixture,
+                                  tsDecimals = 10,
+                                  tsTotalSupply = tokenAmountFixture,
+                                  tsModuleState = moduleStateFixture
+                                }
+                        }
+                expected = BS.pack ([0x05, 0x74, 0x6f, 0x6b, 0x65, 0x6e] ++ replicate 32 0x01 ++ [0x0a, 0x64, 0x0a, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03])
+            encode value `shouldBe` expected
+            decodeFull get expected `shouldBe` Right value
+  where
+    tokenIdFixture = TokenId "token"
+    tokenAmountFixture = TokenAmount 100 10
+    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+    tokenModuleRefFixture =
+        case decode (BS.pack (replicate 32 0x01)) of
+            Right r -> r
+            Left e -> error ("Failed to decode token module ref fixture: " ++ e)
+
 -- | Tests for token types.
 tests :: Spec
 tests = parallel $ do
@@ -191,4 +281,17 @@ tests = parallel $ do
             withMaxSuccess 10000 testTokenAmountEncodeDecode
     describe "TokenAccountState" $ do
         it "Binary Serialization and deserialization of valid TokenAccountState" $
-            withMaxSuccess 10000 testTokenAccuntStateEncodeDecode
+            withMaxSuccess 10000 testTokenAccountStateEncodeDecode
+        testTokenAccountStateSerializationExamples
+    describe "Token" $ do
+        it "Binary Serialization and deserialization of valid Token" $
+            withMaxSuccess 10000 testTokenEncodeDecode
+        testTokenSerializationExamples
+    describe "TokenState" $ do
+        it "Binary Serialization and deserialization of valid TokenState" $
+            withMaxSuccess 10000 testTokenStateEncodeDecode
+        testTokenStateSerializationExamples
+    describe "TokenInfo" $ do
+        it "Binary Serialization and deserialization of valid TokenInfo" $
+            withMaxSuccess 10000 testTokenInfoEncodeDecode
+        testTokenInfoSerializationExamples

--- a/haskell-tests/Types/TokensSpec.hs
+++ b/haskell-tests/Types/TokensSpec.hs
@@ -176,89 +176,89 @@ testTokenAccountStateEncodeDecode = forAll genTokenAccountState $ \a ->
 testTokenAccountStateSerializationExamples :: Spec
 testTokenAccountStateSerializationExamples =
     describe "TokenAccountState binary serialization examples" $ do
-        it "encodes and decodes fixture value with module state" $ do
-            let value = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Just moduleStateFixture}
+        it "encodes and decodes example value with module state" $ do
+            let value = TokenAccountState{balance = tokenAmountExample, moduleAccountState = Just moduleStateExample}
                 expected = BS.pack [0x64, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
             encode value `shouldBe` expected
             decodeFull get expected `shouldBe` Right value
 
-        it "encodes and decodes fixture value without module state" $ do
-            let value = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Nothing}
+        it "encodes and decodes example value without module state" $ do
+            let value = TokenAccountState{balance = tokenAmountExample, moduleAccountState = Nothing}
                 expected = BS.pack [0x64, 0x0a, 0x00]
             encode value `shouldBe` expected
             decodeFull get expected `shouldBe` Right value
   where
-    tokenAmountFixture = TokenAmount 100 10
-    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+    tokenAmountExample = TokenAmount 100 10
+    moduleStateExample = BS.pack [0x01, 0x02, 0x03]
 
 -- | Binary serialization examples for 'Token'.
 testTokenSerializationExamples :: Spec
 testTokenSerializationExamples =
     describe "Token binary serialization examples" $ do
-        it "encodes and decodes fixture value" $ do
+        it "encodes and decodes example value" $ do
             let value =
                     Token
-                        { tokenId = tokenIdFixture,
-                          tokenAccountState = TokenAccountState{balance = tokenAmountFixture, moduleAccountState = Just moduleStateFixture}
+                        { tokenId = tokenIdExample,
+                          tokenAccountState = TokenAccountState{balance = tokenAmountExample, moduleAccountState = Just moduleStateExample}
                         }
                 expected = BS.pack [0x05, 0x74, 0x6f, 0x6b, 0x65, 0x6e, 0x64, 0x0a, 0x01, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03]
             encode value `shouldBe` expected
             decodeFull get expected `shouldBe` Right value
   where
-    tokenIdFixture = TokenId "token"
-    tokenAmountFixture = TokenAmount 100 10
-    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
+    tokenIdExample = TokenId "token"
+    tokenAmountExample = TokenAmount 100 10
+    moduleStateExample = BS.pack [0x01, 0x02, 0x03]
 
 -- | Binary serialization examples for 'TokenState'.
 testTokenStateSerializationExamples :: Spec
 testTokenStateSerializationExamples =
     describe "TokenState binary serialization examples" $ do
-        it "encodes and decodes fixture value" $ do
+        it "encodes and decodes example value" $ do
             let value =
                     TokenState
-                        { tsTokenModuleRef = tokenModuleRefFixture,
+                        { tsTokenModuleRef = tokenModuleRefExample,
                           tsDecimals = 10,
-                          tsTotalSupply = tokenAmountFixture,
-                          tsModuleState = moduleStateFixture
+                          tsTotalSupply = tokenAmountExample,
+                          tsModuleState = moduleStateExample
                         }
                 expected = BS.pack (replicate 32 0x01 ++ [0x0a, 0x64, 0x0a, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03])
             encode value `shouldBe` expected
             decodeFull get expected `shouldBe` Right value
   where
-    tokenAmountFixture = TokenAmount 100 10
-    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
-    tokenModuleRefFixture =
+    tokenAmountExample = TokenAmount 100 10
+    moduleStateExample = BS.pack [0x01, 0x02, 0x03]
+    tokenModuleRefExample =
         case decode (BS.pack (replicate 32 0x01)) of
             Right r -> r
-            Left e -> error ("Failed to decode token module ref fixture: " ++ e)
+            Left e -> error ("Failed to decode token module ref example: " ++ e)
 
 -- | Binary serialization examples for 'TokenInfo'.
 testTokenInfoSerializationExamples :: Spec
 testTokenInfoSerializationExamples =
     describe "TokenInfo binary serialization examples" $ do
-        it "encodes and decodes fixture value" $ do
+        it "encodes and decodes example value" $ do
             let value =
                     TokenInfo
-                        { tiTokenId = tokenIdFixture,
+                        { tiTokenId = tokenIdExample,
                           tiTokenState =
                             TokenState
-                                { tsTokenModuleRef = tokenModuleRefFixture,
+                                { tsTokenModuleRef = tokenModuleRefExample,
                                   tsDecimals = 10,
-                                  tsTotalSupply = tokenAmountFixture,
-                                  tsModuleState = moduleStateFixture
+                                  tsTotalSupply = tokenAmountExample,
+                                  tsModuleState = moduleStateExample
                                 }
                         }
                 expected = BS.pack ([0x05, 0x74, 0x6f, 0x6b, 0x65, 0x6e] ++ replicate 32 0x01 ++ [0x0a, 0x64, 0x0a, 0x00, 0x00, 0x00, 0x03, 0x01, 0x02, 0x03])
             encode value `shouldBe` expected
             decodeFull get expected `shouldBe` Right value
   where
-    tokenIdFixture = TokenId "token"
-    tokenAmountFixture = TokenAmount 100 10
-    moduleStateFixture = BS.pack [0x01, 0x02, 0x03]
-    tokenModuleRefFixture =
+    tokenIdExample = TokenId "token"
+    tokenAmountExample = TokenAmount 100 10
+    moduleStateExample = BS.pack [0x01, 0x02, 0x03]
+    tokenModuleRefExample =
         case decode (BS.pack (replicate 32 0x01)) of
             Right r -> r
-            Left e -> error ("Failed to decode token module ref fixture: " ++ e)
+            Left e -> error ("Failed to decode token module ref example: " ++ e)
 
 -- | Tests for token types.
 tests :: Spec


### PR DESCRIPTION
## Purpose

Adding tests for the Serialize Class implementation for Query Token Types.

## Changes

- Added `Property` tests inside `TokenSpec.hs` for query token types;
- Added `Spec` tests inside `TokenSpec.hs` for query token types that match their Rust counterpart;
- Added generators for query token types in `Generator.hs`;

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [x] I accept the above linked CLA.
