### PR TITLE
Cor 2231/support rbac

### DIFF
--- a/.github/workflows/build-test-contracts-common.yaml
+++ b/.github/workflows/build-test-contracts-common.yaml
@@ -20,7 +20,7 @@ on:
 name: Clippy & fmt
 
 env:
-  RUST_VERSION: "1.85"
+  RUST_VERSION: "1.88"
 
 defaults:
   run:

--- a/.github/workflows/build-test-smart-contracts.yaml
+++ b/.github/workflows/build-test-smart-contracts.yaml
@@ -15,7 +15,7 @@ on:
   workflow_dispatch: # allows manual trigger
 
 env:
-  RUST_VERSION: 1.85
+  RUST_VERSION: 1.88
 
 jobs:
 

--- a/.github/workflows/build-test-sources.yaml
+++ b/.github/workflows/build-test-sources.yaml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.85
+        - rust: 1.88
         crates:
         - rust-src
         - rust-bins
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         plan:
-        - rust: 1.85
+        - rust: 1.88
         crates:
         - rust-src
         - rust-bins
@@ -143,7 +143,7 @@ jobs:
       matrix:
         plan:
         - ghc: 9.10.2 # used as cache key only; stack uses the one specified in stack.yaml
-          rust: 1.85
+          rust: 1.88
 
     steps:
     - name: Checkout


### PR DESCRIPTION
## Purpose
upgrading rust version to 1.88 as the rust sdk on feature/p11-rbac workflow is pointing to this and failing due to a lower rust version than expected (based on the log)

## Changes
workflows updated to 1.88

## Checklist

- [ x ] My code follows the style of this project.
- [ x ] The code compiles without warnings.
- [ x ] I have performed a self-review of the changes.
- [ x ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
