### PR TITLE
Add nested CBOR limit

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -14,6 +14,8 @@
   - `LockAccountFunds`
   - `LockedTokenAmount`
 - Added CBOR serialization for `TransactionTime` and `TokenId`.
+- Dynamic CBOR `Value` decoding and skipped-item traversal now default to a maximum nesting depth of 128;
+  the finite limit is configurable through `SerializationOptions`, and exceeding it returns an error.
 
 - Introduce `TokenAuthorizations` representing the CBOR encoding of the `getTokenAuthorizations` query.
 - Introduce lock query boundary types representing the CBOR encoding of the `getLockInfo` query.

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -329,15 +329,38 @@ pub enum UnknownMapKeys {
     Fail,
 }
 
-/// Options applied when serializing and deserializing
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+/// Options applied when serializing and deserializing.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SerializationOptions {
     pub unknown_map_keys: UnknownMapKeys,
+    /// Maximum depth of nested CBOR arrays, maps, and tags.
+    pub max_nesting_depth: usize,
+}
+
+impl Default for SerializationOptions {
+    fn default() -> Self {
+        Self {
+            unknown_map_keys: UnknownMapKeys::default(),
+            max_nesting_depth: 128,
+        }
+    }
 }
 
 impl SerializationOptions {
+    /// Sets how unknown keys in decoded CBOR maps are handled.
     pub fn unknown_map_keys(self, unknown_map_keys: UnknownMapKeys) -> Self {
-        Self { unknown_map_keys }
+        Self {
+            unknown_map_keys,
+            ..self
+        }
+    }
+
+    /// Sets the finite maximum depth of nested CBOR arrays, maps, and tags.
+    pub fn max_nesting_depth(self, max_nesting_depth: usize) -> Self {
+        Self {
+            max_nesting_depth,
+            ..self
+        }
     }
 }
 
@@ -389,6 +412,11 @@ impl CborSerializationError {
         } else {
             anyhow!("expected map size {}, was indefinite", expected).into()
         }
+    }
+
+    /// Returns an error indicating that CBOR nesting exceeded `max_nesting_depth`.
+    pub fn nesting_limit_exceeded(max_nesting_depth: usize) -> Self {
+        anyhow!("maximum nesting depth of {} exceeded", max_nesting_depth).into()
     }
 }
 
@@ -490,6 +518,21 @@ pub trait CborDeserialize {
     fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
     where
         Self: Sized;
+
+    /// Deserialize while preserving the current CBOR structural nesting depth.
+    ///
+    /// Container decoders use this to propagate the current depth when recursively
+    /// decoding dynamic values. The default preserves compatibility for types that
+    /// do not track nesting depth.
+    fn deserialize_with_nesting_depth<C: CborDecoder>(
+        decoder: C,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize(decoder)
+    }
 
     fn deserialize_maybe_known<C: CborDecoder>(
         decoder: C,
@@ -747,8 +790,30 @@ pub trait CborMapDecoder {
     /// all entries in the map has been deserialized.
     fn deserialize_key<K: CborDeserialize>(&mut self) -> CborSerializationResult<Option<K>>;
 
+    /// Deserialize an entry key while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Option<K>> {
+        self.deserialize_key()
+    }
+
     /// Deserialize an entry value.
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V>;
+
+    /// Deserialize an entry value while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<V> {
+        self.deserialize_value()
+    }
 
     /// Skips entry value
     fn skip_value(&mut self) -> CborSerializationResult<()>;
@@ -765,6 +830,17 @@ pub trait CborArrayDecoder {
     /// The total number of elements that can be deserialized is equal
     /// to [`Self::size`].
     fn deserialize_element<T: CborDeserialize>(&mut self) -> CborSerializationResult<Option<T>>;
+
+    /// Deserialize an array element while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Option<T>> {
+        self.deserialize_element()
+    }
 }
 
 impl<T: CborSerialize> CborSerialize for &T {
@@ -940,6 +1016,29 @@ mod test {
 
     use crate::common::cbor::value::Value;
     use std::collections::HashMap;
+
+    #[test]
+    fn serialization_options_default_nesting_depth() {
+        assert_eq!(SerializationOptions::default().max_nesting_depth, 128);
+    }
+
+    #[test]
+    fn serialization_options_custom_nesting_depth() {
+        let options = SerializationOptions::default()
+            .unknown_map_keys(UnknownMapKeys::Fail)
+            .max_nesting_depth(64);
+
+        assert_eq!(options.max_nesting_depth, 64);
+        assert_eq!(options.unknown_map_keys, UnknownMapKeys::Fail);
+    }
+
+    #[test]
+    fn nesting_limit_error_includes_limit() {
+        assert_eq!(
+            CborSerializationError::nesting_limit_exceeded(64).to_string(),
+            "maximum nesting depth of 64 exceeded"
+        );
+    }
 
     /// Struct with named fields encoded as map. Uses field name string literals
     /// as keys.
@@ -1660,8 +1759,7 @@ mod test {
         let err = cbor_decode::<Vec<u64>>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -1683,8 +1781,7 @@ mod test {
         let err = cbor_decode::<HashMap<u64, u64>>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -22,6 +22,96 @@ impl<R: Read> Decoder<R> {
     }
 }
 
+impl<R: Read> Decoder<R>
+where
+    R::Error: std::error::Error,
+{
+    fn skip_data_item_at_nesting_depth(
+        mut self: &mut Self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<()> {
+        match self.peek_data_item_header()?.to_type() {
+            DataItemType::Positive
+            | DataItemType::Negative
+            | DataItemType::Simple
+            | DataItemType::Float => {
+                self.inner.pull()?;
+            }
+            DataItemType::Tag => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                self.inner.pull()?;
+                self.skip_data_item_at_nesting_depth(nesting_depth)?;
+            }
+            DataItemType::Bytes => {
+                self.decode_bytes()?;
+            }
+            DataItemType::Text => {
+                self.decode_text()?;
+            }
+            DataItemType::Array => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                let array_decoder = self.decode_array()?;
+                // Arrays of definite length encodes "size" number of data item elements,
+                // arrays of indefinite length encodes data item elements until a break is
+                // encountered.
+                if let Some(size) = array_decoder.size() {
+                    for _ in 0..size {
+                        array_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                } else {
+                    while !array_decoder.decoder.pull_break()? {
+                        array_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                }
+            }
+            DataItemType::Map => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                let map_decoder = self.decode_map()?;
+                // Maps of definite length encodes "size" number of data item pairs,
+                // maps of indefinite length encodes data item pairs until a break is
+                // encountered.
+                if let Some(size) = map_decoder.size() {
+                    for _ in 0..size {
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                } else {
+                    while !map_decoder.decoder.pull_break()? {
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                }
+            }
+            DataItemType::Break => {
+                return Err(anyhow!("break is not a valid data item").into());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn next_nesting_depth(&self, nesting_depth: usize) -> CborSerializationResult<usize> {
+        nesting_depth
+            .checked_add(1)
+            .filter(|depth| *depth <= self.options.max_nesting_depth)
+            .ok_or_else(|| {
+                CborSerializationError::nesting_limit_exceeded(self.options.max_nesting_depth)
+            })
+    }
+}
+
 impl<'a, R: Read> CborDecoder for &'a mut Decoder<R>
 where
     <R as Read>::Error: std::error::Error,
@@ -155,62 +245,8 @@ where
         DataItemHeader::try_from_header(self.peek_header()?)
     }
 
-    fn skip_data_item(mut self) -> CborSerializationResult<()> {
-        match self.peek_data_item_header()?.to_type() {
-            DataItemType::Positive
-            | DataItemType::Negative
-            | DataItemType::Simple
-            | DataItemType::Float => {
-                self.inner.pull()?;
-            }
-            DataItemType::Tag => {
-                self.inner.pull()?;
-                self.skip_data_item()?;
-            }
-            DataItemType::Bytes => {
-                self.decode_bytes()?;
-            }
-            DataItemType::Text => {
-                self.decode_text()?;
-            }
-            DataItemType::Array => {
-                let array_decoder = self.decode_array()?;
-                // Arrays of definite length encodes "size" number of data item elements,
-                // arrays of indefinite length encodes data item elements until a break is
-                // encountered.
-                if let Some(size) = array_decoder.size() {
-                    for _ in 0..size {
-                        array_decoder.decoder.skip_data_item()?;
-                    }
-                } else {
-                    while !array_decoder.decoder.pull_break()? {
-                        array_decoder.decoder.skip_data_item()?;
-                    }
-                }
-            }
-            DataItemType::Map => {
-                let map_decoder = self.decode_map()?;
-                // Maps of definite length encodes "size" number of data item pairs,
-                // maps of indefinite length encodes data item pairs until a break is
-                // encountered.
-                if let Some(size) = map_decoder.size() {
-                    for _ in 0..size {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
-                    }
-                } else {
-                    while !map_decoder.decoder.pull_break()? {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
-                    }
-                }
-            }
-            DataItemType::Break => {
-                return Err(anyhow!("break is not a valid data item").into());
-            }
-        }
-
-        Ok(())
+    fn skip_data_item(self) -> CborSerializationResult<()> {
+        self.skip_data_item_at_nesting_depth(0)
     }
 
     fn options(&self) -> SerializationOptions {
@@ -408,6 +444,36 @@ where
         Ok(Some(K::deserialize(&mut *self.decoder)?))
     }
 
+    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Option<K>> {
+        self.state = match self.state {
+            MapDecoderStateEnum::ExpectKey => MapDecoderStateEnum::ExpectValue,
+            MapDecoderStateEnum::ExpectValue => {
+                return Err(anyhow!(
+                    "map decoder expected to decode entry value since entry key was decoded last"
+                )
+                .into());
+            }
+        };
+
+        if let Some(declared_size) = self.declared_size {
+            if self.decoded_entries == declared_size {
+                return Ok(None);
+            }
+        } else if self.decoder.pull_break()? {
+            return Ok(None);
+        }
+
+        self.decoded_entries += 1;
+
+        Ok(Some(K::deserialize_with_nesting_depth(
+            &mut *self.decoder,
+            nesting_depth,
+        )?))
+    }
+
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V> {
         self.state = match self.state {
             MapDecoderStateEnum::ExpectKey => {
@@ -420,6 +486,23 @@ where
         };
 
         V::deserialize(&mut *self.decoder)
+    }
+
+    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<V> {
+        self.state = match self.state {
+            MapDecoderStateEnum::ExpectKey => {
+                return Err(anyhow!(
+                    "map decoder expected to decode entry key since entry value was decoded last"
+                )
+                .into());
+            }
+            MapDecoderStateEnum::ExpectValue => MapDecoderStateEnum::ExpectKey,
+        };
+
+        V::deserialize_with_nesting_depth(&mut *self.decoder, nesting_depth)
     }
 
     fn skip_value(&mut self) -> CborSerializationResult<()> {
@@ -478,6 +561,26 @@ where
         self.decoded_elements += 1;
 
         Ok(Some(T::deserialize(&mut *self.decoder)?))
+    }
+
+    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Option<T>> {
+        if let Some(declared_size) = self.declared_size {
+            if self.decoded_elements == declared_size {
+                return Ok(None);
+            }
+        } else if self.decoder.pull_break()? {
+            return Ok(None);
+        }
+
+        self.decoded_elements += 1;
+
+        Ok(Some(T::deserialize_with_nesting_depth(
+            &mut *self.decoder,
+            nesting_depth,
+        )?))
     }
 }
 
@@ -847,6 +950,105 @@ mod test {
             encoder.push(Header::Positive(2)).unwrap();
             encoder.push(Header::Break).unwrap();
         });
+    }
+
+    fn nested_array(depth: usize, indefinite: bool) -> Vec<u8> {
+        let mut cbor = vec![if indefinite { 0x9f } else { 0x81 }; depth];
+        cbor.push(0);
+        if indefinite {
+            cbor.extend(std::iter::repeat_n(0xff, depth));
+        }
+        cbor
+    }
+
+    fn nested_map(depth: usize, indefinite: bool) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(3 * depth + 1);
+        for _ in 0..depth {
+            cbor.extend([if indefinite { 0xbf } else { 0xa1 }, 0]);
+        }
+        cbor.push(0);
+        if indefinite {
+            cbor.extend(std::iter::repeat_n(0xff, depth));
+        }
+        cbor
+    }
+
+    fn nested_tag(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0xc0; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    fn mixed_nested_structures(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(3 * depth + 1);
+        let mut breaks = 0;
+        for index in 0..depth {
+            match index % 5 {
+                0 => cbor.push(0x81),
+                1 => {
+                    cbor.push(0x9f);
+                    breaks += 1;
+                }
+                2 => cbor.extend([0xa1, 0]),
+                3 => {
+                    cbor.extend([0xbf, 0]);
+                    breaks += 1;
+                }
+                _ => cbor.push(0xc0),
+            }
+        }
+        cbor.push(0);
+        cbor.extend(std::iter::repeat_n(0xff, breaks));
+        cbor
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_boundary() {
+        for cbor in [
+            nested_array(128, false),
+            nested_array(128, true),
+            nested_map(128, false),
+            nested_map(128, true),
+            nested_tag(128),
+        ] {
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            decoder.skip_data_item().unwrap();
+        }
+
+        for cbor in [
+            nested_array(129, false),
+            nested_array(129, true),
+            nested_map(129, false),
+            nested_map(129, true),
+            nested_tag(129),
+        ] {
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            let error = decoder.skip_data_item().unwrap_err();
+            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+        }
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_mixed_structures() {
+        for depth in [128, 129] {
+            let cbor = mixed_nested_structures(depth);
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            let result = decoder.skip_data_item();
+            assert_eq!(result.is_ok(), depth <= 128);
+        }
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_uses_custom_option() {
+        let options = SerializationOptions::default().max_nesting_depth(3);
+        let cbor = nested_map(3, true);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder.skip_data_item().unwrap();
+
+        let cbor = nested_map(4, true);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        let error = decoder.skip_data_item().unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
     }
 
     fn test_skip_data_item_impl(encode_data_item: impl FnOnce(&mut Encoder<&mut Vec<u8>>)) {

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -1,6 +1,7 @@
 use crate::common::cbor::{
     self, Bytes, CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
-    CborMapDecoder, CborMapEncoder, CborSerializationResult, CborSerialize, DataItemHeader,
+    CborMapDecoder, CborMapEncoder, CborSerializationError, CborSerializationResult, CborSerialize,
+    DataItemHeader,
 };
 use anyhow::Context;
 use ciborium_ll::simple;
@@ -76,11 +77,11 @@ impl CborSerialize for Value {
     }
 }
 
-impl CborDeserialize for Value {
-    fn deserialize<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
+impl Value {
+    fn deserialize_at_nesting_depth<C: CborDecoder>(
+        mut decoder: C,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Self> {
         Ok(match decoder.peek_data_item_header()? {
             DataItemHeader::Positive(_) => Value::Positive(decoder.decode_positive()?),
             DataItemHeader::Negative(_) => Value::Negative(decoder.decode_negative()?),
@@ -90,29 +91,37 @@ impl CborDeserialize for Value {
                     .context("text data item not valid UTF8 encoding")?,
             ),
             DataItemHeader::Array(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut array_decoder = decoder.decode_array()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     array_decoder.size().unwrap_or_default(),
                 ));
-                while let Some(element) = array_decoder.deserialize_element()? {
+                while let Some(element) =
+                    array_decoder.deserialize_element_with_nesting_depth(nesting_depth)?
+                {
                     vec.push(element);
                 }
                 Value::Array(vec)
             }
             DataItemHeader::Map(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut map_decoder = decoder.decode_map()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     map_decoder.size().unwrap_or_default(),
                 ));
 
-                while let Some(entry) = map_decoder.deserialize_entry()? {
-                    vec.push(entry);
+                while let Some(key) =
+                    map_decoder.deserialize_key_with_nesting_depth(nesting_depth)?
+                {
+                    let value = map_decoder.deserialize_value_with_nesting_depth(nesting_depth)?;
+                    vec.push((key, value));
                 }
                 Value::Map(vec)
             }
             DataItemHeader::Tag(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let tag = decoder.decode_tag()?;
-                let value = Value::deserialize(decoder)?;
+                let value = Self::deserialize_at_nesting_depth(decoder, nesting_depth)?;
                 Value::Tag(tag, Box::new(value))
             }
             DataItemHeader::Simple(_) => match decoder.decode_simple()? {
@@ -123,6 +132,37 @@ impl CborDeserialize for Value {
             },
             DataItemHeader::Float(_) => Value::Float(decoder.decode_float()?),
         })
+    }
+}
+
+fn next_nesting_depth<C: CborDecoder>(
+    decoder: &C,
+    nesting_depth: usize,
+) -> CborSerializationResult<usize> {
+    nesting_depth
+        .checked_add(1)
+        .filter(|depth| *depth <= decoder.options().max_nesting_depth)
+        .ok_or_else(|| {
+            CborSerializationError::nesting_limit_exceeded(decoder.options().max_nesting_depth)
+        })
+}
+
+impl CborDeserialize for Value {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize_at_nesting_depth(decoder, 0)
+    }
+
+    fn deserialize_with_nesting_depth<C: CborDecoder>(
+        decoder: C,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize_at_nesting_depth(decoder, nesting_depth)
     }
 
     fn null() -> Option<Self>
@@ -136,7 +176,9 @@ impl CborDeserialize for Value {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::common::cbor::{cbor_decode, cbor_encode};
+    use crate::common::cbor::{
+        cbor_decode, cbor_decode_with_options, cbor_encode, SerializationOptions,
+    };
 
     #[test]
     fn test_positive() {
@@ -309,5 +351,49 @@ mod test {
         let cbor = cbor_encode(&value);
         let value_decoded: Value = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
+    }
+
+    fn nested_array(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0x81; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    fn nested_map(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(depth * 2 + 1);
+        for _ in 0..depth {
+            cbor.extend([0xa1, 0]);
+        }
+        cbor.push(0);
+        cbor
+    }
+
+    fn nested_tag(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0xc0; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    #[test]
+    fn nesting_limit_accepts_128_structural_items() {
+        for cbor in [nested_array(128), nested_map(128), nested_tag(128)] {
+            assert!(cbor_decode::<Value>(cbor).is_ok());
+        }
+    }
+
+    #[test]
+    fn nesting_limit_rejects_129_structural_items() {
+        for cbor in [nested_array(129), nested_map(129), nested_tag(129)] {
+            let error = cbor_decode::<Value>(cbor).unwrap_err();
+            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+        }
+    }
+
+    #[test]
+    fn nesting_limit_uses_custom_option() {
+        let options = SerializationOptions::default().max_nesting_depth(3);
+        assert!(cbor_decode_with_options::<Value>(nested_array(3), options).is_ok());
+        let error = cbor_decode_with_options::<Value>(nested_array(4), options).unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
     }
 }


### PR DESCRIPTION
## Purpose

Add a nesting limit to the cbor decoder. 128 was chosen as the value, as this is also used as a nesting limit in serde_json, and it seems like a reasonable upper bound.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.
