### PR TITLE
Add RBAC operations in Haskell CBOR.

### DIFF
--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -582,6 +582,132 @@ tokenMetadataUrlFromBytes =
 tokenMetadataUrlToBytes :: TokenMetadataUrl -> BS.ByteString
 tokenMetadataUrlToBytes = encodeToBytes . encodeTokenMetadataUrl
 
+-- * Administrative roles
+
+-- | The different admin roles defined for the current token module implementation.
+--  Each role gives access to specific adminstrative operations.
+data TokenAdminRole
+    = -- | Authority to perform @assignAdminRoles@ and @revokeAdminRoles@.
+      RoleUpdateAdminRoles
+    | -- | Authority to perform @mint@.
+      RoleMint
+    | -- | Authority to perfrom @burn@.
+      RoleBurn
+    | -- | Authority to perform @addAllowList@ and @removeAllowList@.
+      RoleUpdateAllowList
+    | -- | Authority to perform @addDenyList@ and @removeDenyList@.
+      RoleUpdateDenyList
+    | -- | Authority to perform @pause@ and @unpause@.
+      RolePause
+    | -- | Authority to perform @updateMetadata@.
+      RoleUpdateMetadata
+    deriving (Eq, Show)
+
+instance AE.ToJSON TokenAdminRole where
+    toJSON = AE.String . tokenAdminRoleToText
+
+instance AE.FromJSON TokenAdminRole where
+    parseJSON = AE.withText "TokenAdminRole" $ \role -> case tokenAdminRoleFromText role of
+        Just r -> return r
+        Nothing -> fail $ "Unsupported role: " ++ show role
+
+-- | Parse a 'Text' as a 'TokenAdminRole'.
+tokenAdminRoleFromText :: Text -> Maybe TokenAdminRole
+tokenAdminRoleFromText "updateAdminRoles" = Just RoleUpdateAdminRoles
+tokenAdminRoleFromText "mint" = Just RoleMint
+tokenAdminRoleFromText "burn" = Just RoleBurn
+tokenAdminRoleFromText "updateAllowList" = Just RoleUpdateAllowList
+tokenAdminRoleFromText "updateDenyList" = Just RoleUpdateDenyList
+tokenAdminRoleFromText "pause" = Just RolePause
+tokenAdminRoleFromText "updateMetadata" = Just RoleUpdateMetadata
+tokenAdminRoleFromText _ = Nothing
+
+-- | Encode a 'TokenAdminRole' as 'Text'.
+tokenAdminRoleToText :: TokenAdminRole -> Text
+tokenAdminRoleToText RoleUpdateAdminRoles = "updateAdminRoles"
+tokenAdminRoleToText RoleMint = "mint"
+tokenAdminRoleToText RoleBurn = "burn"
+tokenAdminRoleToText RoleUpdateAllowList = "updateAllowList"
+tokenAdminRoleToText RoleUpdateDenyList = "updateDenyList"
+tokenAdminRoleToText RolePause = "pause"
+tokenAdminRoleToText RoleUpdateMetadata = "updateMetadata"
+
+-- | Decode a CBOR-encoded 'TokenAdminRole'.
+decodeTokenAdminRole :: Decoder s TokenAdminRole
+decodeTokenAdminRole = do
+    role <- decodeString
+    case tokenAdminRoleFromText role of
+        Just r -> return r
+        Nothing -> fail $ "Unsupported role: " ++ show role
+
+-- | Encode a 'TokenAdminRole' as CBOR.
+encodeTokenAdminRole :: TokenAdminRole -> Encoding
+encodeTokenAdminRole = encodeString . tokenAdminRoleToText
+
+-- | The details of @assignAdminRoles@ and @revokeAdminRoles@ operations.
+data UpdateAdminRolesDetails = UpdateAdminRolesDetails
+    { -- | The account to assign or revoke administrative roles.
+      uardAccount :: !CborAccountAddress,
+      -- | The roles to assign or revoke.
+      uardRoles :: !(Seq.Seq TokenAdminRole)
+    }
+    deriving (Eq, Show)
+
+instance AE.ToJSON UpdateAdminRolesDetails where
+    toJSON UpdateAdminRolesDetails{..} = do
+        AE.object $
+            [ "account" AE..= uardAccount,
+              "roles" AE..= uardRoles
+            ]
+
+instance AE.FromJSON UpdateAdminRolesDetails where
+    parseJSON = AE.withObject "UpdateAdminRolesDetails" $ \o -> do
+        uardAccount <- o AE..: "account"
+        uardRoles <- o AE..: "roles"
+        return UpdateAdminRolesDetails{..}
+
+data UpdateAdminRolesDetailsBuilder = UpdateAdminRolesDetailsBuilder
+    { _uardbAccount :: Maybe CborAccountAddress,
+      _uardbRoles :: Maybe (Seq.Seq TokenAdminRole)
+    }
+
+makeLenses ''UpdateAdminRolesDetailsBuilder
+
+-- | Empty 'UpdateAdminRolesDetailsBuilder'.
+emptyUpdateAdminRolesDetailsBuilder :: UpdateAdminRolesDetailsBuilder
+emptyUpdateAdminRolesDetailsBuilder = UpdateAdminRolesDetailsBuilder Nothing Nothing
+
+-- | Construct an 'UpdateAdminRolesDetails' from a 'UpdateAdminRolesDetailsBuilder'.
+--  This results in @Left err@ (where @err@ describes the failure reason) when a required parameter
+--  is missing.
+buildUpdateAdminRolesDetails :: UpdateAdminRolesDetailsBuilder -> Either String UpdateAdminRolesDetails
+buildUpdateAdminRolesDetails UpdateAdminRolesDetailsBuilder{..} = do
+    uardAccount <- _uardbAccount `orFail` "Missing \"account\""
+    uardRoles <- _uardbRoles `orFail` "Missing \"roles\""
+    return UpdateAdminRolesDetails{..}
+
+-- | Decode a CBOR-encoded 'UpdateAdminRolesDetails'.
+decodeUpdateAdminRolesDetails :: Decoder s UpdateAdminRolesDetails
+decodeUpdateAdminRolesDetails =
+    decodeMap
+        valDecoder
+        buildUpdateAdminRolesDetails
+        emptyUpdateAdminRolesDetailsBuilder
+  where
+    valDecoder k@"account" = Just $ mapValueDecoder k decodeCborAccountAddress uardbAccount
+    valDecoder k@"roles" = Just $ mapValueDecoder k (decodeSequence decodeTokenAdminRole) uardbRoles
+    valDecoder _ = Nothing
+
+-- | Encode an 'UpdateAdminRolesDetails' as CBOR.
+encodeUpdateAdminRolesDetails :: UpdateAdminRolesDetails -> Encoding
+encodeUpdateAdminRolesDetails UpdateAdminRolesDetails{..} =
+    encodeMapDeterministic $
+        Map.empty
+            & k "account" ?~ encodeCborAccountAddress uardAccount
+            & k "roles" ?~ encodeSequence encodeTokenAdminRole uardRoles
+  where
+    k = at . makeMapKeyEncoding . encodeString
+
 -- * Initialization parameters
 
 -- | The parsed token-initialization-parameters. These parameters are passed to the token module
@@ -862,6 +988,12 @@ data TokenOperation
       TokenPause
     | -- | Unpause transfer/mint/burn operations for the token.
       TokenUnpause
+    | -- | Assign admin roles to an account.
+      TokenAssignAdminRoles !UpdateAdminRolesDetails
+    | -- | Revoke admin roles from an account.
+      TokenRevokeAdminRoles !UpdateAdminRolesDetails
+    | -- | Update metadata
+      TokenUpdateMetadata !TokenMetadataUrl
     deriving (Eq, Show)
 
 instance AE.ToJSON TokenOperation where
@@ -901,6 +1033,18 @@ instance AE.ToJSON TokenOperation where
         AE.object
             [ "unpause" AE..= AE.object []
             ]
+    toJSON (TokenAssignAdminRoles update) =
+        AE.object
+            [ "assignAdminRoles" AE..= update
+            ]
+    toJSON (TokenRevokeAdminRoles update) =
+        AE.object
+            [ "revokeAdminRoles" AE..= update
+            ]
+    toJSON (TokenUpdateMetadata metadata) =
+        AE.object
+            [ "updateMetadata" AE..= metadata
+            ]
 
 instance AE.FromJSON TokenOperation where
     parseJSON = AE.withObject "TokenOperation" $ \o -> do
@@ -931,6 +1075,15 @@ instance AE.FromJSON TokenOperation where
                 pure TokenPause
             ["unpause"] -> do
                 pure TokenUnpause
+            ["assignAdminRoles"] -> do
+                body <- o AE..: "assignAdminRoles"
+                pure $ TokenAssignAdminRoles body
+            ["revokeAdminRoles"] -> do
+                body <- o AE..: "revokeAdminRoles"
+                pure $ TokenRevokeAdminRoles body
+            ["updateMetadata"] -> do
+                metadata <- o AE..: "updateMetadata"
+                pure $ TokenUpdateMetadata metadata
             other -> fail $ "token-operation: unsupported operation type: " ++ show other
 
 -- | Decode a CBOR-encoded 'TokenOperation'.
@@ -952,6 +1105,9 @@ decodeTokenOperation = do
         "removeDenyList" -> TokenRemoveDenyList <$> decodeListTarget opType
         "pause" -> TokenPause <$ decodeEmptyMap
         "unpause" -> TokenUnpause <$ decodeEmptyMap
+        "assignAdminRoles" -> TokenAssignAdminRoles <$> decodeUpdateAdminRolesDetails
+        "revokeAdminRoles" -> TokenRevokeAdminRoles <$> decodeUpdateAdminRolesDetails
+        "updateMetadata" -> TokenUpdateMetadata <$> decodeTokenMetadataUrl
         _ -> fail $ "token-operation: unsupported operation type: " ++ show opType
     when (isNothing maybeMapLen) $ do
         isEnd <- decodeBreakOr
@@ -990,6 +1146,18 @@ encodeTokenOperation = \case
     TokenRemoveDenyList target -> encodeListTarget "removeDenyList" target
     TokenPause -> encodePause
     TokenUnpause -> encodeUnpause
+    TokenAssignAdminRoles body ->
+        encodeMapLen 1
+            <> encodeString "assignAdminRoles"
+            <> encodeUpdateAdminRolesDetails body
+    TokenRevokeAdminRoles body ->
+        encodeMapLen 1
+            <> encodeString "revokeAdminRoles"
+            <> encodeUpdateAdminRolesDetails body
+    TokenUpdateMetadata metadata ->
+        encodeMapLen 1
+            <> encodeString "updateMetadata"
+            <> encodeTokenMetadataUrl metadata
   where
     encodeSupplyUpdate opType amount =
         encodeMapLen 1

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -99,6 +99,25 @@ genTaggableMemo =
           CBORMemo <$> genMemo
         ]
 
+-- | Generator for 'TokenAdminRole'.
+genTokenAdminRole :: Gen TokenAdminRole
+genTokenAdminRole =
+    elements
+        [ RoleUpdateAdminRoles,
+          RoleMint,
+          RoleBurn,
+          RoleUpdateAllowList,
+          RoleUpdateDenyList,
+          RolePause,
+          RoleUpdateMetadata
+        ]
+
+genUpdateAdminRolesDetails :: Gen UpdateAdminRolesDetails
+genUpdateAdminRolesDetails = do
+    uardAccount <- genCborAccountAddress
+    uardRoles <- Seq.fromList <$> listOf genTokenAdminRole
+    return UpdateAdminRolesDetails{..}
+
 -- | Generator for 'TokenGovernanceOperation'.
 genTokenOperation :: Gen TokenOperation
 genTokenOperation =
@@ -111,7 +130,10 @@ genTokenOperation =
           TokenAddDenyList <$> genCborAccountAddress,
           TokenRemoveDenyList <$> genCborAccountAddress,
           pure TokenPause,
-          pure TokenUnpause
+          pure TokenUnpause,
+          TokenAssignAdminRoles <$> genUpdateAdminRolesDetails,
+          TokenRevokeAdminRoles <$> genUpdateAdminRolesDetails,
+          TokenUpdateMetadata <$> genTokenMetadataUrlSimple
         ]
 
 -- | Generator for 'TokenGovernanceOperation'.

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -436,6 +436,56 @@ encTops1 =
                 CBOR.toStrictByteString $
                     encodeTokenUpdateTransaction tops1
 
+-- | Another example 'TokenUpdateTransaction', which tests new operations introduced in P11.
+tops2 :: TokenUpdateTransaction
+tops2 =
+    TokenUpdateTransaction $
+        Seq.fromList
+            [ TokenAssignAdminRoles
+                UpdateAdminRolesDetails
+                    { uardAccount = cborHolder,
+                      uardRoles = Seq.fromList [RoleUpdateAdminRoles, RoleMint, RoleBurn]
+                    },
+              TokenRevokeAdminRoles
+                UpdateAdminRolesDetails
+                    { uardAccount = cborHolder,
+                      uardRoles = Seq.fromList [RoleUpdateAllowList, RoleUpdateDenyList, RolePause, RoleUpdateMetadata]
+                    },
+              TokenUpdateMetadata
+                TokenMetadataUrl
+                    { tmUrl = "https://example.plt",
+                      tmChecksumSha256 = Nothing,
+                      tmAdditional = Map.empty
+                    },
+              TokenUpdateMetadata
+                TokenMetadataUrl
+                    { tmUrl = "https://example2.plt",
+                      tmChecksumSha256 = Just emptyStringHash,
+                      tmAdditional = Map.empty
+                    }
+            ]
+  where
+    cborHolder =
+        CborAccountAddress
+            { chaAccount =
+                AccountAddress $
+                    FBS.pack (replicate 32 1),
+              chaCoinInfo = Just CoinInfoConcordium
+            }
+
+-- | Expected encoding of 'tops2'.
+tops2ExpectedCbor :: BS.ByteString
+tops2ExpectedCbor = BS16.decodeLenient "84a17061737369676e41646d696e526f6c6573a265726f6c6573837075706461746541646d696e526f6c6573646d696e74646275726e676163636f756e74d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101a1707265766f6b6541646d696e526f6c6573a265726f6c6573846f757064617465416c6c6f774c6973746e75706461746544656e794c6973746570617573656e7570646174654d65746164617461676163636f756e74d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101a16e7570646174654d65746164617461a16375726c7368747470733a2f2f6578616d706c652e706c74a16e7570646174654d65746164617461a26375726c7468747470733a2f2f6578616d706c65322e706c746e636865636b73756d5368613235365820e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+-- | Actual encoding of 'tops2'.
+encTops2 :: EncodedTokenOperations
+encTops2 =
+    EncodedTokenOperations $
+        TokenParameter $
+            BSS.toShort $
+                CBOR.toStrictByteString $
+                    encodeTokenUpdateTransaction tops1
+
 -- | A dummy 'CborAccountAddress' value.
 dummyCborHolder :: CborAccountAddress
 dummyCborHolder =
@@ -485,6 +535,21 @@ testEncodedTokenOperationsJSON = describe "EncodedTokenOperations JSON serializa
                 _ -> assertFailure "Does not encode to JSON object"
             _ -> assertFailure "Does not encode to JSON array"
 
+    it "Serialize/Deserialize roundtrip success (P11 ops)" $
+        assertEqual
+            "Deserialized"
+            (Just encTops2)
+            ( AE.decode $
+                AE.encode
+                    encTops2
+            )
+    it "Serializes to expected JSON object (P11 ops)" $
+        case AE.toJSON encTops2 of
+            AE.Array v -> case V.head v of
+                AE.Object o -> assertBool "Does not contain field amount" $ AE.member "transfer" o
+                _ -> assertFailure "Does not encode to JSON object"
+            _ -> assertFailure "Does not encode to JSON array"
+
     it "Serialize/Deserialize roundtrip where CBOR is not a valid TokenUpdateTransaction" $
         assertEqual
             "Deserialized"
@@ -506,6 +571,16 @@ testTokenOperationsCBOR = describe "EncodedTokenOperations CBOR serialization" $
             "CBOR serialized"
             (tokenUpdateTransactionToBytes tops1)
             tops1ExpectedCbor
+    it "Serialize/Deserialize roundtrip (P11 ops)" $
+        assertEqual
+            "Deserialized"
+            (tokenUpdateTransactionFromBytes $ B8.fromStrict $ tokenUpdateTransactionToBytes tops2)
+            (Right tops2)
+    it "Serializes to expected CBOR bytestring (P11 ops)" $
+        assertEqual
+            "CBOR serialized"
+            (tokenUpdateTransactionToBytes tops2)
+            tops2ExpectedCbor
 
 testEncodedTokenEvents :: Spec
 testEncodedTokenEvents = describe "TokenEvents CBOR serialization" $ do


### PR DESCRIPTION
## Purpose

Closes: [RBC-24](https://linear.app/concordium/issue/RBC-24/add-rbac-operations)

Support in the Haskell CBOR encoding/decoding for new operations: `TokenAssignAdminRoles`, `TokenRevokeAdminRoles` and `TokenUpdateMetadata`.

## Changes

- Types:
  - `TokenAdminRole`: represents the possible administrative roles for tokens.
  - `UpdateAdminRolesDetails`: represents the parameres for `TokenAssignAdminRoles` and `TokenRevokeAdminRoles`.
  - Extended `TokenOperation` with `TokenAssignAdminRoles`, `TokenRevokeAdminRoles` and `TokenUpdateMetadata`.
  - Support for CBOR and JSON encoding/decoding.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
