### PR TITLE
Add to and from lock to `TokenTransfer` event.

### DIFF
--- a/concordium-base.cabal
+++ b/concordium-base.cabal
@@ -117,8 +117,8 @@ library
       Concordium.Wasm
       Data.Base58Encoding
       Data.Base58Encoding.TH
-      Data.ULEB128
       Data.FixedByteString
+      Data.ULEB128
       Proto.V2.Concordium.Health Proto.V2.Concordium.Health_Fields Proto.V2.Concordium.Service Proto.V2.Concordium.Service_Fields Proto.V2.Concordium.Types Proto.V2.Concordium.Types_Fields Proto.V2.Concordium.Kernel Proto.V2.Concordium.Kernel_Fields Proto.V2.Concordium.ProtocolLevelTokens Proto.V2.Concordium.ProtocolLevelTokens_Fields
   other-modules:
       Paths_concordium_base

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -915,6 +915,8 @@ tokenUpdateEventToProto TokenTransfer{..} = Right . Proto.make $ do
                 PLTFields.to .= toProto ettTo
                 PLTFields.amount .= toProto ettAmount
                 PLTFields.maybe'memo .= fmap toProto ettMemo
+                PLTFields.maybe'fromLock .= fmap toProto ettFromLock
+                PLTFields.maybe'toLock .= fmap toProto ettToLock
             )
 tokenUpdateEventToProto TokenMint{..} = Right . Proto.make $ do
     PLTFields.tokenId .= toProto etmTokenId
@@ -936,8 +938,6 @@ tokenUpdateEventToProto _ = Left ()
 
 -- | Convert an event to a 'Proto.MetaEvent'. Returns @Left ()@ if the event type is
 --  not one of the meta event types.
---
---  TODO: COR-2305 - support generalized transfer event
 metaUpdateEventToProto :: Event' s -> Either () Proto.MetaEvent
 metaUpdateEventToProto TokenModuleEvent{..} =
     Right . Proto.make $
@@ -958,6 +958,8 @@ metaUpdateEventToProto TokenTransfer{..} =
                     PLTFields.amount .= toProto ettAmount
                     PLTFields.maybe'memo .= fmap toProto ettMemo
                     PLTFields.tokenId .= toProto ettTokenId
+                    PLTFields.maybe'fromLock .= fmap toProto ettFromLock
+                    PLTFields.maybe'toLock .= fmap toProto ettToLock
                 )
 metaUpdateEventToProto TokenMint{..} =
     Right . Proto.make $

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -1415,7 +1415,16 @@ data Event' (supplemented :: Bool)
           -- | The amount transferred.
           ettAmount :: !TokenAmount,
           -- | An optional memo for the transfer.
-          ettMemo :: !(Maybe Memo)
+          ettMemo :: !(Maybe Memo),
+          -- | When the funds originate on the locked balance of an account, the
+          --  identity of the lock controlling the funds. Absent when the funds
+          --  are not on the locked balance of the originating account.
+          ettFromLock :: !(Maybe LockId),
+          -- | When the funds are transferred into the control of a lock, the
+          --  identity of the lock assuming control of the funds. Absent when
+          --  the funds are sent to the available balance of the receiving
+          --  account.
+          ettToLock :: !(Maybe LockId)
         }
     | -- | A token mint event.
       -- The serialization uses a bitmap to indicate which fields are present.
@@ -1728,9 +1737,13 @@ putEvent = \case
             <> S.put ettTo
             <> S.put ettAmount
             <> mapM_ S.put ettMemo
+            <> mapM_ S.put ettFromLock
+            <> mapM_ S.put ettToLock
       where
         bitmap =
             bitFor 0 ettMemo
+                .|. bitFor 1 ettFromLock
+                .|. bitFor 2 ettToLock
     TokenMint{..} ->
         S.putWord8 40
             -- The purpose of the bitmap is to make the event extendable with optional additional fields in the future.
@@ -1967,6 +1980,8 @@ getEvent spv =
                     | testBit bitmap b = Just <$> S.get
                     | otherwise = return Nothing
             ettMemo <- maybeGet 0
+            ettFromLock <- maybeGet 1
+            ettToLock <- maybeGet 2
             return TokenTransfer{..}
         40 | supportPlt -> do
             -- The purpose of the bitmap is to make the event extendable with optional additional fields in the future.
@@ -2006,7 +2021,9 @@ getEvent spv =
     supportSuspend = protocolSupportsSuspend spv
     supportPlt = protocolSupportsPLT spv
     supportLocks = supportsPLTLocks spv
-    configureTokenTransferBitMask = 0b0000000000000001
+    configureTokenTransferBitMask
+        | supportLocks = 0b0000000000000111
+        | otherwise = 0b0000000000000001
     configureTokenMintBitMask = 0b0000000000000000
     configureTokenBurnBitMask = 0b0000000000000000
 
@@ -2290,6 +2307,8 @@ instance AE.ToJSON (Event' supplemented) where
                   "amount" .= ettAmount
                 ]
                     ++ foldMap (\memo -> ["memo" .= memo]) ettMemo
+                    ++ foldMap (\fromLock -> ["fromLock" .= fromLock]) ettFromLock
+                    ++ foldMap (\toLock -> ["toLock" .= toLock]) ettToLock
         TokenMint{..} ->
             AE.object
                 [ "tag" .= AE.String "TokenMint",
@@ -2521,6 +2540,8 @@ instance (SingI supplemented) => AE.FromJSON (Event' supplemented) where
                 ettTo <- obj .: "to"
                 ettAmount <- obj .: "amount"
                 ettMemo <- obj AE..:? "memo"
+                ettFromLock <- obj AE..:? "fromLock"
+                ettToLock <- obj AE..:? "toLock"
                 return TokenTransfer{..}
             "TokenMint" -> do
                 etmTokenId <- obj .: "tokenId"

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -812,7 +812,9 @@ genEvent spv =
                 <*> genTokenHolder
                 <*> genTokenHolder
                 <*> genTokenAmount
-                <*> liftArbitrary genMemo,
+                <*> liftArbitrary genMemo
+                <*> (if supportsPLTLocks spv then liftArbitrary genLockId else return Nothing)
+                <*> (if supportsPLTLocks spv then liftArbitrary genLockId else return Nothing),
               TokenMint <$> genTokenId <*> genTokenHolder <*> genTokenAmount,
               TokenBurn <$> genTokenId <*> genTokenHolder <*> genTokenAmount,
               TokenCreated <$> genCreatePLT

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -44,9 +44,9 @@ testEventSerializationIdentity :: (IsProtocolVersion pv) => SProtocolVersion pv 
 testEventSerializationIdentity spv = forAll (genEvent spv) $ \e -> decodeFull' (getEvent spv) (runPut $ putEvent e) === Right e
 
 testExemplarEventSerialization :: Spec
-testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
+testExemplarEventSerialization = do
     it "Simple TokenTransfer" $
-        t
+        testEncoding
             "27000008746f6b656e696431000101010101010101010101010101010101010101010101010101010101010101000202020202020202020202020202020202020202020202020202020202020202876804"
             ( TokenTransfer
                 { ettTokenId = TokenId "tokenid1",
@@ -59,7 +59,7 @@ testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
                 }
             )
     it "TokenTransfer with memo" $
-        t
+        testEncoding
             "27000108746f6b656e6964310001010101010101010101010101010101010101010101010101010101010101010002020202020202020202020202020202020202020202020202020202020202028768040003010203"
             ( TokenTransfer
                 { ettTokenId = TokenId "tokenid1",
@@ -72,7 +72,7 @@ testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
                 }
             )
     it "TokenTransfer from lock" $
-        t
+        testEncoding
             "27000208746f6b656e6964310001010101010101010101010101010101010101010101010101010101010101010002020202020202020202020202020202020202020202020202020202020202028768040f0e0d0c0b0a0908112233445566778899aabbccddeeff00"
             ( TokenTransfer
                 { ettTokenId = TokenId "tokenid1",
@@ -85,7 +85,7 @@ testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
                 }
             )
     it "TokenTransfer to lock" $
-        t
+        testEncoding
             "27000408746f6b656e69643100010101010101010101010101010101010101010101010101010101010101010100020202020202020202020202020202020202020202020202020202020202020287680499aabbccddeeff000f0e0d0c0b0a09081122334455667788"
             ( TokenTransfer
                 { ettTokenId = TokenId "tokenid1",
@@ -98,7 +98,7 @@ testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
                 }
             )
     it "TokenTransfer with everything" $
-        t
+        testEncoding
             "27\
             \000706546573745454\
             \000d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d\
@@ -118,7 +118,7 @@ testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
                 }
             )
   where
-    t hex expected = do
+    testEncoding hex expected = do
         BS16.encode (runPut $ putEvent expected) `shouldBe` hex
         decodeFull' (getEvent SP11) (BS16.decodeLenient hex) `shouldBe` Right expected
 

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -1,26 +1,126 @@
 {-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Types.TransactionSummarySpec where
 
+import Control.Monad
 import qualified Data.Aeson as AE
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Base16 as BS16
+import qualified Data.ByteString.Short as BSS
 import Data.Serialize
 import Test.Hspec
 import Test.QuickCheck
 
+import Concordium.Types
 import Concordium.Types.Execution
-import Concordium.Types.ProtocolVersion
+import Concordium.Types.Tokens (TokenAmount (..))
+import qualified Data.FixedByteString as FBS
 
 import Generators
+
+-- | Deserialize a value, ensuring that the input is fully consumed.
+decodeFull :: (Serialize a) => BS.ByteString -> Either String a
+decodeFull = decodeFull' get
+
+decodeFull' :: Get a -> BS.ByteString -> Either String a
+decodeFull' getter =
+    runGet
+        ( do
+            g <- getter
+            done <- isEmpty
+            unless done $ fail "Input was not fully consumed"
+            return g
+        )
 
 testTransactionTypesSerialIdentity :: Expectation
 testTransactionTypesSerialIdentity = mapM_ testEncDec transactionTypes
   where
-    testEncDec tt = decode (encode tt) `shouldBe` Right tt
+    testEncDec tt = decodeFull (encode tt) `shouldBe` Right tt
 
 -- | Test that decoding is the inverse of encoding for 'Event's.
 testEventSerializationIdentity :: (IsProtocolVersion pv) => SProtocolVersion pv -> Property
-testEventSerializationIdentity spv = forAll (genEvent spv) $ \e -> runGet (getEvent spv) (runPut $ putEvent e) === Right e
+testEventSerializationIdentity spv = forAll (genEvent spv) $ \e -> decodeFull' (getEvent spv) (runPut $ putEvent e) === Right e
+
+testExemplarEventSerialization :: Spec
+testExemplarEventSerialization = focus {- NOCOMMIT -} $ do
+    it "Simple TokenTransfer" $
+        t
+            "27000008746f6b656e696431000101010101010101010101010101010101010101010101010101010101010101000202020202020202020202020202020202020202020202020202020202020202876804"
+            ( TokenTransfer
+                { ettTokenId = TokenId "tokenid1",
+                  ettFrom = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x01,
+                  ettTo = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x02,
+                  ettAmount = TokenAmount{taValue = 1000, taDecimals = 4},
+                  ettMemo = Nothing,
+                  ettFromLock = Nothing,
+                  ettToLock = Nothing
+                }
+            )
+    it "TokenTransfer with memo" $
+        t
+            "27000108746f6b656e6964310001010101010101010101010101010101010101010101010101010101010101010002020202020202020202020202020202020202020202020202020202020202028768040003010203"
+            ( TokenTransfer
+                { ettTokenId = TokenId "tokenid1",
+                  ettFrom = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x01,
+                  ettTo = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x02,
+                  ettAmount = TokenAmount{taValue = 1000, taDecimals = 4},
+                  ettMemo = Just (Memo "\x01\x02\x03"),
+                  ettFromLock = Nothing,
+                  ettToLock = Nothing
+                }
+            )
+    it "TokenTransfer from lock" $
+        t
+            "27000208746f6b656e6964310001010101010101010101010101010101010101010101010101010101010101010002020202020202020202020202020202020202020202020202020202020202028768040f0e0d0c0b0a0908112233445566778899aabbccddeeff00"
+            ( TokenTransfer
+                { ettTokenId = TokenId "tokenid1",
+                  ettFrom = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x01,
+                  ettTo = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x02,
+                  ettAmount = TokenAmount{taValue = 1000, taDecimals = 4},
+                  ettMemo = Nothing,
+                  ettFromLock = Just (LockId{liAccountIndex = 0x0f0e0d0c0b0a0908, liSequenceNumber = 0x1122334455667788, liCreationOrder = 0x99aabbccddeeff00}),
+                  ettToLock = Nothing
+                }
+            )
+    it "TokenTransfer to lock" $
+        t
+            "27000408746f6b656e69643100010101010101010101010101010101010101010101010101010101010101010100020202020202020202020202020202020202020202020202020202020202020287680499aabbccddeeff000f0e0d0c0b0a09081122334455667788"
+            ( TokenTransfer
+                { ettTokenId = TokenId "tokenid1",
+                  ettFrom = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x01,
+                  ettTo = HolderAccount $ AccountAddress $ FBS.pack $ repeat 0x02,
+                  ettAmount = TokenAmount{taValue = 1000, taDecimals = 4},
+                  ettMemo = Nothing,
+                  ettFromLock = Nothing,
+                  ettToLock = Just (LockId{liAccountIndex = 0x99aabbccddeeff00, liSequenceNumber = 0x0f0e0d0c0b0a0908, liCreationOrder = 0x1122334455667788})
+                }
+            )
+    it "TokenTransfer with everything" $
+        t
+            "27\
+            \000706546573745454\
+            \000d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d0d\
+            \004040404040404040404040404040404040404040404040404040404040404040\
+            \81ffffffffffffffff7fff\
+            \0100000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5d5e5f606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9fa0a1a2a3a4a5a6a7a8a9aaabacadaeafb0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecfd0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeeff0f1f2f3f4f5f6f7f8f9fafbfcfdfeff\
+            \0f0e0d0c0b0a0908112233445566778899aabbccddeeff00\
+            \707172737475767788898a8b8c8d8e8f9f9e9d9c9b9a9998"
+            ( TokenTransfer
+                { ettTokenId = TokenId "TestTT",
+                  ettFrom = HolderAccount $ AccountAddress $ FBS.pack $ repeat 13,
+                  ettTo = HolderAccount $ AccountAddress $ FBS.pack $ repeat 64,
+                  ettAmount = TokenAmount{taValue = maxBound, taDecimals = 255},
+                  ettMemo = Just (Memo $ BSS.pack $ [0x00 .. 0xff]),
+                  ettFromLock = Just LockId{liAccountIndex = 0x0f0e0d0c0b0a0908, liSequenceNumber = 0x1122334455667788, liCreationOrder = 0x99aabbccddeeff00},
+                  ettToLock = Just LockId{liAccountIndex = 0x7071727374757677, liSequenceNumber = 0x88898a8b8c8d8e8f, liCreationOrder = 0x9f9e9d9c9b9a9998}
+                }
+            )
+  where
+    t hex expected = do
+        BS16.encode (runPut $ putEvent expected) `shouldBe` hex
+        decodeFull' (getEvent SP11) (BS16.decodeLenient hex) `shouldBe` Right expected
 
 -- | Test that decoding is the inverse of encoding for 'Event's.
 testEventJSONSerializationIdentity :: (IsProtocolVersion pv) => SProtocolVersion pv -> Property
@@ -28,15 +128,15 @@ testEventJSONSerializationIdentity spv = forAll (genEvent spv) $ \e -> AE.either
 
 -- | Test that decoding is the inverse of encoding for 'RejectReason's.
 testRejectReasonSerializationIdentity :: RejectReason -> Property
-testRejectReasonSerializationIdentity e = decode (encode e) === Right e
+testRejectReasonSerializationIdentity e = decodeFull (encode e) === Right e
 
 -- | Test that decoding is the inverse of encoding for 'ValidResult's.
 testValidResultSerializationIdentity :: (IsProtocolVersion pv) => SProtocolVersion pv -> Property
-testValidResultSerializationIdentity spv = forAll (genValidResult spv) $ \e -> runGet (getValidResult spv) (runPut $ putValidResult e) === Right e
+testValidResultSerializationIdentity spv = forAll (genValidResult spv) $ \e -> decodeFull' (getValidResult spv) (runPut $ putValidResult e) === Right e
 
 -- | Test that decoding is the inverse of encoding for 'TransactionSummary's.
 testTransactionSummarySerializationIdentity :: (IsProtocolVersion pv) => SProtocolVersion pv -> Property
-testTransactionSummarySerializationIdentity spv = forAll (genTransactionSummary spv) $ \e -> runGet (getTransactionSummary spv) (runPut $ putTransactionSummary e) === Right e
+testTransactionSummarySerializationIdentity spv = forAll (genTransactionSummary spv) $ \e -> decodeFull' (getTransactionSummary spv) (runPut $ putTransactionSummary e) === Right e
 
 tests :: Spec
 tests = describe "Transaction summaries" $ do
@@ -56,6 +156,7 @@ tests = describe "Transaction summaries" $ do
     versionedTests SP9
     versionedTests SP10
     versionedTests SP11
+    testExemplarEventSerialization
   where
     versionedTests spv = describe (show $ demoteProtocolVersion spv) $ do
         specify "Event: serialize then deserialize is identity" $ withMaxSuccess 10000 $ testEventSerializationIdentity spv


### PR DESCRIPTION
## Purpose

Support to and from lock IDs in `TokenTransfer` event (in Haskell).

## Changes

- Extend the event type.
- Additional testing.

## Checklist

- [X] My code follows the style of this project.
- [X] The code compiles without warnings.
- [X] I have performed a self-review of the changes.
- [X] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.
