### PR TITLE
Remove additional data from CBOR types, where it is never used

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -27,6 +27,8 @@
   - Implemented checks in `serde::Deserialize` implementation on `TokenId` and `TokenModuleCborTypeDiscriminator` that the internal type
     invariants are fulfilled.
   - Implemented limit on pre-allocation in `concordium_base::common::Deserial` implementation on `RawCbor`.
+  - The field `additional` containing dynamic CBOR model has been removed from `TokenModuleState`, `TokenModuleAccountState` and `TokenModuleInitializationParameters`.
+    The field could not contain any data.
 
 - Introduce protocol version 11 variant `ProtocolVersion::P11`.
 - The flag `serde_deprecated` now guards `serde::Serialize` and `serde::Deserialize` implemetations on the following types. The implementations will eventually be removed.

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_account_state.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_account_state.rs
@@ -1,8 +1,4 @@
-use std::collections::HashMap;
-
 use concordium_base_derive::{CborDeserialize, CborSerialize};
-
-use crate::common::cbor::value;
 
 #[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize, Default)]
 ///  The account state represents account-specific information that is
@@ -23,10 +19,6 @@ pub struct TokenModuleAccountState {
     /// Whether the account is on the deny list.
     /// If `None`, the token does not support a deny list.
     pub deny_list: Option<bool>,
-    /// Additional state information may be provided under further text keys,
-    /// the meaning of which are not defined in the present specification.
-    #[cbor(other)]
-    pub additional: HashMap<String, value::Value>,
 }
 
 #[cfg(test)]
@@ -39,7 +31,6 @@ mod test {
         let mut token_module_account_state = TokenModuleAccountState {
             allow_list: Some(true),
             deny_list: None,
-            additional: Default::default(),
         };
 
         let cbor = cbor::cbor_encode(&token_module_account_state);
@@ -56,18 +47,6 @@ mod test {
         token_module_account_state.deny_list = Some(false);
         let cbor = cbor::cbor_encode(&token_module_account_state);
         assert_eq!(hex::encode(&cbor), "a16864656e794c697374f4");
-        let decoded: TokenModuleAccountState = cbor::cbor_decode(cbor).unwrap();
-        assert_eq!(token_module_account_state, decoded);
-
-        token_module_account_state.additional.insert(
-            "customKey".to_string(),
-            value::Value::Text("customValue".to_string()),
-        );
-        let cbor = cbor::cbor_encode(&token_module_account_state);
-        assert_eq!(
-            hex::encode(&cbor),
-            "a26864656e794c697374f469637573746f6d4b65796b637573746f6d56616c7565"
-        );
         let decoded: TokenModuleAccountState = cbor::cbor_decode(cbor).unwrap();
         assert_eq!(token_module_account_state, decoded);
     }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_initialization_parameters.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_initialization_parameters.rs
@@ -1,7 +1,6 @@
 use super::{MetadataUrl, TokenAmount};
-use crate::{common::cbor::value, protocol_level_tokens::token_holder::CborHolderAccount};
+use crate::protocol_level_tokens::token_holder::CborHolderAccount;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
-use std::collections::HashMap;
 
 /// These parameters are passed to the token module to initialize the token.
 /// The token initialization update will also include the ticker symbol,
@@ -25,9 +24,6 @@ pub struct TokenModuleInitializationParameters {
     pub mintable: Option<bool>,
     /// Whether the token is burnable.
     pub burnable: Option<bool>,
-    /// Additional fields.
-    #[cbor(other)]
-    pub additional: HashMap<String, value::Value>,
 }
 
 #[cfg(test)]
@@ -60,7 +56,6 @@ mod test {
             initial_supply: Some(TokenAmount::from_raw(10000000, 8)),
             mintable: Some(true),
             burnable: Some(true),
-            additional: Default::default(),
         };
 
         let cbor = cbor::cbor_encode(&token_module_initialization_parameters);

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_module_state.rs
@@ -1,9 +1,7 @@
-use std::collections::HashMap;
-
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 
 use super::MetadataUrl;
-use crate::{common::cbor::value, protocol_level_tokens::token_holder::CborHolderAccount};
+use crate::protocol_level_tokens::token_holder::CborHolderAccount;
 
 /// Protocol level token (PLT) module state
 #[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize)]
@@ -24,10 +22,6 @@ pub struct TokenModuleState {
     pub burnable: Option<bool>,
     /// Whether the execution of certain token operations is paused.
     pub paused: Option<bool>,
-    /// Additional state information may be provided under further text keys,
-    /// the meaning of which are not defined in the present specification.
-    #[cbor(other)]
-    pub additional: HashMap<String, value::Value>,
 }
 
 #[cfg(test)]
@@ -60,14 +54,11 @@ mod test {
             mintable: Some(true),
             burnable: Some(true),
             paused: Some(false),
-            additional: vec![("other1".to_string(), value::Value::Positive(2))]
-                .into_iter()
-                .collect(),
         };
 
         let cbor = cbor::cbor_encode(&token_module_state);
         assert_eq!(hex::encode(&cbor),
-        "a9646e616d6563544b31666f74686572310266706175736564f4686275726e61626c65f56864656e794c697374f5686d65746164617461a26375726c7168747470733a2f2f746f6b656e75726c316e636865636b73756d53686132353658200101010101010101010101010101010101010101010101010101010101010101686d696e7461626c65f569616c6c6f774c697374f571676f7665726e616e63654163636f756e74d99d73a201d99d71a101190397035820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "a8646e616d6563544b3166706175736564f4686275726e61626c65f56864656e794c697374f5686d65746164617461a26375726c7168747470733a2f2f746f6b656e75726c316e636865636b73756d53686132353658200101010101010101010101010101010101010101010101010101010101010101686d696e7461626c65f569616c6c6f774c697374f571676f7665726e616e63654163636f756e74d99d73a201d99d71a101190397035820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         );
         let token_module_state_decoded: TokenModuleState = cbor::cbor_decode(&cbor).unwrap();
         assert_eq!(token_module_state_decoded, token_module_state);
@@ -77,14 +68,13 @@ mod test {
 
         let cbor = cbor::cbor_encode(&token_module_state);
         assert_eq!(hex::encode(&cbor),
-        "a7646e616d6563544b31666f74686572310266706175736564f4686d65746164617461a26375726c7168747470733a2f2f746f6b656e75726c316e636865636b73756d53686132353658200101010101010101010101010101010101010101010101010101010101010101686d696e7461626c65f569616c6c6f774c697374f571676f7665726e616e63654163636f756e74d99d73a201d99d71a101190397035820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        "a6646e616d6563544b3166706175736564f4686d65746164617461a26375726c7168747470733a2f2f746f6b656e75726c316e636865636b73756d53686132353658200101010101010101010101010101010101010101010101010101010101010101686d696e7461626c65f569616c6c6f774c697374f571676f7665726e616e63654163636f756e74d99d73a201d99d71a101190397035820ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
         );
         let token_module_state_decoded: TokenModuleState = cbor::cbor_decode(&cbor).unwrap();
         assert_eq!(token_module_state_decoded, token_module_state);
 
         token_module_state.allow_list = None;
         token_module_state.mintable = None;
-        token_module_state.additional = HashMap::new();
         token_module_state.paused = None;
 
         let cbor = cbor::cbor_encode(&token_module_state);


### PR DESCRIPTION
## Purpose

Remove additional data from CBOR types where it is not used, in order to match https://github.com/Concordium/concordium-base/pull/892/changes.

## Changes

_Describe the changes that were needed.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

