### PR TITLE
RBAC events and TokenAuthorizationsMap

### DIFF
--- a/cddl/cis-7.cddl
+++ b/cddl/cis-7.cddl
@@ -361,7 +361,7 @@ token-module-state = {
     ? "paused": bool,
 }
 
-; Describes the authorizations structure for protocol level tokens.
+; Describes the authorizations structure for protocol-level tokens.
 token-authorizations = {
     ; A map of admin roles to the accounts that have those roles assigned.
     * token-admin-role => token-role-authorizations

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1833,23 +1833,35 @@ tokenModuleStateFromBytes = decodeFromBytes decodeTokenModuleState "token module
 -- * Token authorizations
 
 -- | The authorizations structure for a PLT.
-newtype TokenAuthorizations = TokenAuthorizations
+newtype TokenAuthorizationsMap = TokenAuthorizationsMap
     { taMap :: Map.Map TokenAdminRole (Seq.Seq CborAccountAddress)
     }
     deriving newtype (Eq, Show, AE.ToJSON, AE.FromJSON)
 
-encodeTokenAuthorizations :: TokenAuthorizations -> Encoding
-encodeTokenAuthorizations (TokenAuthorizations m) =
+-- | Encode a 'TokenAuthorizationsMap' as CBOR.
+encodeTokenAuthorizationsMap :: TokenAuthorizationsMap -> Encoding
+encodeTokenAuthorizationsMap (TokenAuthorizationsMap m) =
     encodeMapDeterministic $
         Map.mapKeys (makeMapKeyEncoding . encodeTokenAdminRole) $
             encodeSequence encodeCborAccountAddress <$> m
 
-decodeTokenAuthorizations :: Decoder s TokenAuthorizations
-decodeTokenAuthorizations = decodeMap decodeVal (Right . TokenAuthorizations) Map.empty
+-- | Decode a CBOR-encoded 'TokenAuthorizationsMap'.
+decodeTokenAuthorizationsMap :: Decoder s TokenAuthorizationsMap
+decodeTokenAuthorizationsMap = decodeMap decodeVal (Right . TokenAuthorizationsMap) Map.empty
   where
     decodeVal key = do
         role <- tokenAdminRoleFromText key
         return $ mapValueDecoder key (decodeSequence decodeCborAccountAddress) (at role)
+
+-- | Parse a 'TokenAuthorizationsMap' form a 'LBS.ByteString'. The entire bytestring must be
+--  consumed by the parsing.
+tokenAuthorizationsMapFromBytes :: LBS.ByteString -> Either String TokenAuthorizationsMap
+tokenAuthorizationsMapFromBytes =
+    decodeFromBytes decodeTokenAuthorizationsMap "token authorizations"
+
+-- | Encode a 'TokenAuthorizationsMap' as a 'BS.ByteString'.
+tokenAuthorizationsMapToBytes :: TokenAuthorizationsMap -> BS.ByteString
+tokenAuthorizationsMapToBytes = encodeToBytes . encodeTokenAuthorizationsMap
 
 -- * Token account state
 

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -601,15 +602,19 @@ data TokenAdminRole
       RolePause
     | -- | Authority to perform @updateMetadata@.
       RoleUpdateMetadata
-    deriving (Eq, Show)
+    deriving (Eq, Ord, Show)
 
 instance AE.ToJSON TokenAdminRole where
     toJSON = AE.String . tokenAdminRoleToText
 
 instance AE.FromJSON TokenAdminRole where
-    parseJSON = AE.withText "TokenAdminRole" $ \role -> case tokenAdminRoleFromText role of
-        Just r -> return r
-        Nothing -> fail $ "Unsupported role: " ++ show role
+    parseJSON = AE.withText "TokenAdminRole" parseTokenAdminRoleFromText
+
+instance AE.ToJSONKey TokenAdminRole where
+    toJSONKey = AE.toJSONKeyText tokenAdminRoleToText
+
+instance AE.FromJSONKey TokenAdminRole where
+    fromJSONKey = AE.FromJSONKeyTextParser parseTokenAdminRoleFromText
 
 -- | Parse a 'Text' as a 'TokenAdminRole'.
 tokenAdminRoleFromText :: Text -> Maybe TokenAdminRole
@@ -621,6 +626,13 @@ tokenAdminRoleFromText "updateDenyList" = Just RoleUpdateDenyList
 tokenAdminRoleFromText "pause" = Just RolePause
 tokenAdminRoleFromText "updateMetadata" = Just RoleUpdateMetadata
 tokenAdminRoleFromText _ = Nothing
+
+-- | Parse a 'TokenAdminRole' from a 'Text' in a monad that supports 'MonadFail'.
+parseTokenAdminRoleFromText :: (MonadFail m) => Text -> m TokenAdminRole
+{-# INLINE parseTokenAdminRoleFromText #-}
+parseTokenAdminRoleFromText role = case tokenAdminRoleFromText role of
+    Just r -> return r
+    Nothing -> fail $ "Unsupported role: " ++ show role
 
 -- | Encode a 'TokenAdminRole' as 'Text'.
 tokenAdminRoleToText :: TokenAdminRole -> Text
@@ -634,11 +646,7 @@ tokenAdminRoleToText RoleUpdateMetadata = "updateMetadata"
 
 -- | Decode a CBOR-encoded 'TokenAdminRole'.
 decodeTokenAdminRole :: Decoder s TokenAdminRole
-decodeTokenAdminRole = do
-    role <- decodeString
-    case tokenAdminRoleFromText role of
-        Just r -> return r
-        Nothing -> fail $ "Unsupported role: " ++ show role
+decodeTokenAdminRole = decodeString >>= parseTokenAdminRoleFromText
 
 -- | Encode a 'TokenAdminRole' as CBOR.
 encodeTokenAdminRole :: TokenAdminRole -> Encoding
@@ -1821,6 +1829,27 @@ decodeTokenModuleState = decodeMap decodeVal build Map.empty
 --  be consumed in the parsing.
 tokenModuleStateFromBytes :: LBS.ByteString -> Either String TokenModuleState
 tokenModuleStateFromBytes = decodeFromBytes decodeTokenModuleState "token module state"
+
+-- * Token authorizations
+
+-- | The authorizations structure for a PLT.
+newtype TokenAuthorizations = TokenAuthorizations
+    { taMap :: Map.Map TokenAdminRole (Seq.Seq CborAccountAddress)
+    }
+    deriving newtype (Eq, Show, AE.ToJSON, AE.FromJSON)
+
+encodeTokenAuthorizations :: TokenAuthorizations -> Encoding
+encodeTokenAuthorizations (TokenAuthorizations m) =
+    encodeMapDeterministic $
+        Map.mapKeys (makeMapKeyEncoding . encodeTokenAdminRole) $
+            encodeSequence encodeCborAccountAddress <$> m
+
+decodeTokenAuthorizations :: Decoder s TokenAuthorizations
+decodeTokenAuthorizations = decodeMap decodeVal (Right . TokenAuthorizations) Map.empty
+  where
+    decodeVal key = do
+        role <- tokenAdminRoleFromText key
+        return $ mapValueDecoder key (decodeSequence decodeCborAccountAddress) (at role)
 
 -- * Token account state
 

--- a/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
+++ b/haskell-src/Concordium/Types/ProtocolLevelTokens/CBOR.hs
@@ -1233,6 +1233,12 @@ data TokenEvent
       Pause
     | -- | The execution of balance-changing operations was unpaused.
       Unpause
+    | -- | The token metadata reference was updated.
+      UpdateMetadataEvent !TokenMetadataUrl
+    | -- | Admin roles were assigned to an account.
+      AssignAdminRolesEvent !UpdateAdminRolesDetails
+    | -- | Admin roles were revoked from an account.
+      RevokeAdminRolesEvent !UpdateAdminRolesDetails
     deriving (Eq, Show)
 
 -- | CBOR-encode the details for the list update events in the form:
@@ -1282,6 +1288,27 @@ encodeTokenEvent = \case
             { eteType = TokenEventType "unpause",
               eteDetails = emptyEventDetails
             }
+    UpdateMetadataEvent meta ->
+        EncodedTokenEvent
+            { eteType = TokenEventType "updateMetadata",
+              eteDetails =
+                TokenEventDetails . BSS.toShort . CBOR.toStrictByteString $
+                    encodeTokenMetadataUrl meta
+            }
+    AssignAdminRolesEvent details ->
+        EncodedTokenEvent
+            { eteType = TokenEventType "assignAdminRoles",
+              eteDetails =
+                TokenEventDetails . BSS.toShort . CBOR.toStrictByteString $
+                    encodeUpdateAdminRolesDetails details
+            }
+    RevokeAdminRolesEvent details ->
+        EncodedTokenEvent
+            { eteType = TokenEventType "revokeAdminRoles",
+              eteDetails =
+                TokenEventDetails . BSS.toShort . CBOR.toStrictByteString $
+                    encodeUpdateAdminRolesDetails details
+            }
 
 -- | Decoder for the event details of the list update events.
 --  This is the "token-list-update-details" type in the CDDL schema.
@@ -1312,11 +1339,16 @@ decodeTokenEvent EncodedTokenEvent{..} = case tokenEventTypeBytes eteType of
     "removeDenyList" -> RemoveDenyListEvent <$> decodeTarget
     "pause" -> Pause <$ decodePauseUnpause
     "unpause" -> Unpause <$ decodePauseUnpause
+    "updateMetadata" -> UpdateMetadataEvent <$> decodeMetadata
+    "assignAdminRoles" -> AssignAdminRolesEvent <$> decodeRoleUpdate
+    "revokeAdminRoles" -> RevokeAdminRolesEvent <$> decodeRoleUpdate
     unknownType -> Left $ "token-event: unsupported event type: " ++ show unknownType
   where
     detailsLBS = LBS.fromStrict $ BSS.fromShort $ tokenEventDetailsBytes eteDetails
     decodeTarget = decodeFromBytes decodeTokenEventTarget "event details" detailsLBS
     decodePauseUnpause = decodeFromBytes decodeEmptyMap "event details" detailsLBS
+    decodeMetadata = decodeFromBytes decodeTokenMetadataUrl "event details" detailsLBS
+    decodeRoleUpdate = decodeFromBytes decodeUpdateAdminRolesDetails "event details" detailsLBS
 
 -- * Reject reasons
 

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -7,6 +7,7 @@ import qualified Codec.CBOR.Term as CBOR
 import Codec.CBOR.Write
 import qualified Codec.CBOR.Write as CBOR
 import qualified Concordium.Crypto.SHA256 as SHA256
+import Control.Monad
 import qualified Data.Aeson as AE
 import qualified Data.Aeson.KeyMap as AE
 import qualified Data.ByteString as BS
@@ -99,19 +100,36 @@ genTaggableMemo =
           CBORMemo <$> genMemo
         ]
 
+-- | A list of all 'TokenAdminRole's.
+allTokenAdminRoles :: [TokenAdminRole]
+allTokenAdminRoles =
+    [ RoleUpdateAdminRoles,
+      RoleMint,
+      RoleBurn,
+      RoleUpdateAllowList,
+      RoleUpdateDenyList,
+      RolePause,
+      RoleUpdateMetadata
+    ]
+
 -- | Generator for 'TokenAdminRole'.
 genTokenAdminRole :: Gen TokenAdminRole
-genTokenAdminRole =
-    elements
-        [ RoleUpdateAdminRoles,
-          RoleMint,
-          RoleBurn,
-          RoleUpdateAllowList,
-          RoleUpdateDenyList,
-          RolePause,
-          RoleUpdateMetadata
-        ]
+genTokenAdminRole = elements allTokenAdminRoles
 
+-- | Generate a 'TokenAuthorizationsMap' where each role may or may not be present
+--  with an arbitrary list of accounts.
+genTokenAuthorizationsMap :: Gen TokenAuthorizationsMap
+genTokenAuthorizationsMap = TokenAuthorizationsMap <$> foldM f Map.empty allTokenAdminRoles
+  where
+    f m role =
+        oneof
+            [ return m,
+              do
+                accts <- Seq.fromList <$> listOf genCborAccountAddress
+                return $ Map.insert role accts m
+            ]
+
+-- | Generator for 'UpdateAdminRolesDetails'.
 genUpdateAdminRolesDetails :: Gen UpdateAdminRolesDetails
 genUpdateAdminRolesDetails = do
     uardAccount <- genCborAccountAddress
@@ -464,6 +482,31 @@ tevents1 =
       Unpause
     ]
 
+-- | Example 'TokenEvent's introduced in P11.
+tevents2 :: [TokenEvent]
+tevents2 =
+    [ UpdateMetadataEvent $
+        TokenMetadataUrl
+            { tmUrl = "https://example.com/token-metadata",
+              tmChecksumSha256 = Just (SHA256.Hash (FBS.fromByteString "1234567890abcdef1234567890abcdef")),
+              tmAdditional =
+                Map.fromList
+                    [ ("key1", CBOR.TString "extravalue1"),
+                      ("key2", CBOR.TString "extravalue2")
+                    ]
+            },
+      AssignAdminRolesEvent $
+        UpdateAdminRolesDetails
+            { uardAccount = dummyCborHolder,
+              uardRoles = Seq.fromList [RoleMint, RoleBurn]
+            },
+      RevokeAdminRolesEvent $
+        UpdateAdminRolesDetails
+            { uardAccount = dummyCborHolder,
+              uardRoles = Seq.fromList [RoleUpdateAllowList, RoleUpdateDenyList]
+            }
+    ]
+
 -- | Encoded 'TokenHolderTransaction' that cannot be successfully CBOR decoded
 invalidEncTops1 :: EncodedTokenOperations
 invalidEncTops1 =
@@ -517,6 +560,11 @@ testEncodedTokenEvents = describe "TokenEvents CBOR serialization" $ do
             "Deserialized"
             (map (decodeTokenEvent . encodeTokenEvent) tevents1)
             (map Right tevents1)
+    it "Serialize/Deserialize roundtrip (P11)" $
+        assertEqual
+            "Deserialized"
+            (map (decodeTokenEvent . encodeTokenEvent) tevents2)
+            (map Right tevents2)
     it "Serializes to expected CBOR bytestring" $ do
         assertEqual
             "Serialized to expected CBOR bytestring"
@@ -546,6 +594,36 @@ testEncodedTokenEvents = describe "TokenEvents CBOR serialization" $ do
                 }
             ]
             (map encodeTokenEvent tevents1)
+    it "Serializes to expected CBOR bytestring (P11)" $ do
+        assertEqual
+            "Serialized to expected CBOR bytestring"
+            [ EncodedTokenEvent
+                { eteType = TokenEventType "updateMetadata",
+                  eteDetails =
+                    TokenEventDetails . BSS.toShort . BS16.decodeLenient $
+                        "a46375726c782268747470733a2f2f6578616d706c652e636f6d2f746f6b656e\
+                        \2d6d65746164617461646b6579316b657874726176616c756531646b6579326b\
+                        \657874726176616c7565326e636865636b73756d536861323536582031323334\
+                        \35363738393061626364656631323334353637383930616263646566"
+                },
+              EncodedTokenEvent
+                { eteType = TokenEventType "assignAdminRoles",
+                  eteDetails =
+                    TokenEventDetails . BSS.toShort . BS16.decodeLenient $
+                        "a265726f6c657382646d696e74646275726e676163636f756e74d99d73a201d9\
+                        \9d71a10119039703582001010101010101010101010101010101010101010101\
+                        \01010101010101010101"
+                },
+              EncodedTokenEvent
+                { eteType = TokenEventType "revokeAdminRoles",
+                  eteDetails =
+                    TokenEventDetails . BSS.toShort . BS16.decodeLenient $
+                        "a265726f6c6573826f757064617465416c6c6f774c6973746e75706461746544\
+                        \656e794c697374676163636f756e74d99d73a201d99d71a10119039703582001\
+                        \01010101010101010101010101010101010101010101010101010101010101"
+                }
+            ]
+            (map encodeTokenEvent tevents2)
 
 emptyStringHash :: Hash.Hash
 emptyStringHash = Hash.hash ""
@@ -965,6 +1043,71 @@ testTokenMetadataUrlCBOR = describe "TokenMetadataUrl CBOR serialization" $ do
                 "\xA4\x63\x75\x72\x6C\x76\x68\x74\x74\x70\x73\x3A\x2F\x2F\x61\x62\x63\x2E\x74\x6F\x6B\x65\x6E\x2F\x6D\x65\x74\x61\x6E\x63\x68\x65\x63\x6B\x73\x75\x6D\x53\x68\x61\x32\x35\x36\x58\x20\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\xAB\x64\x6B\x65\x79\x31\x18\x2A\x64\x6B\x65\x79\x32\x6B\x65\x78\x74\x72\x61\x20\x76\x61\x6C\x75\x65"
             )
 
+-- | An example 'TokenAuthorizationsMap'.
+exampleTokenAuthorizationsMap :: TokenAuthorizationsMap
+exampleTokenAuthorizationsMap =
+    TokenAuthorizationsMap $
+        Map.fromList
+            [ (RoleUpdateAdminRoles, Seq.empty),
+              (RolePause, Seq.fromList [accountTokenHolder acc1, accountTokenHolderShort acc2])
+            ]
+  where
+    acc1 = AccountAddress $ FBS.pack $ repeat 0
+    acc2 = AccountAddress $ FBS.pack $ repeat 1
+
+-- | The Base-16 CBOR encoding of 'exampleTokenAuthorizationsMap'.
+exampleTokenAuthorizationsMapCBOR :: BS.ByteString
+exampleTokenAuthorizationsMapCBOR =
+    "a265706175736582d99d73a201d99d71a1011903970358200000000000000000\
+    \000000000000000000000000000000000000000000000000d99d73a103582001\
+    \0101010101010101010101010101010101010101010101010101010101010170\
+    \75706461746541646d696e526f6c657380"
+
+-- | The JSON encoding of 'exampleTokenAuthorizationsMap'.
+exampleTokenAuthorizationsMapJSON :: B8.ByteString
+exampleTokenAuthorizationsMapJSON =
+    "{\"updateAdminRoles\":[],\
+    \\"pause\":[\
+    \{\"address\":\"2wkBET2rRgE8pahuaczxKbmv7ciehqsne57F9gtzf1PVdr2VP3\",\
+    \\"coinInfo\":\"CCD\",\"type\":\"account\"},\
+    \{\"address\":\"2xBpaHottqhwFZURMZW4uZduQvpxNDSy46iXMYs9kceNGaPpZX\",\"type\":\"account\"}]}"
+
+-- | Test the CBOR encoding and decoding of 'TokenAuthorizationsMap'.
+testTokenAuthorizationsMapCBOR :: Spec
+testTokenAuthorizationsMapCBOR = describe "TokenAuthorizationsMap CBOR" $ do
+    it "Encode example" $
+        assertEqual
+            "Encoded"
+            exampleTokenAuthorizationsMapCBOR
+            (BS16.encode $ tokenAuthorizationsMapToBytes exampleTokenAuthorizationsMap)
+    it "Decode example" $
+        assertEqual
+            "Decoded"
+            (Right exampleTokenAuthorizationsMap)
+            ( tokenAuthorizationsMapFromBytes . BS.fromStrict . BS16.decodeLenient $
+                exampleTokenAuthorizationsMapCBOR
+            )
+    it "Random examples" $ withMaxSuccess 1000 $ forAll genTokenAuthorizationsMap $ \tam ->
+        Right tam
+            === tokenAuthorizationsMapFromBytes (BS.fromStrict $ tokenAuthorizationsMapToBytes tam)
+
+-- | Test the JSON encoding and decoding of 'TokenAuthorizationsMap'.
+testTokenAuthorizationsMapJSON :: Spec
+testTokenAuthorizationsMapJSON = describe "TokenAuthorizationsMap JSON" $ do
+    it "Serialize example" $
+        assertEqual
+            "Serialized"
+            exampleTokenAuthorizationsMapJSON
+            (AE.encode exampleTokenAuthorizationsMap)
+    it "Deserialize example" $
+        assertEqual
+            "Deserialized"
+            (Just exampleTokenAuthorizationsMap)
+            (AE.decode exampleTokenAuthorizationsMapJSON)
+    it "Random examples" $ withMaxSuccess 1000 $ forAll genTokenAuthorizationsMap $ \tam ->
+        Just tam
+            === AE.decode (AE.encode tam)
+
 -- | A set of test vectors for CBOR decoding that use non-canonical representations.
 testTransactionVectors :: Spec
 testTransactionVectors = do
@@ -1091,6 +1234,8 @@ tests = parallel $ describe "CBOR" $ do
     testTokenModuleAccountStateJSON
     testTokenStateJSON
     testTokenModuleAccountStateCBOR
+    testTokenAuthorizationsMapCBOR
+    testTokenAuthorizationsMapJSON
     describe "UpdateTransaction test vectors" $ testTransactionVectors
     it "JSON (de-)serialization roundtrip for TokenState (simple)" $ withMaxSuccess 1000 $ forAll genTokenStateSimple $ \tt ->
         assertEqual

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -200,7 +200,10 @@ genTokenEvent =
           AddDenyListEvent <$> genCborAccountAddress,
           RemoveDenyListEvent <$> genCborAccountAddress,
           pure Pause,
-          pure Unpause
+          pure Unpause,
+          UpdateMetadataEvent <$> genTokenMetadataUrlSimple,
+          AssignAdminRolesEvent <$> genUpdateAdminRolesDetails,
+          RevokeAdminRolesEvent <$> genUpdateAdminRolesDetails
         ]
 
 -- | Generator for 'TokenRejectReason'.


### PR DESCRIPTION
## Purpose

Closes [RBC-25](https://linear.app/concordium/issue/RBC-25/add-rbac-events)

This adds new token module events with their CBOR encodings: `UpdateMetadataEvent`, `AssignAdminRolesEvent` and `RevokeAdminRolesEvent`. It also adds `TokenAuthorizationsMap` to represent the decoded contents of `TokenAuthorizations`.

## Changes

- Add new `TokenEvent`s.
- Add `TokenAuthorizationsMap`.
- CBOR encoding/decoding.
- Tests.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
