### PR TITLE
Rust types for node locks state

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -1,4 +1,13 @@
 ## Unreleased
+
+- Added `protocol_level_locks` module with types for PLT locks:
+  - `LockId`
+  - `LockConfig`
+  - `LockController`
+  - `LockControllerSimpleV0`
+  - `LockControllerSimpleV0Grant`
+  - `LockControllerSimpleV0Capability`
+- Added CBOR serialization for `TransactionTime` and `TokenId`.
 - Implemented `common::from_bytes_complete` that fails if all bytes are not consumed during deserialization.
 - `cbor::cbor_encode` is now infallible and returns `Vec<u8>` instead of `CborSerializationResult<Vec<u8>>`
 - `&[T]` no longer implements `CborSerialize` in order to avoid ambiguity with `CborSerialize` implementation for `[u8]`. 

--- a/rust-src/concordium_base/src/base.rs
+++ b/rust-src/concordium_base/src/base.rs
@@ -330,7 +330,9 @@ pub struct Round {
 #[repr(transparent)]
 #[derive(SerdeSerialize, SerdeDeserialize, Serialize)]
 #[serde(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, FromStr, Display, From, Into)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, FromStr, Display, From, Into,
+)]
 /// A sequence number ordering transactions from a specific account. The initial
 /// sequence number is `1`, and a transaction with sequence number `m` must be
 /// followed by a transaction with sequence number `m+1`.
@@ -552,7 +554,9 @@ impl AbsoluteBlockHeight {
 #[repr(transparent)]
 #[derive(SerdeSerialize, SerdeDeserialize, Serialize)]
 #[serde(transparent)]
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug, FromStr, Display, From, Into)]
+#[derive(
+    Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Debug, FromStr, Display, From, Into,
+)]
 /// Index of the account in the account table. These are assigned sequentially
 /// in the order of creation of accounts. The first account has index 0.
 pub struct AccountIndex {

--- a/rust-src/concordium_base/src/common/types.rs
+++ b/rust-src/concordium_base/src/common/types.rs
@@ -6,6 +6,7 @@ use super::{
 };
 use crate::common::Serialize;
 use byteorder::{BigEndian, ReadBytesExt};
+use concordium_base_derive::{CborDeserialize, CborSerialize};
 use concordium_contracts_common::{
     self as concordium_std, ContractAddress, ContractName, OwnedContractName, OwnedParameter,
     OwnedReceiveName, Parameter, ReceiveName,
@@ -479,11 +480,27 @@ impl Deserial for TransactionSignaturesV1 {
     }
 }
 
+/// CBOR tag for epoch-based date/time, see
+/// <https://www.rfc-editor.org/rfc/rfc8949.html#name-standard-date-time-string>
+const EPOCH_TIME_TAG: u64 = 1;
+
 /// Datatype used to indicate transaction expiry.
 #[derive(
-    SerdeDeserialize, SerdeSerialize, PartialEq, Eq, Debug, Serialize, Clone, Copy, PartialOrd, Ord,
+    SerdeDeserialize,
+    SerdeSerialize,
+    PartialEq,
+    Eq,
+    Debug,
+    Serialize,
+    Clone,
+    Copy,
+    PartialOrd,
+    Ord,
+    CborSerialize,
+    CborDeserialize,
 )]
 #[serde(transparent)]
+#[cbor(transparent, tag = EPOCH_TIME_TAG)]
 pub struct TransactionTime {
     /// Seconds since the unix epoch.
     pub seconds: u64,
@@ -707,6 +724,45 @@ mod tests {
         assert!(
             serde_json::from_str::<Amount>(r#""12345612312315415123123""#).is_err(),
             "Parsed overflowing amount, but should not."
+        );
+    }
+
+    /// Round-trip test for [`TransactionTime`] CBOR encoding:
+    /// encode then decode produces the identical value.
+    #[test]
+    fn transaction_time_cbor_round_trip() {
+        use crate::common::cbor;
+
+        let tt = TransactionTime::from_seconds(1804806000);
+        let encoded = cbor::cbor_encode(&tt);
+        let decoded: TransactionTime = cbor::cbor_decode(&encoded).unwrap();
+        assert_eq!(tt, decoded, "round-trip failed for TransactionTime");
+
+        // Also test with 0 and u64::MAX as edge cases
+        for seconds in [0u64, 1u64, u64::MAX] {
+            let tt = TransactionTime::from_seconds(seconds);
+            let encoded = cbor::cbor_encode(&tt);
+            let decoded: TransactionTime = cbor::cbor_decode(&encoded).unwrap();
+            assert_eq!(tt, decoded, "round-trip failed for seconds={}", seconds);
+        }
+    }
+
+    /// Fixture test: known [`TransactionTime`] value produces an expected CBOR
+    /// hex string. This guards against accidental encoding changes.
+    ///
+    /// `TransactionTime::from_seconds(1804806000)` → `c11a6b932770`
+    ///   - `c1`         = CBOR tag 1 (epoch-time)
+    ///   - `1a6b932770` = CBOR uint 1804806000 (4-byte encoding, 0x6b932770)
+    #[test]
+    fn transaction_time_cbor_fixture() {
+        use crate::common::cbor;
+
+        let tt = TransactionTime::from_seconds(1804806000);
+        let encoded = cbor::cbor_encode(&tt);
+        assert_eq!(
+            hex::encode(&encoded),
+            "c11a6b932770",
+            "CBOR encoding of TransactionTime(1804806000) does not match expected fixture"
         );
     }
 }

--- a/rust-src/concordium_base/src/lib.rs
+++ b/rust-src/concordium_base/src/lib.rs
@@ -7,6 +7,7 @@ pub mod cis4_types;
 pub mod constants;
 pub mod hashes;
 mod internal;
+pub mod protocol_level_locks;
 pub mod protocol_level_tokens;
 pub mod smart_contracts;
 pub mod transactions;

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
@@ -8,11 +8,6 @@ use concordium_base_derive::{CborDeserialize, CborSerialize};
 /// Contains the list of recipients, the expiry time, and the controller
 /// configuration for a lock.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub struct LockConfig {
     /// Accounts that can receive funds from this lock.
     pub recipients: Vec<CborHolderAccount>,

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
@@ -1,0 +1,153 @@
+use super::LockController;
+use crate::common::types::TransactionTime;
+use crate::protocol_level_tokens::CborHolderAccount;
+use concordium_base_derive::{CborDeserialize, CborSerialize};
+
+/// Top-level lock configuration.
+///
+/// Contains the list of recipients, the expiry time, and the controller
+/// configuration for a lock.
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub struct LockConfig {
+    /// Accounts that can receive funds from this lock.
+    pub recipients: Vec<CborHolderAccount>,
+    /// Expiry time of the lock (seconds since epoch).
+    pub expiry: TransactionTime,
+    /// Controller configuration for the lock.
+    pub controller: LockController,
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::cbor;
+    use crate::protocol_level_locks::{
+        LockControllerSimpleV0, LockControllerSimpleV0Capability, LockControllerSimpleV0Grant,
+    };
+    use crate::protocol_level_tokens::test_fixtures::ADDRESS;
+
+    /// Build a full `LockConfig` for testing.
+    fn example_lock_config() -> LockConfig {
+        LockConfig {
+            recipients: vec![CborHolderAccount::from(ADDRESS)],
+            expiry: TransactionTime::from_seconds(1804806000),
+            controller: LockController::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![LockControllerSimpleV0Grant {
+                    account: CborHolderAccount::from(ADDRESS),
+                    roles: vec![
+                        LockControllerSimpleV0Capability::Fund,
+                        LockControllerSimpleV0Capability::Send,
+                    ],
+                }],
+                tokens: vec!["CCD".parse().unwrap()],
+                keep_alive: false,
+                memo: None,
+            }),
+        }
+    }
+
+    /// Round-trip test: encode then decode produces the same `LockConfig`.
+    #[test]
+    fn test_lock_config_cbor_round_trip() {
+        let config = example_lock_config();
+        let encoded = cbor::cbor_encode(&config);
+        let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, config);
+    }
+
+    /// Round-trip test with multiple recipients.
+    #[test]
+    fn test_lock_config_cbor_round_trip_multiple_recipients() {
+        let mut config = example_lock_config();
+        config.recipients.push(CborHolderAccount::from(ADDRESS));
+        let encoded = cbor::cbor_encode(&config);
+        let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, config);
+    }
+
+    /// Round-trip test with empty recipients.
+    #[test]
+    fn test_lock_config_cbor_round_trip_empty_recipients() {
+        let mut config = example_lock_config();
+        config.recipients = vec![];
+        let encoded = cbor::cbor_encode(&config);
+        let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, config);
+    }
+
+    /// Fixture test: verify the exact CBOR encoding of a `LockConfig`.
+    ///
+    /// Expected CBOR structure (diagnostic notation):
+    /// ```text
+    /// {
+    ///   "expiry": 1(1804806000),
+    ///   "controller": {"simpleV0": {"grants": [], "tokens": [], "keepAlive": false}},
+    ///   "recipients": [40307({1: 40305({1: 919}), 3: h'0102...1f20'})]
+    /// }
+    /// ```
+    ///
+    /// Map keys sorted by encoded byte length, then lexicographically:
+    /// - "expiry" (6 bytes)
+    /// - "controller" (10 bytes)
+    /// - "recipients" (10 bytes) — same length as "controller", sorted
+    ///   lexicographically
+    #[test]
+    fn test_lock_config_cbor_fixture() {
+        let config = LockConfig {
+            recipients: vec![CborHolderAccount::from(ADDRESS)],
+            expiry: TransactionTime::from_seconds(1804806000),
+            controller: LockController::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![],
+                tokens: vec![],
+                keep_alive: false,
+                memo: None,
+            }),
+        };
+        let encoded = cbor::cbor_encode(&config);
+        // Build expected hex:
+        //
+        // Map(3): a3
+        //
+        // Keys sorted by encoded byte length, then lexicographically:
+        // "expiry" (6 bytes) → 666578706972790
+        // "controller" (10 bytes) → 6a636f6e74726f6c6c6572
+        // "recipients" (10 bytes) → 6a726563697069656e7473
+        //
+        // Values:
+        // expiry: 1(1804806000) → c11a6b932770
+        // controller: {"simpleV0": {grants: [], tokens: [], keepAlive: false}}
+        //   Map(1): a1
+        //     "simpleV0" (8): 6873696d706c655630
+        //     Map(3): a3
+        //       "grants" (6): 666772616e7473, []: 80
+        //       "tokens" (6): 66746f6b656e73, []: 80
+        //       "keepAlive" (9): 696b656570416c697665, false: f4
+        // recipients: [CborHolderAccount]
+        //   Array(1): 81
+        //   CborHolderAccount: d99d73a201d99d71a1011903970358200102...1f20
+        let expected = concat!(
+            "a3",                       // map(3)
+            "66657870697279",           // text "expiry"
+            "c11a6b932770",             // tag(1) uint(1804806000)
+            "6a636f6e74726f6c6c6572",   // text "controller"
+            "a1",                       // map(1) — LockController
+            "6873696d706c655630",       // text "simpleV0"
+            "a3",                       // map(3) — LockControllerSimpleV0
+            "666772616e7473",           // text "grants"
+            "80",                       // array(0)
+            "66746f6b656e73",           // text "tokens"
+            "80",                       // array(0)
+            "696b656570416c697665",     // text "keepAlive"
+            "f4",                       // false
+            "6a726563697069656e7473",   // text "recipients"
+            "81",                       // array(1)
+            "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
@@ -45,7 +45,7 @@ mod test {
                     ],
                 }],
                 tokens: vec!["CCD".parse().unwrap()],
-                keep_alive: false,
+                keep_alive: None,
                 memo: None,
             }),
         }
@@ -86,7 +86,7 @@ mod test {
     /// ```text
     /// {
     ///   "expiry": 1(1804806000),
-    ///   "controller": {"simpleV0": {"grants": [], "tokens": [], "keepAlive": false}},
+    ///   "controller": {"simpleV0": {"grants": [], "tokens": []}},
     ///   "recipients": [40307({1: 40305({1: 919}), 3: h'0102...1f20'})]
     /// }
     /// ```
@@ -96,6 +96,9 @@ mod test {
     /// - "controller" (10 bytes)
     /// - "recipients" (10 bytes) — same length as "controller", sorted
     ///   lexicographically
+    ///
+    /// Note: `keep_alive: None` and `memo: None` are omitted by the derive
+    /// macro, so the inner `LockControllerSimpleV0` map has only 2 entries.
     #[test]
     fn test_lock_config_cbor_fixture() {
         let config = LockConfig {
@@ -104,7 +107,7 @@ mod test {
             controller: LockController::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
                 tokens: vec![],
-                keep_alive: false,
+                keep_alive: None,
                 memo: None,
             }),
         };
@@ -114,19 +117,18 @@ mod test {
         // Map(3): a3
         //
         // Keys sorted by encoded byte length, then lexicographically:
-        // "expiry" (6 bytes) → 666578706972790
+        // "expiry" (6 bytes) → 66657870697279
         // "controller" (10 bytes) → 6a636f6e74726f6c6c6572
         // "recipients" (10 bytes) → 6a726563697069656e7473
         //
         // Values:
         // expiry: 1(1804806000) → c11a6b932770
-        // controller: {"simpleV0": {grants: [], tokens: [], keepAlive: false}}
+        // controller: {"simpleV0": {grants: [], tokens: []}}
         //   Map(1): a1
         //     "simpleV0" (8): 6873696d706c655630
-        //     Map(3): a3
+        //     Map(2): a2
         //       "grants" (6): 666772616e7473, []: 80
         //       "tokens" (6): 66746f6b656e73, []: 80
-        //       "keepAlive" (9): 696b656570416c697665, false: f4
         // recipients: [CborHolderAccount]
         //   Array(1): 81
         //   CborHolderAccount: d99d73a201d99d71a1011903970358200102...1f20
@@ -137,13 +139,11 @@ mod test {
             "6a636f6e74726f6c6c6572",   // text "controller"
             "a1",                       // map(1) — LockController
             "6873696d706c655630",       // text "simpleV0"
-            "a3",                       // map(3) — LockControllerSimpleV0
+            "a2",                       // map(2) — LockControllerSimpleV0
             "666772616e7473",           // text "grants"
             "80",                       // array(0)
             "66746f6b656e73",           // text "tokens"
             "80",                       // array(0)
-            "696b656570416c697665",     // text "keepAlive"
-            "f4",                       // false
             "6a726563697069656e7473",   // text "recipients"
             "81",                       // array(1)
             "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
@@ -6,11 +6,6 @@ use concordium_base_derive::{CborDeserialize, CborSerialize};
 /// Each variant represents a different controller version.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
 #[cbor(map)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub enum LockController {
     /// SimpleV0 lock controller configuration.
     SimpleV0(LockControllerSimpleV0),

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
@@ -1,0 +1,101 @@
+use super::LockControllerSimpleV0;
+use concordium_base_derive::{CborDeserialize, CborSerialize};
+
+/// Top-level lock controller type.
+///
+/// Each variant represents a different controller version.
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+#[cbor(map)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub enum LockController {
+    /// SimpleV0 lock controller configuration.
+    SimpleV0(LockControllerSimpleV0),
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::cbor;
+    use crate::protocol_level_locks::{
+        LockControllerSimpleV0Capability, LockControllerSimpleV0Grant,
+    };
+    use crate::protocol_level_tokens::test_fixtures::ADDRESS;
+    use crate::protocol_level_tokens::CborHolderAccount;
+
+    /// Round-trip test for `LockController::SimpleV0` with a full
+    /// configuration.
+    #[test]
+    fn test_lock_controller_cbor_round_trip() {
+        let controller = LockController::SimpleV0(LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: CborHolderAccount::from(ADDRESS),
+                roles: vec![
+                    LockControllerSimpleV0Capability::Fund,
+                    LockControllerSimpleV0Capability::Send,
+                ],
+            }],
+            tokens: vec!["CCD".parse().unwrap()],
+            keep_alive: false,
+            memo: None,
+        });
+        let encoded = cbor::cbor_encode(&controller);
+        let decoded: LockController = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, controller);
+    }
+
+    /// Round-trip test for `LockController::SimpleV0` with minimal
+    /// configuration (empty grants and tokens).
+    #[test]
+    fn test_lock_controller_cbor_round_trip_minimal() {
+        let controller = LockController::SimpleV0(LockControllerSimpleV0 {
+            grants: vec![],
+            tokens: vec![],
+            keep_alive: false,
+            memo: None,
+        });
+        let encoded = cbor::cbor_encode(&controller);
+        let decoded: LockController = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, controller);
+    }
+
+    /// Fixture test: `LockController::SimpleV0` wraps the inner value in a
+    /// single-entry CBOR map with key `"simpleV0"`.
+    ///
+    /// Expected CBOR structure (diagnostic notation):
+    /// ```text
+    /// {"simpleV0": {"grants": [], "tokens": [], "keepAlive": false}}
+    /// ```
+    ///
+    /// Map(1): a1
+    ///   key "simpleV0" (8 bytes): 6873696d706c655630
+    ///   value: Map(3) for LockControllerSimpleV0 with empty grants/tokens
+    ///     "grants" (6): 666772616e7473, value []: 80
+    ///     "tokens" (6): 66746f6b656e73, value []: 80
+    ///     "keepAlive" (9): 696b656570416c697665, value false: f4
+    #[test]
+    fn test_lock_controller_cbor_fixture() {
+        let controller = LockController::SimpleV0(LockControllerSimpleV0 {
+            grants: vec![],
+            tokens: vec![],
+            keep_alive: false,
+            memo: None,
+        });
+        let encoded = cbor::cbor_encode(&controller);
+        let expected = concat!(
+            "a1",                   // map(1)
+            "6873696d706c655630",   // text "simpleV0"
+            "a3",                   // map(3) — inner LockControllerSimpleV0
+            "666772616e7473",       // text "grants"
+            "80",                   // array(0)
+            "66746f6b656e73",       // text "tokens"
+            "80",                   // array(0)
+            "696b656570416c697665", // text "keepAlive"
+            "f4",                   // false
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
@@ -39,7 +39,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: false,
+            keep_alive: None,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);
@@ -54,7 +54,7 @@ mod test {
         let controller = LockController::SimpleV0(LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: false,
+            keep_alive: None,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);
@@ -67,34 +67,34 @@ mod test {
     ///
     /// Expected CBOR structure (diagnostic notation):
     /// ```text
-    /// {"simpleV0": {"grants": [], "tokens": [], "keepAlive": false}}
+    /// {"simpleV0": {"grants": [], "tokens": []}}
     /// ```
     ///
     /// Map(1): a1
     ///   key "simpleV0" (8 bytes): 6873696d706c655630
-    ///   value: Map(3) for LockControllerSimpleV0 with empty grants/tokens
+    ///   value: Map(2) for LockControllerSimpleV0 with empty grants/tokens
     ///     "grants" (6): 666772616e7473, value []: 80
     ///     "tokens" (6): 66746f6b656e73, value []: 80
-    ///     "keepAlive" (9): 696b656570416c697665, value false: f4
+    ///
+    /// Note: `keep_alive: None` and `memo: None` are omitted by the derive
+    /// macro.
     #[test]
     fn test_lock_controller_cbor_fixture() {
         let controller = LockController::SimpleV0(LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: false,
+            keep_alive: None,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);
         let expected = concat!(
-            "a1",                   // map(1)
-            "6873696d706c655630",   // text "simpleV0"
-            "a3",                   // map(3) — inner LockControllerSimpleV0
-            "666772616e7473",       // text "grants"
-            "80",                   // array(0)
-            "66746f6b656e73",       // text "tokens"
-            "80",                   // array(0)
-            "696b656570416c697665", // text "keepAlive"
-            "f4",                   // false
+            "a1",                 // map(1)
+            "6873696d706c655630", // text "simpleV0"
+            "a2",                 // map(2) — inner LockControllerSimpleV0
+            "666772616e7473",     // text "grants"
+            "80",                 // array(0)
+            "66746f6b656e73",     // text "tokens"
+            "80",                 // array(0)
         );
         assert_eq!(hex::encode(&encoded), expected);
     }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -2,6 +2,8 @@ use crate::common::cbor::{
     CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
     CborSerialize,
 };
+use crate::protocol_level_tokens::CborHolderAccount;
+use concordium_base_derive::{CborDeserialize, CborSerialize};
 
 /// Capability that can be granted to an account for a SimpleV0 lock
 /// controller.
@@ -66,10 +68,30 @@ impl CborDeserialize for LockControllerSimpleV0Capability {
     }
 }
 
+/// A grant of capabilities to a specific account for a SimpleV0 lock
+/// controller.
+///
+/// Each grant assigns one or more [`LockControllerSimpleV0Capability`] roles
+/// to the given account, authorizing it to perform the corresponding lock
+/// operations.
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub struct LockControllerSimpleV0Grant {
+    /// The account receiving the grant.
+    pub account: CborHolderAccount,
+    /// The capabilities granted to the account.
+    pub roles: Vec<LockControllerSimpleV0Capability>,
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::common::cbor;
+    use crate::protocol_level_tokens::test_fixtures::ADDRESS;
 
     /// Round-trip test for all `LockControllerSimpleV0Capability` variants.
     #[test]
@@ -114,5 +136,68 @@ mod test {
     fn test_capability_cbor_fixture_cancel() {
         let encoded = cbor::cbor_encode(&LockControllerSimpleV0Capability::Cancel);
         assert_eq!(hex::encode(&encoded), "6663616e63656c");
+    }
+
+    /// Round-trip test for `LockControllerSimpleV0Grant` with an account and
+    /// multiple roles.
+    #[test]
+    fn test_grant_cbor_round_trip() {
+        let grant = LockControllerSimpleV0Grant {
+            account: CborHolderAccount::from(ADDRESS),
+            roles: vec![
+                LockControllerSimpleV0Capability::Fund,
+                LockControllerSimpleV0Capability::Send,
+            ],
+        };
+        let encoded = cbor::cbor_encode(&grant);
+        let decoded: LockControllerSimpleV0Grant =
+            cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, grant);
+    }
+
+    /// Fixture test for `LockControllerSimpleV0Grant` with a known account
+    /// address and roles `[Fund, Cancel]`.
+    ///
+    /// Expected CBOR structure (diagnostic notation):
+    /// ```text
+    /// {
+    ///   "roles": ["fund", "cancel"],
+    ///   "account": 40307({1: 40305({1: 919}), 3: h'0102...1f20'})
+    /// }
+    /// ```
+    ///
+    /// Note: CBOR map keys are ordered by length (deterministic encoding),
+    /// so `"roles"` (5 bytes) appears before `"account"` (7 bytes).
+    #[test]
+    fn test_grant_cbor_fixture() {
+        let grant = LockControllerSimpleV0Grant {
+            account: CborHolderAccount::from(ADDRESS),
+            roles: vec![
+                LockControllerSimpleV0Capability::Fund,
+                LockControllerSimpleV0Capability::Cancel,
+            ],
+        };
+        let encoded = cbor::cbor_encode(&grant);
+        // Build expected hex:
+        // Map(2) with text keys "account" and "roles"
+        // "account" value: CborHolderAccount(ADDRESS) with coin_info = Some(CCD)
+        //   Known encoding: d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+        // "roles" value: Array(2) ["fund", "cancel"]
+        //   "fund" = 6466756e64, "cancel" = 6663616e63656c
+        //   Array(2): 82 6466756e64 6663616e63656c
+        //
+        // Map(2): a2
+        //   key "account" (7 bytes): 67 6163636f756e74
+        //   key "roles" (5 bytes):   65 726f6c6573
+        let expected = concat!(
+            "a2",                                                                 // map(2)
+            "65726f6c6573",                                                       // text "roles"
+            "82",                                                                 // array(2)
+            "6466756e64",                                                         // text "fund"
+            "6663616e63656c",                                                     // text "cancel"
+            "676163636f756e74",                                                   // text "account"
+            "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount
+        );
+        assert_eq!(hex::encode(&encoded), expected);
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -1,8 +1,8 @@
 use crate::common::cbor::{
-    CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
-    CborSerialize,
+    CborDecoder, CborDeserialize, CborEncoder, CborMapDecoder, CborMapEncoder,
+    CborSerializationError, CborSerializationResult, CborSerialize, MapKey, MapKeyRef,
 };
-use crate::protocol_level_tokens::CborHolderAccount;
+use crate::protocol_level_tokens::{CborHolderAccount, CborMemo, TokenId};
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 
 /// Capability that can be granted to an account for a SimpleV0 lock
@@ -87,11 +87,103 @@ pub struct LockControllerSimpleV0Grant {
     pub roles: Vec<LockControllerSimpleV0Capability>,
 }
 
+/// Configuration for a SimpleV0 lock controller.
+///
+/// Contains the list of capability grants, which tokens are affected,
+/// a keep-alive flag, and an optional memo.
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub struct LockControllerSimpleV0 {
+    /// Capability grants to accounts.
+    pub grants: Vec<LockControllerSimpleV0Grant>,
+    /// Tokens affected by this lock controller.
+    pub tokens: Vec<TokenId>,
+    /// Whether the lock should be kept alive after all funds are
+    /// returned. Defaults to `false` when omitted from CBOR.
+    #[cfg_attr(feature = "serde_deprecated", serde(default))]
+    pub keep_alive: bool,
+    /// Optional memo attached to the lock.
+    #[cfg_attr(
+        feature = "serde_deprecated",
+        serde(skip_serializing_if = "Option::is_none")
+    )]
+    pub memo: Option<CborMemo>,
+}
+
+impl CborSerialize for LockControllerSimpleV0 {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
+        let mut map_encoder = encoder.encode_map()?;
+        map_encoder.serialize_entry(&MapKeyRef::Text("grants"), &self.grants)?;
+        map_encoder.serialize_entry(&MapKeyRef::Text("tokens"), &self.tokens)?;
+        // Always serialize keep_alive (even when false), matching normal CBOR
+        // map behavior for non-optional fields.
+        map_encoder.serialize_entry(&MapKeyRef::Text("keepAlive"), &self.keep_alive)?;
+        if !CborSerialize::is_null(&self.memo) {
+            map_encoder.serialize_entry(&MapKeyRef::Text("memo"), &self.memo)?;
+        }
+        map_encoder.end()?;
+        Ok(())
+    }
+}
+
+impl CborDeserialize for LockControllerSimpleV0 {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        let mut grants = None;
+        let mut tokens = None;
+        let mut keep_alive = None;
+        let mut memo: Option<Option<CborMemo>> = None;
+
+        let mut map_decoder = decoder.decode_map()?;
+        while let Some(map_key) = CborMapDecoder::deserialize_key::<MapKey>(&mut map_decoder)? {
+            match map_key.as_ref() {
+                MapKeyRef::Text("grants") => {
+                    grants = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
+                }
+                MapKeyRef::Text("tokens") => {
+                    tokens = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
+                }
+                MapKeyRef::Text("keepAlive") => {
+                    keep_alive = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
+                }
+                MapKeyRef::Text("memo") => {
+                    memo = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
+                }
+                _ => {
+                    CborMapDecoder::skip_value(&mut map_decoder)?;
+                }
+            }
+        }
+
+        let grants = grants
+            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("grants")))?;
+        let tokens = tokens
+            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("tokens")))?;
+        // Default to false when omitted from CBOR.
+        let keep_alive = keep_alive.unwrap_or(false);
+        let memo = memo.unwrap_or(None);
+
+        Ok(LockControllerSimpleV0 {
+            grants,
+            tokens,
+            keep_alive,
+            memo,
+        })
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::common::cbor;
     use crate::protocol_level_tokens::test_fixtures::ADDRESS;
+    use crate::transactions::Memo;
 
     /// Round-trip test for all `LockControllerSimpleV0Capability` variants.
     #[test]
@@ -197,6 +289,147 @@ mod test {
             "6663616e63656c",                                                     // text "cancel"
             "676163636f756e74",                                                   // text "account"
             "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    /// Round-trip test for `LockControllerSimpleV0` with full configuration
+    /// (including memo and keep_alive = true).
+    #[test]
+    fn test_simple_v0_cbor_round_trip_full() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: CborHolderAccount::from(ADDRESS),
+                roles: vec![
+                    LockControllerSimpleV0Capability::Fund,
+                    LockControllerSimpleV0Capability::Send,
+                ],
+            }],
+            tokens: vec!["CCD".parse().unwrap()],
+            keep_alive: true,
+            memo: Some(CborMemo::Raw(
+                Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
+            )),
+        };
+        let encoded = cbor::cbor_encode(&controller);
+        let decoded: LockControllerSimpleV0 =
+            cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, controller);
+    }
+
+    /// Round-trip test for `LockControllerSimpleV0` with minimal configuration
+    /// (no memo, keep_alive = false).
+    #[test]
+    fn test_simple_v0_cbor_round_trip_minimal() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![],
+            tokens: vec![],
+            keep_alive: false,
+            memo: None,
+        };
+        let encoded = cbor::cbor_encode(&controller);
+        let decoded: LockControllerSimpleV0 =
+            cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, controller);
+    }
+
+    /// Test that `keep_alive` defaults to `false` when the key is missing
+    /// from the CBOR map.
+    #[test]
+    fn test_simple_v0_cbor_keep_alive_default() {
+        // Manually construct CBOR map without "keepAlive" key:
+        // {"grants": [], "tokens": []}
+        //
+        // Map(2): a2
+        // "grants" sorted before "tokens" (both 6-char keys, "g" < "t"):
+        //   "grants": 666772616e7473, value []: 80
+        //   "tokens": 66746f6b656e73, value []: 80
+        let cbor_hex = "a2666772616e74738066746f6b656e7380";
+        let cbor_bytes = hex::decode(cbor_hex).expect("valid hex");
+        let decoded: LockControllerSimpleV0 = cbor::cbor_decode(&cbor_bytes)
+            .expect("CBOR decode should succeed with missing keepAlive");
+        assert!(!decoded.keep_alive, "keep_alive should default to false");
+        assert!(decoded.memo.is_none(), "memo should be None when omitted");
+    }
+
+    /// Fixture test for `LockControllerSimpleV0` with a known configuration.
+    ///
+    /// Expected CBOR structure (diagnostic notation):
+    /// ```text
+    /// {
+    ///   "memo": h'010203',
+    ///   "grants": [{
+    ///     "roles": ["fund", "cancel"],
+    ///     "account": 40307({1: 40305({1: 919}), 3: h'0102...1f20'})
+    ///   }],
+    ///   "tokens": ["CCD"],
+    ///   "keepAlive": true
+    /// }
+    /// ```
+    ///
+    /// Map keys sorted by encoded byte length:
+    /// - "memo" (4 bytes)
+    /// - "grants" (6 bytes)
+    /// - "tokens" (6 bytes) — same length as "grants", sorted lexicographically
+    /// - "keepAlive" (9 bytes)
+    #[test]
+    fn test_simple_v0_cbor_fixture() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: CborHolderAccount::from(ADDRESS),
+                roles: vec![
+                    LockControllerSimpleV0Capability::Fund,
+                    LockControllerSimpleV0Capability::Cancel,
+                ],
+            }],
+            tokens: vec!["CCD".parse().unwrap()],
+            keep_alive: true,
+            memo: Some(CborMemo::Raw(
+                Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
+            )),
+        };
+        let encoded = cbor::cbor_encode(&controller);
+        // Build expected hex:
+        //
+        // Map(4): a4
+        //
+        // Keys sorted by encoded byte length, then lexicographically:
+        // "memo" (4 bytes) → 646d656d6f
+        // "grants" (6 bytes) → 666772616e7473
+        // "tokens" (6 bytes) → 66746f6b656e73
+        // "keepAlive" (9 bytes) → 696b656570416c697665
+        //
+        // Values:
+        // memo: Raw(h'010203') → 43010203 (bytes(3))
+        // grants: [{roles: [fund, cancel], account: CborHolderAccount}]
+        //   Array(1): 81
+        //     Map(2): a2
+        //       "roles" (5): 65726f6c6573
+        //       ["fund", "cancel"]: 82 6466756e64 6663616e63656c
+        //       "account" (7): 676163636f756e74
+        //       CborHolderAccount: d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20
+        // tokens: ["CCD"]
+        //   Array(1): 81
+        //     "CCD": 63434344
+        // keepAlive: true → f5
+        let expected = concat!(
+            "a4",                     // map(4)
+            "646d656d6f",             // text "memo"
+            "43010203",               // bytes(3) h'010203'
+            "666772616e7473",         // text "grants"
+            "81",                     // array(1)
+            "a2",                     // map(2) — grant entry
+            "65726f6c6573",           // text "roles"
+            "82",                     // array(2)
+            "6466756e64",             // text "fund"
+            "6663616e63656c",         // text "cancel"
+            "676163636f756e74",       // text "account"
+            "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount
+            "66746f6b656e73",         // text "tokens"
+            "81",                     // array(1)
+            "63434344",               // text "CCD"
+            "696b656570416c697665",   // text "keepAlive"
+            "f5",                     // true
         );
         assert_eq!(hex::encode(&encoded), expected);
     }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -11,11 +11,6 @@ use concordium_base_derive::{CborDeserialize, CborSerialize, Serialize};
 /// Each capability authorizes the grantee to perform the corresponding lock
 /// operation.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub enum LockControllerSimpleV0Capability {
     Fund,
     Return,
@@ -75,11 +70,6 @@ impl CborDeserialize for LockControllerSimpleV0Capability {
 /// to the given account, authorizing it to perform the corresponding lock
 /// operations.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub struct LockControllerSimpleV0Grant {
     /// The account receiving the grant.
     pub account: CborHolderAccount,
@@ -92,11 +82,6 @@ pub struct LockControllerSimpleV0Grant {
 /// Contains the list of capability grants, which tokens are affected,
 /// a keep-alive flag, and an optional memo.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub struct LockControllerSimpleV0 {
     /// Capability grants to accounts.
     pub grants: Vec<LockControllerSimpleV0Grant>,
@@ -104,16 +89,8 @@ pub struct LockControllerSimpleV0 {
     pub tokens: Vec<TokenId>,
     /// Whether the lock should be kept alive after all funds are
     /// returned. Interpreted as `false` when omitted.
-    #[cfg_attr(
-        feature = "serde_deprecated",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
     pub keep_alive: Option<bool>,
     /// Optional memo attached to the lock.
-    #[cfg_attr(
-        feature = "serde_deprecated",
-        serde(skip_serializing_if = "Option::is_none")
-    )]
     pub memo: Option<CborMemo>,
 }
 

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -121,6 +121,7 @@ pub struct LockControllerSimpleV0 {
 mod test {
     use super::*;
     use crate::common::cbor;
+    use crate::common::{serialize_deserialize, to_bytes};
     use crate::protocol_level_tokens::test_fixtures::ADDRESS;
     use crate::transactions::Memo;
 
@@ -387,5 +388,49 @@ mod test {
             "80",             // array(0)
         );
         assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    /// Round-trip test for all `LockControllerSimpleV0Capability` variants
+    /// using binary (`Serial`/`Deserial`) encoding.
+    #[test]
+    fn test_capability_serial_round_trip() {
+        let variants = [
+            LockControllerSimpleV0Capability::Fund,
+            LockControllerSimpleV0Capability::Return,
+            LockControllerSimpleV0Capability::Send,
+            LockControllerSimpleV0Capability::Cancel,
+        ];
+        for variant in &variants {
+            let result = serialize_deserialize(variant).expect("Serial round-trip should succeed");
+            assert_eq!(&result, variant);
+        }
+    }
+
+    /// Fixture test: `LockControllerSimpleV0Capability` binary (`Serial`)
+    /// encoding.
+    ///
+    /// Enum tags are single bytes, 0-indexed by declaration order:
+    /// - `Fund`   → `00`
+    /// - `Return` → `01`
+    /// - `Send`   → `02`
+    /// - `Cancel` → `03`
+    #[test]
+    fn test_capability_serial_fixture() {
+        assert_eq!(
+            hex::encode(to_bytes(&LockControllerSimpleV0Capability::Fund)),
+            "00"
+        );
+        assert_eq!(
+            hex::encode(to_bytes(&LockControllerSimpleV0Capability::Return)),
+            "01"
+        );
+        assert_eq!(
+            hex::encode(to_bytes(&LockControllerSimpleV0Capability::Send)),
+            "02"
+        );
+        assert_eq!(
+            hex::encode(to_bytes(&LockControllerSimpleV0Capability::Cancel)),
+            "03"
+        );
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -1,6 +1,6 @@
 use crate::common::cbor::{
-    CborDecoder, CborDeserialize, CborEncoder, CborMapDecoder, CborMapEncoder,
-    CborSerializationError, CborSerializationResult, CborSerialize, MapKey, MapKeyRef,
+    CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
+    CborSerialize,
 };
 use crate::protocol_level_tokens::{CborHolderAccount, CborMemo, TokenId};
 use concordium_base_derive::{CborDeserialize, CborSerialize, Serialize};
@@ -91,7 +91,7 @@ pub struct LockControllerSimpleV0Grant {
 ///
 /// Contains the list of capability grants, which tokens are affected,
 /// a keep-alive flag, and an optional memo.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)
@@ -103,79 +103,18 @@ pub struct LockControllerSimpleV0 {
     /// Tokens affected by this lock controller.
     pub tokens: Vec<TokenId>,
     /// Whether the lock should be kept alive after all funds are
-    /// returned. Defaults to `false` when omitted from CBOR.
-    #[cfg_attr(feature = "serde_deprecated", serde(default))]
-    pub keep_alive: bool,
+    /// returned. Interpreted as `false` when omitted.
+    #[cfg_attr(
+        feature = "serde_deprecated",
+        serde(skip_serializing_if = "Option::is_none")
+    )]
+    pub keep_alive: Option<bool>,
     /// Optional memo attached to the lock.
     #[cfg_attr(
         feature = "serde_deprecated",
         serde(skip_serializing_if = "Option::is_none")
     )]
     pub memo: Option<CborMemo>,
-}
-
-impl CborSerialize for LockControllerSimpleV0 {
-    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
-        let mut map_encoder = encoder.encode_map()?;
-        map_encoder.serialize_entry(&MapKeyRef::Text("grants"), &self.grants)?;
-        map_encoder.serialize_entry(&MapKeyRef::Text("tokens"), &self.tokens)?;
-        // Always serialize keep_alive (even when false), matching normal CBOR
-        // map behavior for non-optional fields.
-        map_encoder.serialize_entry(&MapKeyRef::Text("keepAlive"), &self.keep_alive)?;
-        if !CborSerialize::is_null(&self.memo) {
-            map_encoder.serialize_entry(&MapKeyRef::Text("memo"), &self.memo)?;
-        }
-        map_encoder.end()?;
-        Ok(())
-    }
-}
-
-impl CborDeserialize for LockControllerSimpleV0 {
-    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
-        let mut grants = None;
-        let mut tokens = None;
-        let mut keep_alive = None;
-        let mut memo: Option<Option<CborMemo>> = None;
-
-        let mut map_decoder = decoder.decode_map()?;
-        while let Some(map_key) = CborMapDecoder::deserialize_key::<MapKey>(&mut map_decoder)? {
-            match map_key.as_ref() {
-                MapKeyRef::Text("grants") => {
-                    grants = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("tokens") => {
-                    tokens = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("keepAlive") => {
-                    keep_alive = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("memo") => {
-                    memo = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                _ => {
-                    CborMapDecoder::skip_value(&mut map_decoder)?;
-                }
-            }
-        }
-
-        let grants = grants
-            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("grants")))?;
-        let tokens = tokens
-            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("tokens")))?;
-        // Default to false when omitted from CBOR.
-        let keep_alive = keep_alive.unwrap_or(false);
-        let memo = memo.unwrap_or(None);
-
-        Ok(LockControllerSimpleV0 {
-            grants,
-            tokens,
-            keep_alive,
-            memo,
-        })
-    }
 }
 
 #[cfg(test)]
@@ -306,7 +245,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: true,
+            keep_alive: true.into(),
             memo: Some(CborMemo::Raw(
                 Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
             )),
@@ -324,32 +263,13 @@ mod test {
         let controller = LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: false,
+            keep_alive: None,
             memo: None,
         };
         let encoded = cbor::cbor_encode(&controller);
         let decoded: LockControllerSimpleV0 =
             cbor::cbor_decode(&encoded).expect("CBOR decode failed");
         assert_eq!(decoded, controller);
-    }
-
-    /// Test that `keep_alive` defaults to `false` when the key is missing
-    /// from the CBOR map.
-    #[test]
-    fn test_simple_v0_cbor_keep_alive_default() {
-        // Manually construct CBOR map without "keepAlive" key:
-        // {"grants": [], "tokens": []}
-        //
-        // Map(2): a2
-        // "grants" sorted before "tokens" (both 6-char keys, "g" < "t"):
-        //   "grants": 666772616e7473, value []: 80
-        //   "tokens": 66746f6b656e73, value []: 80
-        let cbor_hex = "a2666772616e74738066746f6b656e7380";
-        let cbor_bytes = hex::decode(cbor_hex).expect("valid hex");
-        let decoded: LockControllerSimpleV0 = cbor::cbor_decode(&cbor_bytes)
-            .expect("CBOR decode should succeed with missing keepAlive");
-        assert!(!decoded.keep_alive, "keep_alive should default to false");
-        assert!(decoded.memo.is_none(), "memo should be None when omitted");
     }
 
     /// Fixture test for `LockControllerSimpleV0` with a known configuration.
@@ -373,7 +293,7 @@ mod test {
     /// - "tokens" (6 bytes) — same length as "grants", sorted lexicographically
     /// - "keepAlive" (9 bytes)
     #[test]
-    fn test_simple_v0_cbor_fixture() {
+    fn test_simple_v0_cbor_fixture_full() {
         let controller = LockControllerSimpleV0 {
             grants: vec![LockControllerSimpleV0Grant {
                 account: CborHolderAccount::from(ADDRESS),
@@ -383,7 +303,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: true,
+            keep_alive: true.into(),
             memo: Some(CborMemo::Raw(
                 Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
             )),
@@ -430,6 +350,41 @@ mod test {
             "63434344",               // text "CCD"
             "696b656570416c697665",   // text "keepAlive"
             "f5",                     // true
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    /// Fixture test for `LockControllerSimpleV0` with a minimal configuration.
+    ///
+    /// `keep_alive: None` and `memo: None` are omitted by the derive macro,
+    /// so the CBOR map contains only `"grants"` and `"tokens"` (both empty
+    /// arrays).
+    ///
+    /// Expected CBOR structure (diagnostic notation):
+    /// ```text
+    /// {"grants": [], "tokens": []}
+    /// ```
+    ///
+    /// Map keys sorted by encoded byte length (both 6 bytes), then
+    /// lexicographically: `"grants"` < `"tokens"`.
+    #[test]
+    fn test_simple_v0_cbor_fixture_minimal() {
+        let controller = LockControllerSimpleV0 {
+            grants: vec![],
+            tokens: vec![],
+            keep_alive: None,
+            memo: None,
+        };
+        let encoded = cbor::cbor_encode(&controller);
+        // Map(2): a2
+        //   "grants" (6 bytes): 666772616e7473, []: 80
+        //   "tokens" (6 bytes): 66746f6b656e73, []: 80
+        let expected = concat!(
+            "a2",             // map(2)
+            "666772616e7473", // text "grants"
+            "80",             // array(0)
+            "66746f6b656e73", // text "tokens"
+            "80",             // array(0)
         );
         assert_eq!(hex::encode(&encoded), expected);
     }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -3,14 +3,14 @@ use crate::common::cbor::{
     CborSerializationError, CborSerializationResult, CborSerialize, MapKey, MapKeyRef,
 };
 use crate::protocol_level_tokens::{CborHolderAccount, CborMemo, TokenId};
-use concordium_base_derive::{CborDeserialize, CborSerialize};
+use concordium_base_derive::{CborDeserialize, CborSerialize, Serialize};
 
 /// Capability that can be granted to an account for a SimpleV0 lock
 /// controller.
 ///
 /// Each capability authorizes the grantee to perform the corresponding lock
 /// operation.
-#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -1,0 +1,118 @@
+use crate::common::cbor::{
+    CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
+    CborSerialize,
+};
+
+/// Capability that can be granted to an account for a SimpleV0 lock
+/// controller.
+///
+/// Each capability authorizes the grantee to perform the corresponding lock
+/// operation.
+#[derive(Debug, Clone, Eq, PartialEq, Hash)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub enum LockControllerSimpleV0Capability {
+    Fund,
+    Return,
+    Send,
+    Cancel,
+}
+
+impl LockControllerSimpleV0Capability {
+    fn as_str(&self) -> &'static str {
+        match self {
+            Self::Fund => "fund",
+            Self::Return => "return",
+            Self::Send => "send",
+            Self::Cancel => "cancel",
+        }
+    }
+
+    fn from_str(s: &str) -> Result<Self, CborSerializationError> {
+        match s {
+            "fund" => Ok(Self::Fund),
+            "return" => Ok(Self::Return),
+            "send" => Ok(Self::Send),
+            "cancel" => Ok(Self::Cancel),
+            other => Err(CborSerializationError::invalid_data(format_args!(
+                "unknown LockControllerSimpleV0Capability: \"{}\"",
+                other
+            ))),
+        }
+    }
+}
+
+impl CborSerialize for LockControllerSimpleV0Capability {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
+        encoder.encode_text(self.as_str())
+    }
+}
+
+impl CborDeserialize for LockControllerSimpleV0Capability {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        let text_bytes = decoder.decode_text()?;
+        let text = std::str::from_utf8(&text_bytes).map_err(|_| {
+            CborSerializationError::invalid_data(format_args!(
+                "LockControllerSimpleV0Capability text is not valid UTF-8"
+            ))
+        })?;
+        Self::from_str(text)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::cbor;
+
+    /// Round-trip test for all `LockControllerSimpleV0Capability` variants.
+    #[test]
+    fn test_capability_cbor_round_trip() {
+        let variants = [
+            LockControllerSimpleV0Capability::Fund,
+            LockControllerSimpleV0Capability::Return,
+            LockControllerSimpleV0Capability::Send,
+            LockControllerSimpleV0Capability::Cancel,
+        ];
+        for variant in &variants {
+            let encoded = cbor::cbor_encode(variant);
+            let decoded: LockControllerSimpleV0Capability =
+                cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+            assert_eq!(&decoded, variant);
+        }
+    }
+
+    /// Fixture test: `Fund` → CBOR text "fund" → `6466756e64`
+    #[test]
+    fn test_capability_cbor_fixture_fund() {
+        let encoded = cbor::cbor_encode(&LockControllerSimpleV0Capability::Fund);
+        assert_eq!(hex::encode(&encoded), "6466756e64");
+    }
+
+    /// Fixture test: `Return` → CBOR text "return" → `6672657475726e`
+    #[test]
+    fn test_capability_cbor_fixture_return() {
+        let encoded = cbor::cbor_encode(&LockControllerSimpleV0Capability::Return);
+        assert_eq!(hex::encode(&encoded), "6672657475726e");
+    }
+
+    /// Fixture test: `Send` → CBOR text "send" → `6473656e64`
+    #[test]
+    fn test_capability_cbor_fixture_send() {
+        let encoded = cbor::cbor_encode(&LockControllerSimpleV0Capability::Send);
+        assert_eq!(hex::encode(&encoded), "6473656e64");
+    }
+
+    /// Fixture test: `Cancel` → CBOR text "cancel" → `6663616e63656c`
+    #[test]
+    fn test_capability_cbor_fixture_cancel() {
+        let encoded = cbor::cbor_encode(&LockControllerSimpleV0Capability::Cancel);
+        assert_eq!(hex::encode(&encoded), "6663616e63656c");
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
@@ -1,8 +1,11 @@
 use crate::{
     base::{AccountIndex, Nonce},
-    common::cbor::{
-        CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
-        CborSerializationResult, CborSerialize,
+    common::{
+        cbor::{
+            CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
+            CborSerializationResult, CborSerialize,
+        },
+        Serialize,
     },
 };
 use anyhow::anyhow;
@@ -14,7 +17,7 @@ const LOCK_ID_TAG: u64 = 40920;
 const LOCK_ID_ARRAY_SIZE: usize = 3;
 
 /// Unique identifier for a PLT lock.
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
@@ -80,6 +80,7 @@ impl CborDeserialize for LockId {
 mod test {
     use super::*;
     use crate::common::cbor;
+    use crate::common::{serialize_deserialize, to_bytes};
 
     fn example_lock_id() -> LockId {
         LockId {
@@ -114,6 +115,35 @@ mod test {
         let lock_id = example_lock_id();
         let encoded = cbor::cbor_encode(&lock_id);
         assert_eq!(hex::encode(&encoded), "d99fd8831927110500");
+    }
+
+    /// Round-trip test: binary (`Serial`/`Deserial`) encoding of `LockId`
+    /// produces the same value.
+    #[test]
+    fn test_lock_id_serial_round_trip() {
+        let lock_id = example_lock_id();
+        let result = serialize_deserialize(&lock_id).expect("Serial round-trip should succeed");
+        assert_eq!(result, lock_id);
+    }
+
+    /// Fixture test: verify the exact binary (`Serial`) encoding of `LockId`.
+    ///
+    /// `LockId { account_index: 10001, sequence_number: 5, creation_order: 0
+    /// }`:
+    /// - `account_index.index` = 10001 = `0x0000000000002711` (8 bytes BE u64)
+    /// - `sequence_number.nonce` = 5 = `0x0000000000000005` (8 bytes BE u64)
+    /// - `creation_order` = 0 = `0x0000000000000000` (8 bytes BE u64)
+    ///
+    /// Total 24 bytes:
+    /// `000000000000271100000000000000050000000000000000`
+    #[test]
+    fn test_lock_id_serial_fixture() {
+        let lock_id = example_lock_id();
+        let bytes = to_bytes(&lock_id);
+        assert_eq!(
+            hex::encode(&bytes),
+            "000000000000271100000000000000050000000000000000"
+        );
     }
 
     /// Test with zero values.

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
@@ -18,11 +18,6 @@ const LOCK_ID_ARRAY_SIZE: usize = 3;
 
 /// Unique identifier for a PLT lock.
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd, Serialize)]
-#[cfg_attr(
-    feature = "serde_deprecated",
-    derive(serde::Serialize, serde::Deserialize)
-)]
-#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
 pub struct LockId {
     /// Index of the account that created the lock.
     pub account_index: AccountIndex,

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_id.rs
@@ -1,0 +1,141 @@
+use crate::{
+    base::{AccountIndex, Nonce},
+    common::cbor::{
+        CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
+        CborSerializationResult, CborSerialize,
+    },
+};
+use anyhow::anyhow;
+
+/// CBOR tag for [`LockId`]
+const LOCK_ID_TAG: u64 = 40920;
+
+/// Number of elements in the CBOR array encoding of a [`LockId`].
+const LOCK_ID_ARRAY_SIZE: usize = 3;
+
+/// Unique identifier for a PLT lock.
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Ord, PartialOrd)]
+#[cfg_attr(
+    feature = "serde_deprecated",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(feature = "serde_deprecated", serde(rename_all = "camelCase"))]
+pub struct LockId {
+    /// Index of the account that created the lock.
+    pub account_index: AccountIndex,
+    /// Account sequence number at the time of lock creation.
+    pub sequence_number: Nonce,
+    /// Order of lock creation within the transaction.
+    pub creation_order: u64,
+}
+
+impl CborSerialize for LockId {
+    fn serialize<C: CborEncoder>(&self, mut encoder: C) -> Result<(), C::WriteError> {
+        encoder.encode_tag(LOCK_ID_TAG)?;
+        let mut array_encoder = encoder.encode_array()?;
+        array_encoder.serialize_element(&self.account_index.index)?;
+        array_encoder.serialize_element(&self.sequence_number.nonce)?;
+        array_encoder.serialize_element(&self.creation_order)?;
+        array_encoder.end()?;
+        Ok(())
+    }
+}
+
+impl CborDeserialize for LockId {
+    fn deserialize<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        decoder.decode_tag_expect(LOCK_ID_TAG)?;
+        let mut array_decoder = decoder.decode_array_expect_size(LOCK_ID_ARRAY_SIZE)?;
+
+        let Some(account_index_raw) =
+            CborArrayDecoder::deserialize_element::<u64>(&mut array_decoder)?
+        else {
+            return Err(anyhow!("expected account_index element in LockId array").into());
+        };
+        let Some(sequence_number_raw) =
+            CborArrayDecoder::deserialize_element::<u64>(&mut array_decoder)?
+        else {
+            return Err(anyhow!("expected sequence_number element in LockId array").into());
+        };
+        let Some(creation_order) =
+            CborArrayDecoder::deserialize_element::<u64>(&mut array_decoder)?
+        else {
+            return Err(anyhow!("expected creation_order element in LockId array").into());
+        };
+
+        Ok(LockId {
+            account_index: account_index_raw.into(),
+            sequence_number: sequence_number_raw.into(),
+            creation_order,
+        })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::common::cbor;
+
+    fn example_lock_id() -> LockId {
+        LockId {
+            account_index: AccountIndex { index: 10001 },
+            sequence_number: Nonce { nonce: 5 },
+            creation_order: 0,
+        }
+    }
+
+    /// Round-trip test: encode then decode produces the same `LockId`.
+    #[test]
+    fn test_lock_id_cbor_round_trip() {
+        let lock_id = example_lock_id();
+        let encoded = cbor::cbor_encode(&lock_id);
+        let decoded: LockId = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, lock_id);
+    }
+
+    /// Fixture test: verify the exact CBOR encoding.
+    ///
+    /// Expected encoding for `LockId { account_index: 10001, sequence_number:
+    /// 5, creation_order: 0 }`:
+    /// - Tag 40920 (0x9FD8): `d9 9f d8`
+    /// - Array of 3: `83`
+    /// - 10001 (0x2711, 2-byte uint): `19 27 11`
+    /// - 5: `05`
+    /// - 0: `00`
+    ///
+    /// Full: `d99fd8831927110500`
+    #[test]
+    fn test_lock_id_cbor_fixture() {
+        let lock_id = example_lock_id();
+        let encoded = cbor::cbor_encode(&lock_id);
+        assert_eq!(hex::encode(&encoded), "d99fd8831927110500");
+    }
+
+    /// Test with zero values.
+    #[test]
+    fn test_lock_id_cbor_zero_values() {
+        let lock_id = LockId {
+            account_index: AccountIndex { index: 0 },
+            sequence_number: Nonce { nonce: 0 },
+            creation_order: 0,
+        };
+        let encoded = cbor::cbor_encode(&lock_id);
+        let decoded: LockId = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, lock_id);
+    }
+
+    /// Test with max u64 values.
+    #[test]
+    fn test_lock_id_cbor_max_values() {
+        let lock_id = LockId {
+            account_index: AccountIndex { index: u64::MAX },
+            sequence_number: Nonce { nonce: u64::MAX },
+            creation_order: u64::MAX,
+        };
+        let encoded = cbor::cbor_encode(&lock_id);
+        let decoded: LockId = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, lock_id);
+    }
+}

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -1,4 +1,29 @@
 //! Types for working with PLT (Protocol Level Token) locks.
+//!
+//! This module defines the data types used to create, configure, and manage
+//! protocol-level locks on tokens. A lock restricts how tokens can be
+//! transferred by specifying recipients, an expiry time, and a controller
+//! that grants capabilities (such as funding, sending, returning, or
+//! cancelling) to designated accounts.
+//!
+//! # Key types
+//!
+//! - [`LockId`] — Unique identifier for a lock, derived from the creating
+//!   account, its sequence number, and an intra-transaction creation order.
+//! - [`LockConfig`] — Top-level lock configuration containing recipients,
+//!   expiry, and controller settings.
+//! - [`LockController`] — Enum of controller versions (currently
+//!   [`LockControllerSimpleV0`]).
+//! - [`LockControllerSimpleV0`] — Controller configuration with capability
+//!   grants, token list, keep-alive flag, and optional memo.
+//! - [`LockControllerSimpleV0Grant`] — A grant of capabilities to a specific
+//!   account.
+//! - [`LockControllerSimpleV0Capability`] — Individual capability that can be
+//!   granted (`Fund`, `Return`, `Send`, `Cancel`).
+//!
+//! All types support CBOR serialization/deserialization, and optionally
+//! JSON serialization via serde when the `serde_deprecated` feature is
+//! enabled.
 
 mod lock_config;
 mod lock_controller;

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -1,9 +1,11 @@
 //! Types for working with PLT (Protocol Level Token) locks.
 
+mod lock_config;
 mod lock_controller;
 mod lock_controller_simple_v0;
 mod lock_id;
 
+pub use lock_config::*;
 pub use lock_controller::*;
 pub use lock_controller_simple_v0::*;
 pub use lock_id::*;

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -1,0 +1,5 @@
+//! Types for working with PLT (Protocol Level Token) locks.
+
+mod lock_id;
+
+pub use lock_id::*;

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -1,5 +1,7 @@
 //! Types for working with PLT (Protocol Level Token) locks.
 
+mod lock_controller_simple_v0;
 mod lock_id;
 
+pub use lock_controller_simple_v0::*;
 pub use lock_id::*;

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -1,7 +1,9 @@
 //! Types for working with PLT (Protocol Level Token) locks.
 
+mod lock_controller;
 mod lock_controller_simple_v0;
 mod lock_id;
 
+pub use lock_controller::*;
 pub use lock_controller_simple_v0::*;
 pub use lock_id::*;

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
@@ -1,4 +1,5 @@
 use crate::common;
+use crate::common::cbor::{self, CborEncoder, CborSerializationError, CborSerialize};
 use crate::common::{Get, SerdeDeserialize};
 use serde::de::Error;
 use serde::Deserializer;
@@ -107,8 +108,32 @@ impl common::Deserial for TokenId {
     }
 }
 
+/// CBOR serialization of [`TokenId`] as a CBOR text string.
+impl CborSerialize for TokenId {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
+        encoder.encode_text(self.value.as_str())
+    }
+}
+
+/// CBOR deserialization of [`TokenId`] from a CBOR text string.
+impl cbor::CborDeserialize for TokenId {
+    fn deserialize<C: cbor::CborDecoder>(decoder: C) -> cbor::CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        let text_bytes = decoder.decode_text()?;
+        let text = String::from_utf8(text_bytes).map_err(|_| {
+            CborSerializationError::invalid_data(format_args!("TokenId text is not valid UTF-8"))
+        })?;
+        text.try_into()
+            .map_err(|e| CborSerializationError::invalid_data(format_args!("{}", e)))
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use crate::common::cbor::{cbor_decode, cbor_encode};
+
     use super::*;
     use std::str::FromStr;
 
@@ -176,7 +201,7 @@ mod tests {
         // token id which is too long
         let bytes: Vec<_> = [129]
             .into_iter()
-            .chain("a".repeat(129).as_bytes().to_vec().into_iter())
+            .chain("a".repeat(129).as_bytes().to_vec())
             .collect();
         let err = common::from_bytes::<TokenId, _>(&mut bytes.as_slice()).expect_err("deserial");
         assert!(
@@ -206,5 +231,23 @@ mod tests {
             "err: {}",
             err
         );
+    }
+
+    /// CBOR round-trip test for [`TokenId`].
+    #[test]
+    fn test_token_id_cbor_round_trip() {
+        let token_id: TokenId = "tokenid1".parse().unwrap();
+        let encoded = cbor_encode(&token_id);
+        let decoded: TokenId = cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, token_id);
+    }
+
+    /// Fixture test: `TokenId("CCD")` → CBOR text "CCD" → `63434344`
+    #[test]
+    fn test_token_id_cbor_fixture() {
+        let token_id: TokenId = "CCD".parse().unwrap();
+        let encoded = cbor_encode(&token_id);
+        // 63 = text string of length 3, 434344 = "CCD" in ASCII
+        assert_eq!(hex::encode(&encoded), "63434344");
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_id.rs
@@ -121,10 +121,7 @@ impl cbor::CborDeserialize for TokenId {
     where
         Self: Sized,
     {
-        let text_bytes = decoder.decode_text()?;
-        let text = String::from_utf8(text_bytes).map_err(|_| {
-            CborSerializationError::invalid_data(format_args!("TokenId text is not valid UTF-8"))
-        })?;
+        let text = <String as common::cbor::CborDeserialize>::deserialize(decoder)?;
         text.try_into()
             .map_err(|e| CborSerializationError::invalid_data(format_args!("{}", e)))
     }

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -4,7 +4,7 @@ use crate::{
     protocol_level_tokens::{CborHolderAccount, CoinInfo, RawCbor, TokenAmount, TokenId},
     transactions::Memo,
 };
-use concordium_base_derive::{CborDeserialize, CborSerialize};
+use concordium_base_derive::{CborDeserialize, CborSerialize, Serialize};
 use concordium_contracts_common::AccountAddress;
 
 /// Module that implements easy construction of protocol level token operations.
@@ -259,7 +259,7 @@ pub struct TokenTransfer {
 }
 
 /// Memo attached to a protocol level token transfer
-#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize, Serialize)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_operations.rs
@@ -287,7 +287,10 @@ impl From<CborMemo> for Memo {
 pub mod test {
     use super::*;
     use crate::{
-        common::cbor::{self, value},
+        common::{
+            cbor::{self, value},
+            serialize_deserialize, to_bytes,
+        },
         protocol_level_tokens::{token_holder::test_fixtures::ADDRESS, CborHolderAccount},
     };
     use assert_matches::assert_matches;
@@ -495,5 +498,50 @@ pub mod test {
             .collect();
         let operations_decoded = payload.decode_operations_maybe_known().unwrap();
         assert_eq!(operations_decoded, operations_known);
+    }
+
+    /// Round-trip test for `CborMemo::Raw` and `CborMemo::Cbor` variants using
+    /// binary (`Serial`/`Deserial`) encoding.
+    #[test]
+    fn test_cbor_memo_serial_round_trip() {
+        let raw = CborMemo::Raw(Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap());
+        let result = serialize_deserialize(&raw).expect("Serial round-trip should succeed");
+        assert_eq!(result, raw);
+
+        let cbor_memo = CborMemo::Cbor(Memo::try_from(vec![0xAA, 0xBB]).unwrap());
+        let result = serialize_deserialize(&cbor_memo).expect("Serial round-trip should succeed");
+        assert_eq!(result, cbor_memo);
+    }
+
+    /// Fixture test: `CborMemo::Raw(Memo([0x01, 0x02, 0x03]))` binary (`Serial`)
+    /// encoding.
+    ///
+    /// Expected encoding:
+    /// - tag: `00` (Raw = variant 0)
+    /// - memo length prefix: `0003` (u16 BE, 3 bytes)
+    /// - memo bytes: `010203`
+    ///
+    /// Full: `000003010203`
+    #[test]
+    fn test_cbor_memo_serial_fixture_raw() {
+        let memo = CborMemo::Raw(Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap());
+        let bytes = to_bytes(&memo);
+        assert_eq!(hex::encode(&bytes), "000003010203");
+    }
+
+    /// Fixture test: `CborMemo::Cbor(Memo([0xAA, 0xBB]))` binary (`Serial`)
+    /// encoding.
+    ///
+    /// Expected encoding:
+    /// - tag: `01` (Cbor = variant 1)
+    /// - memo length prefix: `0002` (u16 BE, 2 bytes)
+    /// - memo bytes: `aabb`
+    ///
+    /// Full: `010002aabb`
+    #[test]
+    fn test_cbor_memo_serial_fixture_cbor() {
+        let memo = CborMemo::Cbor(Memo::try_from(vec![0xAA, 0xBB]).unwrap());
+        let bytes = to_bytes(&memo);
+        assert_eq!(hex::encode(&bytes), "010002aabb");
     }
 }


### PR DESCRIPTION
Ref COR-2213

## Purpose

Add types needed to represent locks state in the node block state

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.