### PR TITLE
MetaUpdatePayload decoding should disallow unknown fields.

### DIFF
--- a/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
@@ -111,9 +111,13 @@ pub struct MetaUpdatePayload {
 }
 
 impl MetaUpdatePayload {
-    /// Decode meta-update operations from CBOR
+    /// Decode meta-update operations from CBOR. This disallows extraneous fields
+    /// in the encoded CBOR.
     pub fn decode_operations(&self) -> CborSerializationResult<MetaUpdateOperations> {
-        cbor::cbor_decode(&self.operations)
+        let decode_options = cbor::SerializationOptions {
+            unknown_map_keys: cbor::UnknownMapKeys::Fail,
+        };
+        cbor::cbor_decode_with_options(&self.operations, decode_options)
     }
 }
 


### PR DESCRIPTION
## Purpose

Decoding of `MetaUpdatePayload` should not permit unknown fields.