### PR TITLE
add missing to/from_lock fields in token transfer event

### DIFF
--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -301,12 +301,24 @@ pub struct TokenTransferEvent {
     pub amount: TokenAmount,
     /// An optional memo field that can be used to attach a message to the token
     /// transfer.
+    #[cfg_attr(
+        feature = "serde_deprecated",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
     pub memo: Option<Memo>,
     /// When the funds originate on the locked balance of an account, the
     /// identity of the lock controlling the funds.
+    #[cfg_attr(
+        feature = "serde_deprecated",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
     pub from_lock: Option<LockId>,
     /// When the funds are transferred into the control of a lock, the identity
     /// of the lock assuming control of the funds.
+    #[cfg_attr(
+        feature = "serde_deprecated",
+        serde(default, skip_serializing_if = "Option::is_none")
+    )]
     pub to_lock: Option<LockId>,
 }
 

--- a/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/token_event.rs
@@ -2,6 +2,7 @@ use super::{CborHolderAccount, RawCbor, TokenAmount};
 use crate::common;
 use crate::common::cbor::CborSerializationResult;
 use crate::common::{cbor, Buffer, Deserial, Get, ParseResult, SerdeDeserialize, Serial};
+use crate::protocol_level_locks::LockId;
 use crate::protocol_level_tokens::{MetadataUrl, TokenAdminRole};
 use crate::transactions::Memo;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
@@ -301,6 +302,12 @@ pub struct TokenTransferEvent {
     /// An optional memo field that can be used to attach a message to the token
     /// transfer.
     pub memo: Option<Memo>,
+    /// When the funds originate on the locked balance of an account, the
+    /// identity of the lock controlling the funds.
+    pub from_lock: Option<LockId>,
+    /// When the funds are transferred into the control of a lock, the identity
+    /// of the lock assuming control of the funds.
+    pub to_lock: Option<LockId>,
 }
 
 /// An event emitted when the token supply is updated, i.e. by minting/burning


### PR DESCRIPTION
## Purpose

Added missing `to_lock` and `from_lock` fields for the token transfer event.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.