### PR TITLE
Feature/rbc 7 update token metadata url support

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Implemented definition for `UpdateMetadata` token operation and token event which allows to update the metadata of a protocol level token.
 - Implemented definition for `TokenAdminRole` which describes the list of supported roles. 
   Implemented `assignAdminRoles` and `revokeAdminRoles` token operations for RBAC too.
 - Implemented `common::from_bytes_complete` that fails if all bytes are not consumed during deserialization.

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -2,7 +2,7 @@ use super::{CborHolderAccount, RawCbor, TokenAmount};
 use crate::common;
 use crate::common::cbor::CborSerializationResult;
 use crate::common::{cbor, Buffer, Deserial, Get, ParseResult, SerdeDeserialize, Serial};
-use crate::protocol_level_tokens::TokenAdminRole;
+use crate::protocol_level_tokens::{MetadataUrl, TokenAdminRole};
 use crate::transactions::Memo;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 use concordium_contracts_common::AccountAddress;
@@ -28,10 +28,12 @@ pub enum TokenModuleEventType {
     /// Execution of certain operations on a protocol level token was
     /// unpaused ([`UnpauseEvent`])
     Unpause,
-    // Assign admin roles to an Account for a protocol level token.
+    /// Assign admin roles to an Account for a protocol level token.
     AssignAdminRoles,
-    // Revoke admin roles from an Account for a protocol level token.
+    /// Revoke admin roles from an Account for a protocol level token.
     RevokeAdminRoles,
+    /// Update token metadata for a protocol level token.
+    UpdateMetada,
 }
 
 /// Unknown token module event
@@ -51,6 +53,7 @@ impl TokenModuleEventType {
             TokenModuleEventType::Unpause => "unpause",
             TokenModuleEventType::AssignAdminRoles => "assignAdminRoles",
             TokenModuleEventType::RevokeAdminRoles => "revokeAdminRoles",
+            TokenModuleEventType::UpdateMetada => "updateMetadata",
         }
     }
 
@@ -72,6 +75,7 @@ impl TokenModuleEventType {
             "unpause" => TokenModuleEventType::Unpause,
             "assignAdminRoles" => TokenModuleEventType::AssignAdminRoles,
             "revokeAdminRoles" => TokenModuleEventType::RevokeAdminRoles,
+            "updateMetadata" => TokenModuleEventType::UpdateMetada,
             _ => {
                 return Err(UnknownTokenModuleEventTypeError(
                     type_discriminator.to_string(),
@@ -82,7 +86,7 @@ impl TokenModuleEventType {
 }
 
 /// Token module event parsed from type and CBOR
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)
@@ -107,6 +111,8 @@ pub enum TokenModuleEvent {
     AssignAdminRoles(AssignAdminRolesEvent),
     /// Revoke admin roles to an Account for a protocol level token
     RevokeAdminRoles(RevokeAdminRolesEvent),
+    /// NEW VARIANT HERE: Indicates that a token had its metadata reference updated.
+    UpdateMetadata(UpdateMetadataEvent),
 }
 
 impl TokenModuleEvent {
@@ -121,6 +127,7 @@ impl TokenModuleEvent {
             TokenModuleEvent::Unpause(_) => TokenModuleEventType::Unpause,
             TokenModuleEvent::AssignAdminRoles(_) => TokenModuleEventType::AssignAdminRoles,
             TokenModuleEvent::RevokeAdminRoles(_) => TokenModuleEventType::RevokeAdminRoles,
+            TokenModuleEvent::UpdateMetadata(_) => TokenModuleEventType::UpdateMetada,
         }
     }
 
@@ -159,6 +166,10 @@ impl TokenModuleEvent {
                 TokenModuleEventType::RevokeAdminRoles,
                 RawCbor::from(cbor::cbor_encode(event)),
             ),
+            TokenModuleEvent::UpdateMetadata(event) => (
+                TokenModuleEventType::UpdateMetada,
+                RawCbor::from(cbor::cbor_encode(event)),
+            ),
         }
     }
 
@@ -188,6 +199,9 @@ impl TokenModuleEvent {
             TokenModuleEventType::RevokeAdminRoles => {
                 TokenModuleEvent::RevokeAdminRoles(cbor::cbor_decode(cbor)?)
             }
+            TokenModuleEventType::UpdateMetada => {
+                TokenModuleEvent::UpdateMetadata(cbor::cbor_decode(cbor)?)
+            }
         })
     }
 }
@@ -200,6 +214,7 @@ pub type PauseEvent = TokenPauseEventDetails;
 pub type UnpauseEvent = TokenPauseEventDetails;
 pub type AssignAdminRolesEvent = TokenUpdateAdminRolesEventDetails;
 pub type RevokeAdminRolesEvent = TokenUpdateAdminRolesEventDetails;
+pub type UpdateMetadataEvent = TokenUpdateMetadataEventDetails;
 
 /// Details of an event updating the allow or deny list of a protocol level
 /// token
@@ -236,6 +251,18 @@ pub struct TokenUpdateAdminRolesEventDetails {
     pub roles: Vec<TokenAdminRole>,
     // The account to update admin for.
     pub account: CborHolderAccount,
+}
+
+/// An event emmitted when there are updatesto the token metadata for a
+/// protocol level token.
+#[derive(Debug, Clone, PartialEq, CborSerialize, CborDeserialize)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub struct TokenUpdateMetadataEventDetails {
+    pub metadata_url: MetadataUrl,
 }
 
 /// An entity that can hold PLTs (protocol level tokens).
@@ -389,6 +416,8 @@ impl From<TokenModuleCborTypeDiscriminator> for String {
 
 #[cfg(test)]
 mod test {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::{
         common,
@@ -517,6 +546,27 @@ mod test {
         assert_eq!(hex::encode(&cbor), "a265726f6c6573877075706461746541646d696e526f6c6573646d696e74646275726e6f757064617465416c6c6f774c6973746e75706461746544656e794c6973746570617573656e7570646174654d65746164617461676163636f756e74d99d73a10358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
 
         let event_decoded: TokenUpdateAdminRolesEventDetails = cbor::cbor_decode(cbor).unwrap();
+        assert_eq!(event_decoded, event);
+    }
+
+    /// Test Update token metadata event
+    #[test]
+    fn test_decode_update_metadata_event_cbor() {
+        let event = TokenUpdateMetadataEventDetails {
+            metadata_url: MetadataUrl {
+                url: "http://someUrl.com".to_string(),
+                checksum_sha_256: None,
+                additional: HashMap::new(),
+            },
+        };
+
+        let cbor = cbor::cbor_encode(&event);
+        assert_eq!(
+            hex::encode(&cbor),
+            "a16b6d6574616461746155726ca16375726c72687474703a2f2f736f6d6555726c2e636f6d"
+        );
+
+        let event_decoded: TokenUpdateMetadataEventDetails = cbor::cbor_decode(cbor).unwrap();
         assert_eq!(event_decoded, event);
     }
 

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -1,6 +1,7 @@
 use crate::common::cbor::{
     CborDecoder, CborDeserialize, CborEncoder, CborMaybeKnown, CborSerialize,
 };
+use crate::protocol_level_tokens::MetadataUrl;
 use crate::{
     common::cbor::{self, CborSerializationResult},
     protocol_level_tokens::{CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId},
@@ -136,6 +137,12 @@ pub mod operations {
             roles,
         })
     }
+
+    /// Construct operation to update token metadata for a protocol
+    /// level token.
+    pub fn update_metadata(metadata_url: MetadataUrl) -> TokenOperation {
+        TokenOperation::UpdateMetadata(metadata_url)
+    }
 }
 
 /// Embedded CBOR, see <https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml>
@@ -236,6 +243,8 @@ pub enum TokenOperation {
     AssignAdminRoles(TokenUpdateAdminRolesDetails),
     /// Operation to revoke roles for an account for a protocol level token.
     RevokeAdminRoles(TokenUpdateAdminRolesDetails),
+    /// Operation to update token metadata
+    UpdateMetadata(MetadataUrl),
 }
 
 /// Details of an operation that changes a protocol level token supply.
@@ -404,6 +413,8 @@ impl CborDeserialize for TokenAdminRole {
 
 #[cfg(test)]
 pub mod test {
+    use std::collections::HashMap;
+
     use super::*;
     use crate::{
         common::cbor::{self, value},
@@ -631,6 +642,23 @@ pub mod test {
 
         let cbor = cbor::cbor_encode(&operation);
         assert_eq!(hex::encode(&cbor), "a1707265766f6b6541646d696e526f6c6573a265726f6c6573877075706461746541646d696e526f6c6573646d696e74646275726e6f757064617465416c6c6f774c6973746e75706461746544656e794c6973746570617573656e7570646174654d65746164617461676163636f756e74d99d73a10358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20");
+        let operation_decoded: TokenOperation = cbor::cbor_decode(&cbor).unwrap();
+        assert_eq!(operation_decoded, operation);
+    }
+
+    #[test]
+    fn test_token_operation_update_metadata() {
+        let operation = TokenOperation::UpdateMetadata(MetadataUrl {
+            url: "SomeUrl".to_string(),
+            checksum_sha_256: None,
+            additional: HashMap::new(),
+        });
+
+        let cbor = cbor::cbor_encode(&operation);
+        assert_eq!(
+            hex::encode(&cbor),
+            "a16e7570646174654d65746164617461a16375726c67536f6d6555726c"
+        );
         let operation_decoded: TokenOperation = cbor::cbor_decode(&cbor).unwrap();
         assert_eq!(operation_decoded, operation);
     }

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -2229,6 +2229,10 @@ pub mod cost {
     /// Additional cost of assigning/revoking roles for a PLT
     pub const PLT_ASSIGN_REVOKE_ROLES: Energy = Energy { energy: 50 };
 
+    /// TODO - this is a placeholder value for now - RBC-26 will investigate the correct energy to use.
+    /// Additional cost of update token metadata for a PLT
+    pub const PLT_UPDATE_TOKEN_METADATA: Energy = Energy { energy: 50 };
+
     /// Additional cost of an encrypted transfer.
     #[deprecated(
         since = "5.0.1",
@@ -2631,6 +2635,7 @@ pub mod construct {
                     TokenOperation::AssignAdminRoles(_) | TokenOperation::RevokeAdminRoles(_) => {
                         cost::PLT_ASSIGN_REVOKE_ROLES
                     }
+                    TokenOperation::UpdateMetadata(_) => cost::PLT_UPDATE_TOKEN_METADATA,
                 })
                 .sum()
     }


### PR DESCRIPTION
## Purpose

Add support for updating metadata token information for a protocol level token

## Changes

Added token operation and event details for updating token metadata

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.

