### PR TITLE
`#[cbor(default)]` derive macro for struct fields

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -8,6 +8,9 @@
   - `LockControllerSimpleV0Grant`
   - `LockControllerSimpleV0Capability`
 - Added CBOR serialization for `TransactionTime` and `TokenId`.
+- Added support for `#[cbor(default)]` field attribute in the `CborDeserialize` derive macro.
+  When a CBOR map key is absent, the field is initialized with `Default::default()` instead of
+  producing a deserialization error.
 - Implemented `common::from_bytes_complete` that fails if all bytes are not consumed during deserialization.
 - `cbor::cbor_encode` is now infallible and returns `Vec<u8>` instead of `CborSerializationResult<Vec<u8>>`
 - `&[T]` no longer implements `CborSerialize` in order to avoid ambiguity with `CborSerialize` implementation for `[u8]`. 

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -202,6 +202,22 @@
 //!
 //! In this example, entries in the CBOR map that are not present in the struct
 //! are each deserialized into an entry in the map in the field `unknown`.
+//!
+//! #### `cbor(default)`
+//! For struct fields deserialized from a CBOR map, uses [`Default::default()`]
+//! when the map key is absent instead of producing a deserialization error.
+//! This attribute only affects deserialization; serialization is unchanged.
+//! The field type must implement the [`Default`] trait (enforced at compile
+//! time by the generated code).
+//!
+//! ```ignore
+//! #[derive(CborSerialize, CborDeserialize)]
+//! struct TestStruct {
+//!     name: String,
+//!     #[cbor(default)]
+//!     active: bool, // defaults to `false` when the key is absent
+//! }
+//! ```
 
 mod composites;
 /// CBOR serialization of types from `concordium-contracts-common`
@@ -1671,5 +1687,126 @@ mod test {
         let cbor = hex::decode("f4f4").unwrap();
         let err = cbor_decode::<bool>(&cbor).unwrap_err().to_string();
         assert!(err.contains("data remaining after parse"), "err: {}", err);
+    }
+
+    /// Test that a field annotated with `#[cbor(default)]` receives
+    /// `Default::default()` when its map key is absent from the CBOR input.
+    #[test]
+    fn test_cbor_default_missing_key() {
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct WithDefault {
+            name: String,
+            #[cbor(default)]
+            active: bool,
+        }
+
+        // Encode a struct that only has the `name` field, producing a CBOR map
+        // without the `active` key.
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct NameOnly {
+            name: String,
+        }
+
+        let name_only = NameOnly {
+            name: "Alice".to_string(),
+        };
+        let cbor = cbor_encode(&name_only);
+
+        let decoded: WithDefault = cbor_decode(&cbor).unwrap();
+        assert_eq!(decoded.name, "Alice");
+        assert_eq!(decoded.active, false);
+    }
+
+    /// Test round-trip: encode a struct with a `#[cbor(default)]` field
+    /// present, then decode and verify equality.
+    #[test]
+    fn test_cbor_default_round_trip() {
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct WithDefault {
+            name: String,
+            #[cbor(default)]
+            active: bool,
+        }
+
+        let value = WithDefault {
+            name: "Bob".to_string(),
+            active: true,
+        };
+        let cbor = cbor_encode(&value);
+        let decoded: WithDefault = cbor_decode(&cbor).unwrap();
+        assert_eq!(decoded, value);
+    }
+
+    /// Test mixed fields: a required field (no `#[cbor(default)]`) and a
+    /// default field. The default field should get its `Default` value when
+    /// missing, while a missing required field should produce an error.
+    #[test]
+    fn test_cbor_default_mixed_fields() {
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct Mixed {
+            required: u64,
+            #[cbor(default)]
+            flag: bool,
+        }
+
+        // Encode a struct with only the `required` field.
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct RequiredOnly {
+            required: u64,
+        }
+
+        let required_only = RequiredOnly { required: 42 };
+        let cbor = cbor_encode(&required_only);
+
+        let decoded: Mixed = cbor_decode(&cbor).unwrap();
+        assert_eq!(decoded.required, 42);
+        assert_eq!(decoded.flag, false);
+
+        // Encoding a struct with only the `flag` field should fail when
+        // decoded as `Mixed`, because `required` is not a default field.
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct FlagOnly {
+            flag: bool,
+        }
+
+        let flag_only = FlagOnly { flag: true };
+        let cbor_flag_only = cbor_encode(&flag_only);
+
+        let err = cbor_decode::<Mixed>(&cbor_flag_only)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("not present"),
+            "expected missing-key error, got: {}",
+            err
+        );
+    }
+
+    /// Test `#[cbor(default)]` on an `Option<T>` field. The `Default` impl
+    /// for `Option<T>` returns `None`, so this should work even though it is
+    /// redundant with the `null()` path.
+    #[test]
+    fn test_cbor_default_on_option() {
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct WithOptional {
+            name: String,
+            #[cbor(default)]
+            value: Option<u64>,
+        }
+
+        // Encode a struct with only the `name` field.
+        #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct NameOnly2 {
+            name: String,
+        }
+
+        let name_only = NameOnly2 {
+            name: "Charlie".to_string(),
+        };
+        let cbor = cbor_encode(&name_only);
+
+        let decoded: WithOptional = cbor_decode(&cbor).unwrap();
+        assert_eq!(decoded.name, "Charlie");
+        assert_eq!(decoded.value, None);
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -1,6 +1,6 @@
 use crate::common::cbor::{
-    CborDecoder, CborDeserialize, CborEncoder, CborMapDecoder, CborMapEncoder,
-    CborSerializationError, CborSerializationResult, CborSerialize, MapKey, MapKeyRef,
+    CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
+    CborSerialize,
 };
 use crate::protocol_level_tokens::{CborHolderAccount, CborMemo, TokenId};
 use concordium_base_derive::{CborDeserialize, CborSerialize};
@@ -91,7 +91,7 @@ pub struct LockControllerSimpleV0Grant {
 ///
 /// Contains the list of capability grants, which tokens are affected,
 /// a keep-alive flag, and an optional memo.
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
 #[cfg_attr(
     feature = "serde_deprecated",
     derive(serde::Serialize, serde::Deserialize)
@@ -105,6 +105,7 @@ pub struct LockControllerSimpleV0 {
     /// Whether the lock should be kept alive after all funds are
     /// returned. Defaults to `false` when omitted from CBOR.
     #[cfg_attr(feature = "serde_deprecated", serde(default))]
+    #[cbor(default)]
     pub keep_alive: bool,
     /// Optional memo attached to the lock.
     #[cfg_attr(
@@ -112,70 +113,6 @@ pub struct LockControllerSimpleV0 {
         serde(skip_serializing_if = "Option::is_none")
     )]
     pub memo: Option<CborMemo>,
-}
-
-impl CborSerialize for LockControllerSimpleV0 {
-    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
-        let mut map_encoder = encoder.encode_map()?;
-        map_encoder.serialize_entry(&MapKeyRef::Text("grants"), &self.grants)?;
-        map_encoder.serialize_entry(&MapKeyRef::Text("tokens"), &self.tokens)?;
-        // Always serialize keep_alive (even when false), matching normal CBOR
-        // map behavior for non-optional fields.
-        map_encoder.serialize_entry(&MapKeyRef::Text("keepAlive"), &self.keep_alive)?;
-        if !CborSerialize::is_null(&self.memo) {
-            map_encoder.serialize_entry(&MapKeyRef::Text("memo"), &self.memo)?;
-        }
-        map_encoder.end()?;
-        Ok(())
-    }
-}
-
-impl CborDeserialize for LockControllerSimpleV0 {
-    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
-        let mut grants = None;
-        let mut tokens = None;
-        let mut keep_alive = None;
-        let mut memo: Option<Option<CborMemo>> = None;
-
-        let mut map_decoder = decoder.decode_map()?;
-        while let Some(map_key) = CborMapDecoder::deserialize_key::<MapKey>(&mut map_decoder)? {
-            match map_key.as_ref() {
-                MapKeyRef::Text("grants") => {
-                    grants = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("tokens") => {
-                    tokens = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("keepAlive") => {
-                    keep_alive = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                MapKeyRef::Text("memo") => {
-                    memo = Some(CborMapDecoder::deserialize_value(&mut map_decoder)?);
-                }
-                _ => {
-                    CborMapDecoder::skip_value(&mut map_decoder)?;
-                }
-            }
-        }
-
-        let grants = grants
-            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("grants")))?;
-        let tokens = tokens
-            .ok_or_else(|| CborSerializationError::map_value_missing(MapKeyRef::Text("tokens")))?;
-        // Default to false when omitted from CBOR.
-        let keep_alive = keep_alive.unwrap_or(false);
-        let memo = memo.unwrap_or(None);
-
-        Ok(LockControllerSimpleV0 {
-            grants,
-            tokens,
-            keep_alive,
-            memo,
-        })
-    }
 }
 
 #[cfg(test)]

--- a/rust-src/concordium_base_derive/src/cbor.rs
+++ b/rust-src/concordium_base_derive/src/cbor.rs
@@ -451,6 +451,34 @@ fn cbor_deserialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result
                 }
             };
 
+            let field_missing_key_handling: TokenStream = cbor_fields
+                .0
+                .iter()
+                .filter(|f| !f.opts.other)
+                .zip(field_vars.iter())
+                .zip(field_map_keys.iter())
+                .map(|((field, field_var), field_map_key)| {
+                    if field.opts.default {
+                        quote! {
+                            let #field_var = match #field_var {
+                                None => Default::default(),
+                                Some(#field_var) => #field_var,
+                            };
+                        }
+                    } else {
+                        quote! {
+                            let #field_var = match #field_var {
+                                None => match #cbor_module::CborDeserialize::null() {
+                                    None => return Err(#cbor_module::CborSerializationError::map_value_missing(#field_map_key)),
+                                    Some(null_value) => null_value,
+                                },
+                                Some(#field_var) => #field_var,
+                            };
+                        }
+                    }
+                })
+                .collect();
+
             quote! {
                 let options = decoder.options();
                 #(let mut #field_vars = None;)*
@@ -471,15 +499,7 @@ fn cbor_deserialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result
                     }
                 }
 
-                #(
-                    let #field_vars = match #field_vars {
-                        None => match #cbor_module::CborDeserialize::null() {
-                            None => return Err(#cbor_module::CborSerializationError::map_value_missing(#field_map_keys)),
-                            Some(null_value) => null_value,
-                        },
-                        Some(#field_vars) => #field_vars,
-                    };
-                )*
+                #field_missing_key_handling
 
                 Ok(#self_construct)
             }

--- a/rust-src/concordium_base_derive/src/cbor.rs
+++ b/rust-src/concordium_base_derive/src/cbor.rs
@@ -43,6 +43,9 @@ pub struct CborFieldOpts {
     /// to the field with this attribute.
     #[darling(default)]
     other: bool,
+    /// Use `Default::default()` when the key is absent from the CBOR map.
+    #[darling(default)]
+    default: bool,
 }
 
 #[derive(Debug, Default, FromVariant)]
@@ -166,6 +169,28 @@ impl CborFields {
             return Err(syn::Error::new(
                 Span::call_site(),
                 "cbor(other) can only be specified on a at most a single field",
+            ));
+        }
+
+        if this
+            .0
+            .iter()
+            .any(|field| field.opts.default && field.opts.other)
+        {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "cbor(default) and cbor(other) cannot both be specified on the same field",
+            ));
+        }
+
+        if this
+            .0
+            .iter()
+            .any(|field| field.opts.default && matches!(field.member, Member::Unnamed(_)))
+        {
+            return Err(syn::Error::new(
+                Span::call_site(),
+                "cbor(default) is only valid on named struct fields, not on tuple struct fields",
             ));
         }
 


### PR DESCRIPTION
Ref COR-2213

## Purpose

Add `#[cbor(default)]` derive macro to be used for struct fields, similar to `#[serde(default)]`.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
