### PR TITLE
Add type TokenAuthorizations with CBOR encoding

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Introduce `TokenAuthorizations` representing the CBOR encoding of the `getTokenAuthorizations` query.
 - Implemented definition for `UpdateMetadata` token operation and token event which allows to update the metadata of a protocol level token.
 - Implemented definition for `TokenAdminRole` which describes the list of supported roles.
   Implemented `assignAdminRoles` and `revokeAdminRoles` token operations for RBAC too.

--- a/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/mod.rs
@@ -2,6 +2,7 @@
 
 mod cbor;
 mod token_amount;
+mod token_authorizations;
 mod token_event;
 mod token_holder;
 mod token_id;
@@ -15,6 +16,7 @@ mod token_reject_reason;
 
 pub use cbor::*;
 pub use token_amount::*;
+pub use token_authorizations::*;
 pub use token_event::*;
 pub use token_holder::*;
 pub use token_id::*;

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
@@ -1,0 +1,57 @@
+use crate::protocol_level_tokens::CborHolderAccount;
+use concordium_base_derive::{CborDeserialize, CborSerialize};
+
+/// Describes the authorizations structure for protocol level tokens.
+#[derive(Debug, Clone, PartialEq, Eq, CborSerialize, CborDeserialize, Default)]
+pub struct TokenAuthorizations {
+    /// Gives authority to perform `token-assign-admin-roles` and `token-revoke-admin-roles` operations.
+    pub update_admin_roles: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-mint` operations.
+    pub mint: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-burn` operations.
+    pub burn: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-add-allow-list` and `token-remove-allow-list` operations.
+    pub update_allow_list: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-add-deny-list` and `token-remove-deny-list` operations.
+    pub update_deny_list: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-pause` and `token-unpause` operations.
+    pub pause: TokenRoleAuthorizationsCbor,
+    /// Gives authority to perform `token-update-metadata` operations.
+    pub update_metadata: TokenRoleAuthorizationsCbor,
+}
+
+/// Authorizations details applicable to any admin role.
+#[derive(Debug, Clone, PartialEq, Eq, CborSerialize, CborDeserialize, Default)]
+pub struct TokenRoleAuthorizationsCbor {
+    /// The accounts that have the role assigned.
+    pub accounts: Vec<CborHolderAccount>,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::cbor;
+    use concordium_contracts_common::AccountAddress;
+
+    #[test]
+    fn test_token_authorizations_cbor() {
+        let mut token_authorizations = TokenAuthorizations::default();
+
+        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a7646275726ea1686163636f756e747380646d696e74a1686163636f756e747380657061757365a1686163636f756e7473806e75706461746544656e794c697374a1686163636f756e7473806e7570646174654d65746164617461a1686163636f756e7473806f757064617465416c6c6f774c697374a1686163636f756e7473807075706461746541646d696e526f6c6573a1686163636f756e747380");
+
+        token_authorizations
+            .update_admin_roles
+            .accounts
+            .push(CborHolderAccount::from(AccountAddress([5u8; 32])));
+
+        token_authorizations
+            .pause
+            .accounts
+            .push(CborHolderAccount::from(AccountAddress([1u8; 32])));
+        token_authorizations
+            .pause
+            .accounts
+            .push(CborHolderAccount::from(AccountAddress([2u8; 32])));
+        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a7646275726ea1686163636f756e747380646d696e74a1686163636f756e747380657061757365a1686163636f756e747382d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101d99d73a201d99d71a10119039703582002020202020202020202020202020202020202020202020202020202020202026e75706461746544656e794c697374a1686163636f756e7473806e7570646174654d65746164617461a1686163636f756e7473806f757064617465416c6c6f774c697374a1686163636f756e7473807075706461746541646d696e526f6c6573a1686163636f756e747381d99d73a201d99d71a1011903970358200505050505050505050505050505050505050505050505050505050505050505");
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
@@ -1,103 +1,30 @@
-use crate::common::cbor::{CborDeserialize, CborSerialize};
 use crate::protocol_level_tokens::CborHolderAccount;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
-use concordium_contracts_common::AccountAddress;
 
 /// Describes the authorizations structure for protocol level tokens.
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
+#[derive(Debug, CborSerialize, CborDeserialize, Clone, Default)]
 pub struct TokenAuthorizations {
     /// Gives authority to perform `token-assign-admin-roles` and `token-revoke-admin-roles` operations.
-    pub update_admin_roles: Vec<AccountAddress>,
+    pub update_admin_roles: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-mint` operations.
-    pub mint: Vec<AccountAddress>,
+    pub mint: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-burn` operations.
-    pub burn: Vec<AccountAddress>,
+    pub burn: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-add-allow-list` and `token-remove-allow-list` operations.
-    pub update_allow_list: Vec<AccountAddress>,
+    pub update_allow_list: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-add-deny-list` and `token-remove-deny-list` operations.
-    pub update_deny_list: Vec<AccountAddress>,
+    pub update_deny_list: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-pause` and `token-unpause` operations.
-    pub pause: Vec<AccountAddress>,
+    pub pause: Option<TokenRoleAuthorizations>,
     /// Gives authority to perform `token-update-metadata` operations.
-    pub update_metadata: Vec<AccountAddress>,
+    pub update_metadata: Option<TokenRoleAuthorizations>,
 }
 
-impl CborSerialize for TokenAuthorizations {
-    fn serialize<C: crate::common::cbor::CborEncoder>(
-        &self,
-        encoder: C,
-    ) -> Result<(), C::WriteError> {
-        fn mapper(authorized: &[AccountAddress]) -> Option<TokenRoleAuthorizationsCbor> {
-            if authorized.is_empty() {
-                None
-            } else {
-                Some(TokenRoleAuthorizationsCbor {
-                    accounts: authorized
-                        .iter()
-                        .cloned()
-                        .map(CborHolderAccount::from)
-                        .collect(),
-                })
-            }
-        }
-        let model = TokenAuthorizationsCbor {
-            update_admin_roles: mapper(&self.update_admin_roles),
-            mint: mapper(&self.mint),
-            burn: mapper(&self.burn),
-            update_allow_list: mapper(&self.update_allow_list),
-            update_deny_list: mapper(&self.update_deny_list),
-            pause: mapper(&self.pause),
-            update_metadata: mapper(&self.update_metadata),
-        };
-        model.serialize(encoder)
-    }
-}
-impl CborDeserialize for TokenAuthorizations {
-    fn deserialize<C: crate::common::cbor::CborDecoder>(
-        decoder: C,
-    ) -> crate::common::cbor::CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
-        let model = TokenAuthorizationsCbor::deserialize(decoder)?;
-        fn mapper(authorized: Option<TokenRoleAuthorizationsCbor>) -> Vec<AccountAddress> {
-            if let Some(authorized) = authorized {
-                authorized
-                    .accounts
-                    .into_iter()
-                    .map(|holder| holder.address)
-                    .collect()
-            } else {
-                Vec::new()
-            }
-        }
-
-        Ok(Self {
-            update_admin_roles: mapper(model.update_admin_roles),
-            mint: mapper(model.mint),
-            burn: mapper(model.burn),
-            update_allow_list: mapper(model.update_allow_list),
-            update_deny_list: mapper(model.update_deny_list),
-            pause: mapper(model.pause),
-            update_metadata: mapper(model.update_metadata),
-        })
-    }
-}
-
-#[derive(Debug, CborSerialize, CborDeserialize)]
-struct TokenAuthorizationsCbor {
-    update_admin_roles: Option<TokenRoleAuthorizationsCbor>,
-    mint: Option<TokenRoleAuthorizationsCbor>,
-    burn: Option<TokenRoleAuthorizationsCbor>,
-    update_allow_list: Option<TokenRoleAuthorizationsCbor>,
-    update_deny_list: Option<TokenRoleAuthorizationsCbor>,
-    pause: Option<TokenRoleAuthorizationsCbor>,
-    update_metadata: Option<TokenRoleAuthorizationsCbor>,
-}
-
-#[derive(Debug, CborSerialize, CborDeserialize, Default)]
-struct TokenRoleAuthorizationsCbor {
-    accounts: Vec<CborHolderAccount>,
+/// The collection of entities holding a specific role.
+#[derive(Debug, CborSerialize, CborDeserialize, Clone, Default)]
+pub struct TokenRoleAuthorizations {
+    /// Accounts holding the role.
+    pub accounts: Vec<CborHolderAccount>,
 }
 
 #[cfg(test)]
@@ -112,12 +39,16 @@ mod test {
 
         assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a0");
 
-        token_authorizations
-            .update_admin_roles
-            .push(AccountAddress([5u8; 32]));
+        token_authorizations.update_admin_roles = Some(TokenRoleAuthorizations {
+            accounts: vec![AccountAddress([5u8; 32]).into()],
+        });
 
-        token_authorizations.pause.push(AccountAddress([1u8; 32]));
-        token_authorizations.pause.push(AccountAddress([2u8; 32]));
+        token_authorizations.pause = Some(TokenRoleAuthorizations {
+            accounts: vec![
+                AccountAddress([1u8; 32]).into(),
+                AccountAddress([2u8; 32]).into(),
+            ],
+        });
         assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a2657061757365a1686163636f756e747382d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101d99d73a201d99d71a10119039703582002020202020202020202020202020202020202020202020202020202020202027075706461746541646d696e526f6c6573a1686163636f756e747381d99d73a201d99d71a1011903970358200505050505050505050505050505050505050505050505050505050505050505");
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_authorizations.rs
@@ -1,30 +1,103 @@
+use crate::common::cbor::{CborDeserialize, CborSerialize};
 use crate::protocol_level_tokens::CborHolderAccount;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
+use concordium_contracts_common::AccountAddress;
 
 /// Describes the authorizations structure for protocol level tokens.
-#[derive(Debug, Clone, PartialEq, Eq, CborSerialize, CborDeserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
 pub struct TokenAuthorizations {
     /// Gives authority to perform `token-assign-admin-roles` and `token-revoke-admin-roles` operations.
-    pub update_admin_roles: TokenRoleAuthorizationsCbor,
+    pub update_admin_roles: Vec<AccountAddress>,
     /// Gives authority to perform `token-mint` operations.
-    pub mint: TokenRoleAuthorizationsCbor,
+    pub mint: Vec<AccountAddress>,
     /// Gives authority to perform `token-burn` operations.
-    pub burn: TokenRoleAuthorizationsCbor,
+    pub burn: Vec<AccountAddress>,
     /// Gives authority to perform `token-add-allow-list` and `token-remove-allow-list` operations.
-    pub update_allow_list: TokenRoleAuthorizationsCbor,
+    pub update_allow_list: Vec<AccountAddress>,
     /// Gives authority to perform `token-add-deny-list` and `token-remove-deny-list` operations.
-    pub update_deny_list: TokenRoleAuthorizationsCbor,
+    pub update_deny_list: Vec<AccountAddress>,
     /// Gives authority to perform `token-pause` and `token-unpause` operations.
-    pub pause: TokenRoleAuthorizationsCbor,
+    pub pause: Vec<AccountAddress>,
     /// Gives authority to perform `token-update-metadata` operations.
-    pub update_metadata: TokenRoleAuthorizationsCbor,
+    pub update_metadata: Vec<AccountAddress>,
 }
 
-/// Authorizations details applicable to any admin role.
-#[derive(Debug, Clone, PartialEq, Eq, CborSerialize, CborDeserialize, Default)]
-pub struct TokenRoleAuthorizationsCbor {
-    /// The accounts that have the role assigned.
-    pub accounts: Vec<CborHolderAccount>,
+impl CborSerialize for TokenAuthorizations {
+    fn serialize<C: crate::common::cbor::CborEncoder>(
+        &self,
+        encoder: C,
+    ) -> Result<(), C::WriteError> {
+        fn mapper(authorized: &[AccountAddress]) -> Option<TokenRoleAuthorizationsCbor> {
+            if authorized.is_empty() {
+                None
+            } else {
+                Some(TokenRoleAuthorizationsCbor {
+                    accounts: authorized
+                        .iter()
+                        .cloned()
+                        .map(CborHolderAccount::from)
+                        .collect(),
+                })
+            }
+        }
+        let model = TokenAuthorizationsCbor {
+            update_admin_roles: mapper(&self.update_admin_roles),
+            mint: mapper(&self.mint),
+            burn: mapper(&self.burn),
+            update_allow_list: mapper(&self.update_allow_list),
+            update_deny_list: mapper(&self.update_deny_list),
+            pause: mapper(&self.pause),
+            update_metadata: mapper(&self.update_metadata),
+        };
+        model.serialize(encoder)
+    }
+}
+impl CborDeserialize for TokenAuthorizations {
+    fn deserialize<C: crate::common::cbor::CborDecoder>(
+        decoder: C,
+    ) -> crate::common::cbor::CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        let model = TokenAuthorizationsCbor::deserialize(decoder)?;
+        fn mapper(authorized: Option<TokenRoleAuthorizationsCbor>) -> Vec<AccountAddress> {
+            if let Some(authorized) = authorized {
+                authorized
+                    .accounts
+                    .into_iter()
+                    .map(|holder| holder.address)
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        }
+
+        Ok(Self {
+            update_admin_roles: mapper(model.update_admin_roles),
+            mint: mapper(model.mint),
+            burn: mapper(model.burn),
+            update_allow_list: mapper(model.update_allow_list),
+            update_deny_list: mapper(model.update_deny_list),
+            pause: mapper(model.pause),
+            update_metadata: mapper(model.update_metadata),
+        })
+    }
+}
+
+#[derive(Debug, CborSerialize, CborDeserialize)]
+struct TokenAuthorizationsCbor {
+    update_admin_roles: Option<TokenRoleAuthorizationsCbor>,
+    mint: Option<TokenRoleAuthorizationsCbor>,
+    burn: Option<TokenRoleAuthorizationsCbor>,
+    update_allow_list: Option<TokenRoleAuthorizationsCbor>,
+    update_deny_list: Option<TokenRoleAuthorizationsCbor>,
+    pause: Option<TokenRoleAuthorizationsCbor>,
+    update_metadata: Option<TokenRoleAuthorizationsCbor>,
+}
+
+#[derive(Debug, CborSerialize, CborDeserialize, Default)]
+struct TokenRoleAuthorizationsCbor {
+    accounts: Vec<CborHolderAccount>,
 }
 
 #[cfg(test)]
@@ -37,21 +110,14 @@ mod test {
     fn test_token_authorizations_cbor() {
         let mut token_authorizations = TokenAuthorizations::default();
 
-        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a7646275726ea1686163636f756e747380646d696e74a1686163636f756e747380657061757365a1686163636f756e7473806e75706461746544656e794c697374a1686163636f756e7473806e7570646174654d65746164617461a1686163636f756e7473806f757064617465416c6c6f774c697374a1686163636f756e7473807075706461746541646d696e526f6c6573a1686163636f756e747380");
+        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a0");
 
         token_authorizations
             .update_admin_roles
-            .accounts
-            .push(CborHolderAccount::from(AccountAddress([5u8; 32])));
+            .push(AccountAddress([5u8; 32]));
 
-        token_authorizations
-            .pause
-            .accounts
-            .push(CborHolderAccount::from(AccountAddress([1u8; 32])));
-        token_authorizations
-            .pause
-            .accounts
-            .push(CborHolderAccount::from(AccountAddress([2u8; 32])));
-        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a7646275726ea1686163636f756e747380646d696e74a1686163636f756e747380657061757365a1686163636f756e747382d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101d99d73a201d99d71a10119039703582002020202020202020202020202020202020202020202020202020202020202026e75706461746544656e794c697374a1686163636f756e7473806e7570646174654d65746164617461a1686163636f756e7473806f757064617465416c6c6f774c697374a1686163636f756e7473807075706461746541646d696e526f6c6573a1686163636f756e747381d99d73a201d99d71a1011903970358200505050505050505050505050505050505050505050505050505050505050505");
+        token_authorizations.pause.push(AccountAddress([1u8; 32]));
+        token_authorizations.pause.push(AccountAddress([2u8; 32]));
+        assert_eq!(hex::encode(&cbor::cbor_encode(&token_authorizations)), "a2657061757365a1686163636f756e747382d99d73a201d99d71a1011903970358200101010101010101010101010101010101010101010101010101010101010101d99d73a201d99d71a10119039703582002020202020202020202020202020202020202020202020202020202020202027075706461746541646d696e526f6c6573a1686163636f756e747381d99d73a201d99d71a1011903970358200505050505050505050505050505050505050505050505050505050505050505");
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -345,7 +345,7 @@ impl From<CborMemo> for Memo {
 
 /// Defines roles that can be assigned or revoked for an account, for a protocol
 /// level token.
-#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)


### PR DESCRIPTION
## Purpose

Closing [COR-2340](https://linear.app/concordium/issue/COR-2340/implement-cbor-token-authorizations-in-base).

## Changes

- Add the `TokenAuthorizations` struct corresponding to the CDDL.
- Derive `Hash` for enum `TokenAdminRole` .
