### PR TITLE
Add token authorizations type

### DIFF
--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -673,6 +673,12 @@ instance ToProto TokenInfo where
         ProtoFields.tokenId .= toProto tiTokenId
         ProtoFields.tokenState .= toProto tiTokenState
 
+instance ToProto TokenAuthorizations where
+    type Output TokenAuthorizations = Proto.TokenAuthorizations
+    toProto TokenAuthorizations{..} = Proto.make $ do
+        ProtoFields.tokenId .= toProto taTokenId
+        ProtoFields.details .= Proto.make (PLTFields.value .= taDetails)
+
 instance ToProto Wasm.Parameter where
     type Output Wasm.Parameter = Proto.Parameter
     toProto Wasm.Parameter{..} = Proto.make $ ProtoFields.value .= BSS.fromShort parameter

--- a/haskell-src/Concordium/Types/Queries/Tokens.hs
+++ b/haskell-src/Concordium/Types/Queries/Tokens.hs
@@ -9,6 +9,7 @@ module Concordium.Types.Queries.Tokens (
     TokenAccountState (..),
     TokenState (..),
     TokenInfo (..),
+    TokenAuthorizations (..),
 ) where
 
 import Data.Aeson as AE
@@ -225,3 +226,12 @@ instance Serialize TokenInfo where
         tiTokenId <- get
         tiTokenState <- get
         return TokenInfo{..}
+
+-- | Role based authorizations structure for a given token. The authorizations are CBOR encoded
+-- inside the 'taDetails' field
+data TokenAuthorizations = TokenAuthorizations
+    { -- | The symbol uniquely identifying the protocol-level token.
+      taTokenId :: !TokenId,
+      -- | The CBOR encoded authorizations details
+      taDetails :: !BS.ByteString
+    }


### PR DESCRIPTION
Ref RBC-8, Closes RBC-23

## Purpose

Depends on https://github.com/Concordium/concordium-grpc-api/pull/117.

Adds the authorizations model which will be used as the response for the token authorizations query for the GRPC service.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
