### PR TITLE
Revert "fix: dead code flagedd by node release pipeline. Adding deadcode tag …"

### DIFF
--- a/rust-src/concordium_base/src/sigma_protocols/dlogaggequal.rs
+++ b/rust-src/concordium_base/src/sigma_protocols/dlogaggequal.rs
@@ -16,13 +16,11 @@ use crate::{
 use itertools::izip;
 use std::rc::Rc;
 
-#[allow(dead_code)]
 pub struct DlogAndAggregateDlogsEqual<C: Curve> {
     pub dlog: Dlog<C>,
     pub aggregate_dlogs: Vec<AggregateDlog<C>>,
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Serialize)]
 pub struct Response<C: Curve> {
     #[size_length = 4]

--- a/rust-src/concordium_base/src/sigma_protocols/dlogeq.rs
+++ b/rust-src/concordium_base/src/sigma_protocols/dlogeq.rs
@@ -14,7 +14,6 @@ use crate::{
     },
 };
 
-#[allow(dead_code)]
 struct DlogEqual<C: Curve> {
     dlog1: Dlog<C>,
     dlog2: Dlog<C>,


### PR DESCRIPTION
Reverts Concordium/concordium-base#907