### PR TITLE
fix: dead code flagedd by node release pipeline. Adding deadcode tag …

### DIFF
--- a/rust-src/concordium_base/src/sigma_protocols/dlogaggequal.rs
+++ b/rust-src/concordium_base/src/sigma_protocols/dlogaggequal.rs
@@ -16,11 +16,13 @@ use crate::{
 use itertools::izip;
 use std::rc::Rc;
 
+#[allow(dead_code)]
 pub struct DlogAndAggregateDlogsEqual<C: Curve> {
     pub dlog: Dlog<C>,
     pub aggregate_dlogs: Vec<AggregateDlog<C>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 pub struct Response<C: Curve> {
     #[size_length = 4]

--- a/rust-src/concordium_base/src/sigma_protocols/dlogeq.rs
+++ b/rust-src/concordium_base/src/sigma_protocols/dlogeq.rs
@@ -14,6 +14,7 @@ use crate::{
     },
 };
 
+#[allow(dead_code)]
 struct DlogEqual<C: Curve> {
     dlog1: Dlog<C>,
     dlog2: Dlog<C>,


### PR DESCRIPTION

## Purpose

fix dead code errors on node release pipeline for mac OS

## Changes

The node release pipeline has flaggged the following errors for building concordium base, during the `node-macos` build step. 

Added deadcode for now to these 3 structures as they are never constructed.

<img width="1950" height="1004" alt="image" src="https://github.com/user-attachments/assets/0dffc5e1-5d44-428c-a4b3-fb011cb36c2e" />



## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
