### PR TITLE
Max lock duration execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
 ## Unreleased
+
+- Add the P11 `LockDurationTooLong` transaction reject reason for PLT lock creation beyond the configured maximum duration.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,1 @@
 ## Unreleased
-
-- Add the P11 `LockDurationTooLong` transaction reject reason for PLT lock creation beyond the configured maximum duration.

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -805,6 +805,7 @@ instance ToProto RejectReason where
                             ProtoFields.tokenId .= toProto ltrrdTokenId
                         )
         LockRecipientNotPermitted LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockRecipientNotPermitted .= mkLockOpNotAuth larrdLockId larrdAccount
+        LockDurationTooLong lockId -> Proto.make $ ProtoFields.lockDurationTooLong .= toProto lockId
       where
         mkLockOpNotAuth lockId address = Proto.make $ do
             ProtoFields.lockId .= toProto lockId

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -2938,6 +2938,8 @@ data RejectReason
       LockTokenNotPermitted !LockTokenRejectReasonDetails
     | -- | The recipient is not permitted to receive funds controlled by the lock.
       LockRecipientNotPermitted !LockAccountRejectReasonDetails
+    | -- | The requested expiry exceeds the maximum permitted lock duration.
+      LockDurationTooLong !LockId
     deriving (Show, Eq, Generic)
 
 -- | Details for lock reject reasons involving an account.
@@ -3049,6 +3051,7 @@ instance S.Serialize RejectReason where
         LockCancelNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 62 <> S.put larrdLockId <> S.put larrdAccount
         LockTokenNotPermitted LockTokenRejectReasonDetails{..} -> S.putWord8 63 <> S.put ltrrdLockId <> S.put ltrrdTokenId
         LockRecipientNotPermitted LockAccountRejectReasonDetails{..} -> S.putWord8 64 <> S.put larrdLockId <> S.put larrdAccount
+        LockDurationTooLong lockId -> S.putWord8 65 <> S.put lockId
     get =
         S.getWord8 >>= \case
             0 -> return ModuleNotWF
@@ -3125,6 +3128,7 @@ instance S.Serialize RejectReason where
             62 -> LockCancelNotAuthorized <$> getLockAccountRejectReasonDetails
             63 -> LockTokenNotPermitted <$> getLockTokenRejectReasonDetails
             64 -> LockRecipientNotPermitted <$> getLockAccountRejectReasonDetails
+            65 -> LockDurationTooLong <$> S.get
             n -> fail $ "Unrecognized RejectReason tag: " ++ show n
 
 instance AE.ToJSON RejectReason

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -908,7 +908,8 @@ instance Arbitrary RejectReason where
               LockReturnNotAuthorized <$> genLockAccountRejectReasonDetails,
               LockCancelNotAuthorized <$> genLockAccountRejectReasonDetails,
               LockTokenNotPermitted <$> genLockTokenRejectReasonDetails,
-              LockRecipientNotPermitted <$> genLockAccountRejectReasonDetails
+              LockRecipientNotPermitted <$> genLockAccountRejectReasonDetails,
+              LockDurationTooLong <$> genLockId
             ]
 
 genValidResult :: (IsProtocolVersion pv) => SProtocolVersion pv -> Gen ValidResult

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -138,6 +138,10 @@ testLockRejectReasonJSONRepresentation = do
         assertJSON
             (LockExpired lockId)
             (AE.object ["tag" AE..= ("LockExpired" :: String), "contents" AE..= lockId])
+    it "encodes and decodes LockDurationTooLong with contents" $
+        assertJSON
+            (LockDurationTooLong lockId)
+            (AE.object ["tag" AE..= ("LockDurationTooLong" :: String), "contents" AE..= lockId])
     it "encodes and decodes lock account rejects with contents" $ do
         assertJSON
             (LockFundNotAuthorized accountDetails)


### PR DESCRIPTION
Ref COR-2335

Depends on https://github.com/Concordium/concordium-grpc-api/pull/123

## Purpose

Adds reject reason used for transactions failing due to lock creation expiry bounds

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.