### PR TITLE
Default handling for CBOR

### DIFF
--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -1234,6 +1234,29 @@ mod test {
     }
 
     #[test]
+    fn test_struct_default_derived() {
+        #[derive(Debug, Eq, PartialEq, CborSerialize, CborDeserialize)]
+        struct TestStruct {
+            field1: u64,
+            #[cbor(default = 5)]
+            field2: u64,
+        }
+
+        let value = TestStruct { field1: 3, field2: 5 };
+
+        let cbor = cbor_encode(&value);
+        assert_eq!(hex::encode(&cbor), "a1666669656c643103");
+        let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value);
+
+        let value2 = TestStruct { field1: 5, field2: 6 };
+        let cbor = cbor_encode(&value2);
+        assert_eq!(hex::encode(&cbor), "a2666669656c643105666669656c643206");
+        let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();
+        assert_eq!(value_decoded, value2);
+    }
+
+    #[test]
     fn test_enum_as_map_derived() {
         #[derive(Debug, Eq, PartialEq, CborSerialize, CborDeserialize)]
         #[cbor(map)]

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -148,6 +148,44 @@
 //!
 //! In this example `TestStructWrapper` is serialized as `TestStruct`.
 //!
+//! #### `cbor(tuple)`
+//! Serializes the struct as a tuple of its fields, instead of a map with field
+//! names as keys.
+//! 
+//! ```ignore
+//! #[derive(CborSerialize, CborDeserialize)]
+//! #[cbor(tuple)]
+//! struct TestStruct {
+//!    field1: u64,
+//!    field2: String,
+//! }
+//! ```
+//! 
+//! In this example, `TestStruct { field1: 3, field2: "abcd".to_string() }` is
+//! serialized as the CBOR array `[3, "abcd"]` instead of the CBOR map 
+//! `{"field1": 3, "field2": "abcd"}`.
+//! 
+//! #### `cbor(default)`
+//! When applied to a field in a struct with named fields, if the field is not
+//! present in the CBOR map, the field is deserialized to the specified default
+//! value. The field is omitted from the serialization if the value is equal
+//! to the specified default.
+//! 
+//! ```ignore
+//! #[derive(CborSerialize, CborDeserialize)]
+//! struct TestStruct {
+//!    #[cbor(default = 0)]
+//!    field1: u64,
+//!    #[cbor(default = false)]
+//!    field2: bool,
+//! }
+//! ```
+//! 
+//! Note: this differs from the (CDDL specification)[https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.6]
+//! of the `.default` control operator in that this implementation permits the
+//! field to appear with the default value in the CBOR map, while the CDDL
+//! specification requires the field to be omitted from the CBOR map.
+//! 
 //! #### `cbor(other)`
 //! This attribute can be applied to a variant in an enum for a field in a
 //! struct. When applied to a variant in an enum represented as a CBOR map,

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -151,7 +151,7 @@
 //! #### `cbor(tuple)`
 //! Serializes the struct as a tuple of its fields, instead of a map with field
 //! names as keys.
-//! 
+//!
 //! ```ignore
 //! #[derive(CborSerialize, CborDeserialize)]
 //! #[cbor(tuple)]
@@ -160,17 +160,17 @@
 //!    field2: String,
 //! }
 //! ```
-//! 
+//!
 //! In this example, `TestStruct { field1: 3, field2: "abcd".to_string() }` is
-//! serialized as the CBOR array `[3, "abcd"]` instead of the CBOR map 
+//! serialized as the CBOR array `[3, "abcd"]` instead of the CBOR map
 //! `{"field1": 3, "field2": "abcd"}`.
-//! 
+//!
 //! #### `cbor(default)`
 //! When applied to a field in a struct with named fields, if the field is not
 //! present in the CBOR map, the field is deserialized to the specified default
 //! value. The field is omitted from the serialization if the value is equal
 //! to the specified default.
-//! 
+//!
 //! ```ignore
 //! #[derive(CborSerialize, CborDeserialize)]
 //! struct TestStruct {
@@ -180,12 +180,12 @@
 //!    field2: bool,
 //! }
 //! ```
-//! 
+//!
 //! Note: this differs from the (CDDL specification)[https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.6]
 //! of the `.default` control operator in that this implementation permits the
 //! field to appear with the default value in the CBOR map, while the CDDL
 //! specification requires the field to be omitted from the CBOR map.
-//! 
+//!
 //! #### `cbor(other)`
 //! This attribute can be applied to a variant in an enum for a field in a
 //! struct. When applied to a variant in an enum represented as a CBOR map,

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -181,7 +181,7 @@
 //! }
 //! ```
 //!
-//! Note: this differs from the (CDDL specification)[https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.6]
+//! Note: this differs from the [CDDL specification](https://datatracker.ietf.org/doc/html/rfc8610#section-3.8.6)
 //! of the `.default` control operator in that this implementation permits the
 //! field to appear with the default value in the CBOR map, while the CDDL
 //! specification requires the field to be omitted from the CBOR map.

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -1242,14 +1242,20 @@ mod test {
             field2: u64,
         }
 
-        let value = TestStruct { field1: 3, field2: 5 };
+        let value = TestStruct {
+            field1: 3,
+            field2: 5,
+        };
 
         let cbor = cbor_encode(&value);
         assert_eq!(hex::encode(&cbor), "a1666669656c643103");
         let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
 
-        let value2 = TestStruct { field1: 5, field2: 6 };
+        let value2 = TestStruct {
+            field1: 5,
+            field2: 6,
+        };
         let cbor = cbor_encode(&value2);
         assert_eq!(hex::encode(&cbor), "a2666669656c643105666669656c643206");
         let value_decoded: TestStruct = cbor_decode(&cbor).unwrap();

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
@@ -40,7 +40,7 @@ mod test {
                     ],
                 }],
                 tokens: vec!["CCD".parse().unwrap()],
-                keep_alive: None,
+                keep_alive: false,
                 memo: None,
             }),
         }
@@ -102,7 +102,7 @@ mod test {
             controller: LockController::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
                 tokens: vec![],
-                keep_alive: None,
+                keep_alive: false,
                 memo: None,
             }),
         };

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller.rs
@@ -34,7 +34,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: None,
+            keep_alive: false,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);
@@ -49,7 +49,7 @@ mod test {
         let controller = LockController::SimpleV0(LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: None,
+            keep_alive: false,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);
@@ -78,7 +78,7 @@ mod test {
         let controller = LockController::SimpleV0(LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: None,
+            keep_alive: false,
             memo: None,
         });
         let encoded = cbor::cbor_encode(&controller);

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -88,8 +88,9 @@ pub struct LockControllerSimpleV0 {
     /// Tokens affected by this lock controller.
     pub tokens: Vec<TokenId>,
     /// Whether the lock should be kept alive after all funds are
-    /// returned. Interpreted as `false` when omitted.
-    pub keep_alive: Option<bool>,
+    /// returned. Interpreted as `false` when omitted from the serialization.
+    #[cbor(default = false)]
+    pub keep_alive: bool,
     /// Optional memo attached to the lock.
     pub memo: Option<CborMemo>,
 }
@@ -223,7 +224,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: true.into(),
+            keep_alive: true,
             memo: Some(CborMemo::Raw(
                 Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
             )),
@@ -241,7 +242,7 @@ mod test {
         let controller = LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: None,
+            keep_alive: false,
             memo: None,
         };
         let encoded = cbor::cbor_encode(&controller);
@@ -281,7 +282,7 @@ mod test {
                 ],
             }],
             tokens: vec!["CCD".parse().unwrap()],
-            keep_alive: true.into(),
+            keep_alive: true,
             memo: Some(CborMemo::Raw(
                 Memo::try_from(vec![0x01, 0x02, 0x03]).unwrap(),
             )),
@@ -350,7 +351,7 @@ mod test {
         let controller = LockControllerSimpleV0 {
             grants: vec![],
             tokens: vec![],
-            keep_alive: None,
+            keep_alive: false,
             memo: None,
         };
         let encoded = cbor::cbor_encode(&controller);

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_controller_simple_v0.rs
@@ -368,6 +368,45 @@ mod test {
         assert_eq!(hex::encode(&encoded), expected);
     }
 
+    #[test]
+    fn test_simple_v0_cbor_fixture_noncanonical() {
+        // This test verifies that the CBOR decoder accepts non-canonical
+        // encodings of LockControllerSimpleV0. In particular, the `keepAlive` field is encoded as
+        // `false` (0xf4) instead of being omitted.
+        // Additionaly, the fields are not in deterministic order.
+        // {
+        //     "tokens": ["CCD"],
+        //     "keepAlive": false,
+        //     "grants": [
+        //         {
+        //             "account": 40307_1({
+        //                 1: 40305_1({1: 919_2}),
+        //                 3: h'0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20',
+        //             }),
+        //             "roles": ["fund", "cancel"],
+        //         },
+        //     ],
+        // }
+        let encoding = "a366746f6b656e738163434344696b656570416c697665f4666772616e747381a2676163636f756e74d99d73a201d99d71a1011a000003970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f2065726f6c6573826466756e646663616e63656c";
+        let bytes = hex::decode(encoding).expect("invalid hex in test fixture");
+        let decoded: LockControllerSimpleV0 =
+            cbor::cbor_decode(&bytes).expect("CBOR decode failed");
+
+        let expect = LockControllerSimpleV0 {
+            grants: vec![LockControllerSimpleV0Grant {
+                account: CborHolderAccount::from(ADDRESS),
+                roles: vec![
+                    LockControllerSimpleV0Capability::Fund,
+                    LockControllerSimpleV0Capability::Cancel,
+                ],
+            }],
+            tokens: vec!["CCD".parse().unwrap()],
+            keep_alive: false,
+            memo: None,
+        };
+        assert_eq!(decoded, expect);
+    }
+
     /// Round-trip test for all `LockControllerSimpleV0Capability` variants
     /// using binary (`Serial`/`Deserial`) encoding.
     #[test]

--- a/rust-src/concordium_base_derive/src/cbor.rs
+++ b/rust-src/concordium_base_derive/src/cbor.rs
@@ -43,6 +43,10 @@ pub struct CborFieldOpts {
     /// to the field with this attribute.
     #[darling(default)]
     other: bool,
+    /// Default value expression to use when deserializing and the key is
+    /// missing from the map. When serializing, if the value equals this
+    /// default, the key is omitted from the serialized map.
+    default: Option<Expr>,
 }
 
 #[derive(Debug, Default, FromVariant)]
@@ -148,6 +152,16 @@ impl CborFields {
                 }
             })
             .collect())
+    }
+
+    /// Get default value expressions for the fields (if any), in the same
+    /// order as `members()` and `cbor_map_keys()`.
+    fn default_values(&self) -> Vec<Option<Expr>> {
+        self.0
+            .iter()
+            .filter(|field| !field.opts.other)
+            .map(|field| field.opts.default.clone())
+            .collect()
     }
 }
 
@@ -404,6 +418,7 @@ fn cbor_deserialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result
         }
         CborContainer::Map => {
             let field_map_keys = cbor_fields.cbor_map_keys()?;
+            let field_defaults = cbor_fields.default_values();
 
             let other_field_declare = if let Some((ty, other_ident)) = cbor_fields.other_member() {
                 quote! {
@@ -430,6 +445,32 @@ fn cbor_deserialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result
                 }
             };
 
+            let missing_field_handling: Vec<TokenStream> = field_vars
+                .iter()
+                .zip(field_map_keys.iter())
+                .zip(field_defaults.iter())
+                .map(|((field_var, map_key), default_val)| {
+                    if let Some(default_expr) = default_val {
+                        quote! {
+                            let #field_var = match #field_var {
+                                None => #default_expr,
+                                Some(#field_var) => #field_var,
+                            };
+                        }
+                    } else {
+                        quote! {
+                            let #field_var = match #field_var {
+                                None => match #cbor_module::CborDeserialize::null() {
+                                    None => return Err(#cbor_module::CborSerializationError::map_value_missing(#map_key)),
+                                    Some(null_value) => null_value,
+                                },
+                                Some(#field_var) => #field_var,
+                            };
+                        }
+                    }
+                })
+                .collect();
+
             quote! {
                 let options = decoder.options();
                 #(let mut #field_vars = None;)*
@@ -450,15 +491,7 @@ fn cbor_deserialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result
                     }
                 }
 
-                #(
-                    let #field_vars = match #field_vars {
-                        None => match #cbor_module::CborDeserialize::null() {
-                            None => return Err(#cbor_module::CborSerializationError::map_value_missing(#field_map_keys)),
-                            Some(null_value) => null_value,
-                        },
-                        Some(#field_vars) => #field_vars,
-                    };
-                )*
+                #(#missing_field_handling)*
 
                 Ok(#self_construct)
             }
@@ -773,17 +806,35 @@ fn cbor_serialize_struct_body(fields: &Fields, opts: &CborOpts) -> syn::Result<T
         }
         CborContainer::Map => {
             let field_map_keys = cbor_fields.cbor_map_keys()?;
+            let field_defaults = cbor_fields.default_values();
 
             let other_ident = cbor_fields.other_member().into_iter().map(|other| other.1);
+
+            let serialize_entries: Vec<TokenStream> = field_idents
+                .iter()
+                .zip(field_map_keys.iter())
+                .zip(field_defaults.iter())
+                .map(|((field_ident, map_key), default_val)| {
+                    if let Some(default_expr) = default_val {
+                        quote! {
+                            if self.#field_ident != #default_expr {
+                                #cbor_module::CborMapEncoder::serialize_entry(&mut map_encoder, &#map_key, &self.#field_ident)?;
+                            }
+                        }
+                    } else {
+                        quote! {
+                            if !#cbor_module::CborSerialize::is_null(&self.#field_ident) {
+                                #cbor_module::CborMapEncoder::serialize_entry(&mut map_encoder, &#map_key, &self.#field_ident)?;
+                            }
+                        }
+                    }
+                })
+                .collect();
 
             quote! {
                 let mut map_encoder = #cbor_module::CborEncoder::encode_map(encoder)?;
 
-                #(
-                    if !#cbor_module::CborSerialize::is_null(&self.#field_idents) {
-                        #cbor_module::CborMapEncoder::serialize_entry(&mut map_encoder, &#field_map_keys, &self.#field_idents)?;
-                    }
-                )*
+                #(#serialize_entries)*
 
                 #(
                     for (key, value) in self.#other_ident.iter() {


### PR DESCRIPTION

## Purpose

Allow specifying fields with default value that will be used when the field is not present. The field will not be included in the serialization if it has the default value.

## Changes

- CBOR default support in deriving macros
- `keep_alive` field of `LockController::SimpleV0` is treated as default `false`.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.

## CLA acceptance

_Remove if not applicable.

By submitting the contribution I accept the terms and conditions of the
Contributor License Agreement v1.0
- link: https://developers.concordium.com/CLAs/Contributor-License-Agreement-v1.0.pdf

- [ ] I accept the above linked CLA.
