### PR TITLE
Support "any" variant for recipients in lock config

### DIFF
--- a/cddl/cis-7.cddl
+++ b/cddl/cis-7.cddl
@@ -4,7 +4,7 @@
 ;   cargo install cddl
 ;   cddl compile-cddl --cddl cis-7.cddl
 
-; Common Types 
+; Common Types
 
 token-id = (text .size (1..128)) .regexp "[a-zA-Z0-9\\-.%]+"
 
@@ -93,7 +93,7 @@ epoch-time = #6.1(uint)
 
 ; Initialization
 
-; The initialization parameters are used when creating a new PLT instance. They are included as 
+; The initialization parameters are used when creating a new PLT instance. They are included as
 ; part of the CreatePLT chain update transaction. They are passed to the Token Module to
 ; initialize the state.
 token-initialization-parameters = {
@@ -448,12 +448,14 @@ meta-lock-create = {
 lock-config = (
     ; The set of accounts that are permitted to receive funds controlled
     ; by the lock.
-    "recipients": [ * tagged-account-address ],
+    "recipients": lock-recipients,
     ; The expiry time for the lock.
     "expiry": epoch-time,
     ; The initialization parameters for the lock.
     "controller": lock-controller,
 )
+
+lock-recipients = "any" / [ * tagged-account-address ]
 
 lock-controller =
     lock-controller-simple

--- a/haskell-src/Concordium/Types/Locks/CBOR.hs
+++ b/haskell-src/Concordium/Types/Locks/CBOR.hs
@@ -16,6 +16,9 @@ module Concordium.Types.Locks.CBOR (
     LockController (..),
     encodeLockController,
     decodeLockController,
+    LockRecipients (..),
+    encodeLockRecipients,
+    decodeLockRecipients,
     LockConfig (..),
     LockedTokenAmount (..),
     encodeLockAccountFunds,
@@ -32,11 +35,14 @@ module Concordium.Types.Locks.CBOR (
 
 import Codec.CBOR.Decoding
 import Codec.CBOR.Encoding
+import qualified Codec.CBOR.Term as CBORTerm
 import Control.Monad
 import qualified Data.ByteString as BS
 import qualified Data.ByteString.Lazy as LBS
 import qualified Data.Map.Lazy as Map
 import qualified Data.Sequence as Seq
+import Data.Text (Text)
+import qualified Data.Text.Lazy as LazyText
 import Lens.Micro.Platform
 
 import Concordium.Types (TransactionTime (..))
@@ -218,9 +224,41 @@ decodeLockController =
     build (Just cfg) = Right $ LockControllerSimpleV0 cfg
     build Nothing = Left "Missing \"simpleV0\""
 
+-- | Accounts that can receive funds controlled by a lock.
+data LockRecipients
+    = LockRecipientsAny
+    | LockRecipientsLimited !(Seq.Seq CborAccountAddress)
+    deriving (Eq, Show)
+
+-- | Encode lock recipients as CBOR text @"any"@ or an account-address array.
+encodeLockRecipients :: LockRecipients -> Encoding
+encodeLockRecipients LockRecipientsAny = encodeString "any"
+encodeLockRecipients (LockRecipientsLimited accounts) = encodeSequence CBOR.encodeCborAccountAddress accounts
+
+-- | Decode lock recipients from CBOR text @"any"@ or an account-address array.
+decodeLockRecipients :: Decoder s LockRecipients
+decodeLockRecipients = do
+    term <- CBORTerm.decodeTerm
+    either fail return $ decodeLockRecipientsHelper term
+
+-- | Decode lock recipients from a CBOR term.
+decodeLockRecipientsHelper :: CBORTerm.Term -> Either String LockRecipients
+decodeLockRecipientsHelper = \case
+    CBORTerm.TString "any" -> return LockRecipientsAny
+    CBORTerm.TString value -> unsupportedText value
+    CBORTerm.TStringI value ->
+        let strictValue = LazyText.toStrict value
+        in  if strictValue == "any" then return LockRecipientsAny else unsupportedText strictValue
+    CBORTerm.TList accounts -> LockRecipientsLimited . Seq.fromList <$> traverse CBOR.decodeCborAccountAddressHelper accounts
+    CBORTerm.TListI accounts -> LockRecipientsLimited . Seq.fromList <$> traverse CBOR.decodeCborAccountAddressHelper accounts
+    term -> Left $ "lock recipients: expected text \"any\" or account address array, found " ++ show term
+  where
+    unsupportedText :: Text -> Either String LockRecipients
+    unsupportedText value = Left $ "Unsupported lock recipients text value: " ++ show value
+
 -- | Static configuration of a lock.
 data LockConfig = LockConfig
-    { lcRecipients :: !(Seq.Seq CborAccountAddress),
+    { lcRecipients :: !LockRecipients,
       lcExpiry :: !TransactionTime,
       lcController :: !LockController
     }
@@ -321,7 +359,7 @@ data LockInfoDetails = LockInfoDetails
 
 data LockInfoDetailsBuilder = LockInfoDetailsBuilder
     { _lidbLock :: !(Maybe LockId),
-      _lidbRecipients :: !(Maybe (Seq.Seq CborAccountAddress)),
+      _lidbRecipients :: !(Maybe LockRecipients),
       _lidbExpiry :: !(Maybe TransactionTime),
       _lidbController :: !(Maybe LockController),
       _lidbFunds :: !(Maybe (Seq.Seq LockAccountFunds))
@@ -344,7 +382,7 @@ decodeLockInfoDetails =
         lipFunds <- _lidbFunds `CBOR.orFail` "Missing \"funds\""
         return LockInfoDetails{lipConfig = LockConfig{..}, ..}
     valDecoder k@"lock" = Just $ mapValueDecoder k decodeLockId lidbLock
-    valDecoder k@"recipients" = Just $ mapValueDecoder k (decodeSequence CBOR.decodeCborAccountAddress) lidbRecipients
+    valDecoder k@"recipients" = Just $ mapValueDecoder k decodeLockRecipients lidbRecipients
     valDecoder k@"expiry" = Just $ mapValueDecoder k decodeEpochTime lidbExpiry
     valDecoder k@"controller" = Just $ mapValueDecoder k decodeLockController lidbController
     valDecoder k@"funds" = Just $ mapValueDecoder k (decodeSequence decodeLockAccountFunds) lidbFunds
@@ -355,7 +393,7 @@ encodeLockInfoDetails LockInfoDetails{..} =
     encodeMapDeterministic $
         Map.empty
             & k "lock" ?~ encodeLockId lipLock
-            & k "recipients" ?~ encodeSequence CBOR.encodeCborAccountAddress (lcRecipients lipConfig)
+            & k "recipients" ?~ encodeLockRecipients (lcRecipients lipConfig)
             & k "expiry" ?~ encodeEpochTime (lcExpiry lipConfig)
             & k "controller" ?~ encodeLockController (lcController lipConfig)
             & k "funds" ?~ encodeSequence encodeLockAccountFunds lipFunds

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -17,6 +17,7 @@ import qualified Data.ByteString as BS
 import qualified Data.ByteString.Base16 as BS16
 import qualified Data.ByteString.Lazy.Char8 as B8
 import qualified Data.ByteString.Short as BSS
+import Data.Either (isLeft)
 import qualified Data.FixedByteString as FBS
 import qualified Data.Map as Map
 import qualified Data.Sequence as Seq
@@ -1230,7 +1231,7 @@ exampleLockInfoDetails =
                 },
           lipConfig =
             LockConfig
-                { lcRecipients = Seq.singleton $ accountTokenHolder acc,
+                { lcRecipients = LockRecipientsLimited . Seq.singleton $ accountTokenHolder acc,
                   lcExpiry = TransactionTime 1804806000,
                   lcController =
                     LockControllerSimpleV0
@@ -1317,6 +1318,53 @@ testLockInfoDetailsCBOR = describe "LockInfoDetails CBOR" $ do
             `shouldBe` Right exampleLockInfoDetails
         BS16.encode (lockInfoToBytes exampleLockInfoDetails)
             `shouldBe` exampleLockInfoDetailsCBOR
+    it "any recipients fixture" $ do
+        let lockInfoAny =
+                exampleLockInfoDetails
+                    { lipConfig = (lipConfig exampleLockInfoDetails){lcRecipients = LockRecipientsAny}
+                    }
+            lockInfoAnyCBOR =
+                mconcat
+                    [ "a5",
+                      "646c6f636b",
+                      "d99fd8831927110500",
+                      "6566756e6473",
+                      "81",
+                      "a2",
+                      "676163636f756e74",
+                      "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+                      "67616d6f756e7473",
+                      "81",
+                      "a2",
+                      "65746f6b656e",
+                      "627454",
+                      "66616d6f756e74",
+                      "c4822219300c",
+                      "66657870697279",
+                      "c11a6b932770",
+                      "6a636f6e74726f6c6c6572",
+                      "a1",
+                      "6873696d706c655630",
+                      "a2",
+                      "666772616e7473",
+                      "81",
+                      "a2",
+                      "65726f6c6573",
+                      "82",
+                      "6466756e64",
+                      "6473656e64",
+                      "676163636f756e74",
+                      "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+                      "66746f6b656e73",
+                      "81",
+                      "627454",
+                      "6a726563697069656e7473",
+                      "63616e79"
+                    ]
+        lockInfoFromBytes (B8.fromStrict $ BS16.decodeLenient lockInfoAnyCBOR)
+            `shouldBe` Right lockInfoAny
+        BS16.encode (lockInfoToBytes lockInfoAny)
+            `shouldBe` lockInfoAnyCBOR
 
 -- * Lock CBOR tests
 
@@ -1361,6 +1409,30 @@ testLockIdCBOR = describe "LockId CBOR" $ do
             decodeLockId
             (LockId 10001 5 0)
             "d99fd8831927110500"
+
+testLockRecipientsCBOR :: Spec
+testLockRecipientsCBOR = describe "LockRecipients CBOR" $ do
+    it "any" $
+        lockFixture
+            encodeLockRecipients
+            decodeLockRecipients
+            LockRecipientsAny
+            "63616e79"
+    it "limited single account" $
+        lockFixture
+            encodeLockRecipients
+            decodeLockRecipients
+            (LockRecipientsLimited $ Seq.singleton $ accountTokenHolder lockTestAcc)
+            ("81" <> lockTestAccHex)
+    it "limited empty" $
+        lockFixture
+            encodeLockRecipients
+            decodeLockRecipients
+            (LockRecipientsLimited Seq.empty)
+            "80"
+    it "rejects unknown text" $
+        lockDecode decodeLockRecipients (BS16.decodeLenient "63616c6c")
+            `shouldSatisfy` isLeft
 
 testLockControllerSimpleV0CapabilityCBOR :: Spec
 testLockControllerSimpleV0CapabilityCBOR = describe "LockControllerSimpleV0Capability CBOR" $ do
@@ -1661,6 +1733,7 @@ tests = parallel $ describe "CBOR" $ do
     testTokenAuthorizationsMapJSON
     testLockInfoDetailsCBOR
     testLockIdCBOR
+    testLockRecipientsCBOR
     testLockControllerSimpleV0CapabilityCBOR
     testLockControllerSimpleV0GrantCBOR
     testLockControllerSimpleConfigV0CBOR

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config.rs
@@ -1,16 +1,66 @@
 use super::LockController;
-use crate::common::types::TransactionTime;
+use crate::common::{
+    cbor::{
+        CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
+        CborSerialize, DataItemHeader,
+    },
+    types::TransactionTime,
+};
 use crate::protocol_level_tokens::CborHolderAccount;
 use concordium_base_derive::{CborDeserialize, CborSerialize};
 
+/// Accounts that can receive funds controlled by a lock.
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum LockRecipients {
+    /// Any eligible account can receive funds from this lock.
+    Any,
+    /// Only the listed accounts can receive funds from this lock.
+    Limited(Vec<CborHolderAccount>),
+}
+
+impl CborSerialize for LockRecipients {
+    fn serialize<C: CborEncoder>(&self, encoder: C) -> Result<(), C::WriteError> {
+        match self {
+            Self::Any => encoder.encode_text("any"),
+            Self::Limited(accounts) => accounts.serialize(encoder),
+        }
+    }
+}
+
+impl CborDeserialize for LockRecipients {
+    fn deserialize<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        match decoder.peek_data_item_header()? {
+            DataItemHeader::Text(_) => {
+                let value = String::deserialize(decoder)?;
+                if value == "any" {
+                    Ok(Self::Any)
+                } else {
+                    Err(CborSerializationError::invalid_data(format_args!(
+                        "unsupported lock recipients text value {value:?}"
+                    )))
+                }
+            }
+            DataItemHeader::Array(_) => Ok(Self::Limited(Vec::deserialize(decoder)?)),
+            header => Err(CborSerializationError::invalid_data(format_args!(
+                "lock recipients must be text \"any\" or an array of account addresses, was {header:?}"
+            ))),
+        }
+    }
+}
+
 /// Top-level lock configuration.
 ///
-/// Contains the list of recipients, the expiry time, and the controller
-/// configuration for a lock.
+/// Contains the recipients, the expiry time, and the controller configuration
+/// for a lock.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
 pub struct LockConfig {
-    /// Accounts that can receive funds from this lock.
-    pub recipients: Vec<CborHolderAccount>,
+    /// Accounts that can receive funds from this lock, or `Any` for any
+    /// eligible recipient.
+    pub recipients: LockRecipients,
     /// Expiry time of the lock (seconds since epoch).
     pub expiry: TransactionTime,
     /// Controller configuration for the lock.
@@ -29,7 +79,7 @@ mod test {
     /// Build a full `LockConfig` for testing.
     fn example_lock_config() -> LockConfig {
         LockConfig {
-            recipients: vec![CborHolderAccount::from(ADDRESS)],
+            recipients: LockRecipients::Limited(vec![CborHolderAccount::from(ADDRESS)]),
             expiry: TransactionTime::from_seconds(1804806000),
             controller: LockController::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
@@ -59,7 +109,10 @@ mod test {
     #[test]
     fn test_lock_config_cbor_round_trip_multiple_recipients() {
         let mut config = example_lock_config();
-        config.recipients.push(CborHolderAccount::from(ADDRESS));
+        config.recipients = LockRecipients::Limited(vec![
+            CborHolderAccount::from(ADDRESS),
+            CborHolderAccount::from(ADDRESS),
+        ]);
         let encoded = cbor::cbor_encode(&config);
         let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
         assert_eq!(decoded, config);
@@ -69,13 +122,23 @@ mod test {
     #[test]
     fn test_lock_config_cbor_round_trip_empty_recipients() {
         let mut config = example_lock_config();
-        config.recipients = vec![];
+        config.recipients = LockRecipients::Limited(vec![]);
         let encoded = cbor::cbor_encode(&config);
         let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
         assert_eq!(decoded, config);
     }
 
-    /// Fixture test: verify the exact CBOR encoding of a `LockConfig`.
+    /// Round-trip test with any recipients.
+    #[test]
+    fn test_lock_config_cbor_round_trip_any_recipients() {
+        let mut config = example_lock_config();
+        config.recipients = LockRecipients::Any;
+        let encoded = cbor::cbor_encode(&config);
+        let decoded: LockConfig = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, config);
+    }
+
+    /// Fixture test: verify the exact CBOR encoding of limited recipients.
     ///
     /// Expected CBOR structure (diagnostic notation):
     /// ```text
@@ -95,9 +158,9 @@ mod test {
     /// Note: `keep_alive: false` and `memo: None` are omitted from the CBOR
     /// map, so the inner `LockControllerSimpleV0` map has only 2 entries.
     #[test]
-    fn test_lock_config_cbor_fixture() {
+    fn test_lock_config_cbor_fixture_limited_recipients() {
         let config = LockConfig {
-            recipients: vec![CborHolderAccount::from(ADDRESS)],
+            recipients: LockRecipients::Limited(vec![CborHolderAccount::from(ADDRESS)]),
             expiry: TransactionTime::from_seconds(1804806000),
             controller: LockController::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![],
@@ -144,5 +207,49 @@ mod test {
             "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20", // CborHolderAccount
         );
         assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    /// Fixture test: verify the exact CBOR encoding of any recipients.
+    #[test]
+    fn test_lock_config_cbor_fixture_any_recipients() {
+        let config = LockConfig {
+            recipients: LockRecipients::Any,
+            expiry: TransactionTime::from_seconds(1804806000),
+            controller: LockController::SimpleV0(LockControllerSimpleV0 {
+                grants: vec![],
+                tokens: vec![],
+                keep_alive: false,
+                memo: None,
+            }),
+        };
+        let encoded = cbor::cbor_encode(&config);
+        let expected = concat!(
+            "a3",                     // map(3)
+            "66657870697279",         // text "expiry"
+            "c11a6b932770",           // tag(1) uint(1804806000)
+            "6a636f6e74726f6c6c6572", // text "controller"
+            "a1",                     // map(1) — LockController
+            "6873696d706c655630",     // text "simpleV0"
+            "a2",                     // map(2) — LockControllerSimpleV0
+            "666772616e7473",         // text "grants"
+            "80",                     // array(0)
+            "66746f6b656e73",         // text "tokens"
+            "80",                     // array(0)
+            "6a726563697069656e7473", // text "recipients"
+            "63616e79",               // text "any"
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    /// Decode rejects unknown text recipient values.
+    #[test]
+    fn test_lock_recipients_cbor_rejects_unknown_text() {
+        let err = cbor::cbor_decode::<LockRecipients>(hex::decode("63616c6c").unwrap())
+            .expect_err("CBOR decode should fail");
+        assert!(
+            err.to_string()
+                .contains("unsupported lock recipients text value"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/rust-src/concordium_base/src/protocol_level_locks/queries.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/queries.rs
@@ -1,4 +1,4 @@
-use super::{LockController, LockId};
+use super::{LockController, LockId, LockRecipients};
 use crate::common::types::TransactionTime;
 use crate::protocol_level_tokens::{CborHolderAccount, TokenAmount, TokenId};
 use concordium_base_derive::{CborDeserialize, CborSerialize};
@@ -8,8 +8,9 @@ use concordium_base_derive::{CborDeserialize, CborSerialize};
 pub struct LockInfo {
     /// The lock identifier.
     pub lock: LockId,
-    /// Accounts that can receive funds from this lock.
-    pub recipients: Vec<CborHolderAccount>,
+    /// Accounts that can receive funds from this lock, or `Any` for any
+    /// eligible recipient.
+    pub recipients: LockRecipients,
     /// Expiry time of the lock (seconds since epoch).
     pub expiry: TransactionTime,
     /// Controller configuration for the lock.
@@ -56,9 +57,15 @@ mod test {
     }
 
     fn example_lock_info() -> LockInfo {
+        example_lock_info_with_recipients(LockRecipients::Limited(vec![CborHolderAccount::from(
+            ADDRESS,
+        )]))
+    }
+
+    fn example_lock_info_with_recipients(recipients: LockRecipients) -> LockInfo {
         LockInfo {
             lock: example_lock_id(),
-            recipients: vec![CborHolderAccount::from(ADDRESS)],
+            recipients,
             expiry: TransactionTime::from_seconds(1804806000),
             controller: LockController::SimpleV0(LockControllerSimpleV0 {
                 grants: vec![LockControllerSimpleV0Grant {
@@ -131,6 +138,66 @@ mod test {
             "6a726563697069656e7473",
             "81",
             "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+        );
+        assert_eq!(hex::encode(&encoded), expected);
+    }
+
+    #[test]
+    fn test_lock_info_cbor_round_trip_any_recipients() {
+        let lock_info = example_lock_info_with_recipients(LockRecipients::Any);
+        let encoded = cbor::cbor_encode(&lock_info);
+        let decoded: LockInfo = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, lock_info);
+    }
+
+    #[test]
+    fn test_lock_info_cbor_round_trip_empty_limited_recipients() {
+        let lock_info = example_lock_info_with_recipients(LockRecipients::Limited(vec![]));
+        let encoded = cbor::cbor_encode(&lock_info);
+        let decoded: LockInfo = cbor::cbor_decode(&encoded).expect("CBOR decode failed");
+        assert_eq!(decoded, lock_info);
+    }
+
+    #[test]
+    fn test_lock_info_cbor_fixture_any_recipients() {
+        let lock_info = example_lock_info_with_recipients(LockRecipients::Any);
+        let encoded = cbor::cbor_encode(&lock_info);
+        let expected = concat!(
+            "a5",
+            "646c6f636b",
+            "d99fd8831927110500",
+            "6566756e6473",
+            "81",
+            "a2",
+            "676163636f756e74",
+            "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            "67616d6f756e7473",
+            "81",
+            "a2",
+            "65746f6b656e",
+            "63434344",
+            "66616d6f756e74",
+            "c4822219300c",
+            "66657870697279",
+            "c11a6b932770",
+            "6a636f6e74726f6c6c6572",
+            "a1",
+            "6873696d706c655630",
+            "a2",
+            "666772616e7473",
+            "81",
+            "a2",
+            "65726f6c6573",
+            "82",
+            "6466756e64",
+            "6473656e64",
+            "676163636f756e74",
+            "d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20",
+            "66746f6b656e73",
+            "81",
+            "63434344",
+            "6a726563697069656e7473",
+            "63616e79"
         );
         assert_eq!(hex::encode(&encoded), expected);
     }

--- a/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
@@ -561,7 +561,7 @@ mod tests {
     use crate::common::types::TransactionTime;
     use crate::protocol_level_locks::{
         LockController, LockControllerSimpleV0, LockControllerSimpleV0Capability,
-        LockControllerSimpleV0Grant,
+        LockControllerSimpleV0Grant, LockRecipients,
     };
     use crate::protocol_level_tokens::{test_fixtures::ADDRESS, MetadataUrl, TokenAdminRole};
     use crate::transactions::Memo;
@@ -831,7 +831,7 @@ mod tests {
     fn test_meta_operation_cbor_lock_create() {
         let operation = MetaUpdateOperation::LockCreate(MetaLockCreateDetails {
             config: LockConfig {
-                recipients: vec![CborHolderAccount::from(ADDRESS)],
+                recipients: LockRecipients::Limited(vec![CborHolderAccount::from(ADDRESS)]),
                 expiry: TransactionTime::from_seconds(1_000_000),
                 controller: LockController::SimpleV0(LockControllerSimpleV0 {
                     grants: vec![


### PR DESCRIPTION
Ref COR-2427, Ref COR-2420, Ref COR-2418

## Purpose

Adds support for lock configurations with "any" recipient.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.