### PR TITLE
Nested CBOR accounting v2

### DIFF
--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -14,6 +14,8 @@
   - `LockAccountFunds`
   - `LockedTokenAmount`
 - Added CBOR serialization for `TransactionTime` and `TokenId`.
+- Dynamic CBOR `Value` decoding and skipped-item traversal now default to a maximum nesting depth of 128;
+  the finite limit is configurable through `SerializationOptions`, and exceeding it returns an error.
 
 - Introduce `TokenAuthorizations` representing the CBOR encoding of the `getTokenAuthorizations` query.
 - Introduce lock query boundary types representing the CBOR encoding of the `getLockInfo` query.

--- a/rust-src/concordium_base/CHANGELOG.md
+++ b/rust-src/concordium_base/CHANGELOG.md
@@ -14,8 +14,7 @@
   - `LockAccountFunds`
   - `LockedTokenAmount`
 - Added CBOR serialization for `TransactionTime` and `TokenId`.
-- Dynamic CBOR `Value` decoding and skipped-item traversal now default to a maximum nesting depth of 128;
-  the finite limit is configurable through `SerializationOptions`, and exceeding it returns an error.
+- CBOR decoding now limits nested arrays, maps, and tags to a default depth of 128, configurable through `SerializationOptions`.
 
 - Introduce `TokenAuthorizations` representing the CBOR encoding of the `getTokenAuthorizations` query.
 - Introduce lock query boundary types representing the CBOR encoding of the `getLockInfo` query.

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -772,8 +772,18 @@ pub trait CborDecoder {
 
 /// Decoder of a CBOR tagged value.
 pub trait CborTagDecoder {
+    /// Decoder type used for the tagged value.
+    type Decoder<'a>: CborDecoder
+    where
+        Self: 'a;
+
     /// The decoded tag.
     fn tag(&self) -> u64;
+
+    /// Borrow the tagged value decoder. In general, this should not be used manually:
+    /// use [`Self::deserialize`] instead.
+    // NOTE: This is needed by derived tagged types that decode their own untagged representation.
+    fn decoder(&mut self) -> Self::Decoder<'_>;
 
     /// Deserialize the tagged value.
     fn deserialize<T: CborDeserialize>(self) -> CborSerializationResult<T>;
@@ -1299,6 +1309,21 @@ mod test {
     }
 
     #[test]
+    fn test_derived_tag_counts_towards_nesting_limit() {
+        #[derive(Debug, PartialEq, CborDeserialize)]
+        #[cbor(transparent, tag = 42)]
+        struct TaggedValue(Value);
+
+        let cbor = [0xd8, 42, 0xc0, 0]; // 42(0(0))
+        let options = SerializationOptions::default().max_nesting_depth(2);
+        assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_ok());
+
+        let options = SerializationOptions::default().max_nesting_depth(1);
+        let error = cbor_decode_with_options::<TaggedValue>(cbor, options).unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 1 exceeded");
+    }
+
+    #[test]
     fn test_struct_tag_derived_transparent() {
         #[derive(Debug, Eq, PartialEq, CborSerialize, CborDeserialize)]
         #[cbor(transparent, tag = 39999)]
@@ -1502,6 +1527,24 @@ mod test {
         assert_eq!(hex::encode(&cbor), "d99c386461626364");
         let value_decoded: TestEnum = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
+    }
+
+    #[test]
+    fn test_derived_tagged_enum_counts_towards_nesting_limit() {
+        #[derive(Debug, PartialEq, CborDeserialize)]
+        #[cbor(tagged)]
+        enum TaggedValue {
+            #[cbor(tag = 42)]
+            Value(Value),
+        }
+
+        let cbor = [0xd8, 42, 0xc0, 0]; // 42(0(0))
+        let options = SerializationOptions::default().max_nesting_depth(2);
+        assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_ok());
+
+        let options = SerializationOptions::default().max_nesting_depth(1);
+        let error = cbor_decode_with_options::<TaggedValue>(cbor, options).unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 1 exceeded");
     }
 
     #[test]

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -658,58 +658,39 @@ pub trait CborArrayEncoder {
 
 /// Decoder of CBOR. See <https://www.rfc-editor.org/rfc/rfc8949.html#section-3>
 pub trait CborDecoder {
+    /// Associated tag decoder
+    type TagDecoder: CborTagDecoder;
     /// Associated map decoder
     type MapDecoder: CborMapDecoder;
     /// Associated array decoder
     type ArrayDecoder: CborArrayDecoder;
 
-    /// Decode tag data item
+    /// Decode tag data item.
     fn decode_tag(&mut self) -> CborSerializationResult<u64>;
 
-    /// Decode a tag and its tagged value. In general, this should be used over
-    /// `decode_tag`.
-    ///
-    /// Returns an error if the tag, tagged value, or the nesting limit specified in the
-    /// serialzation options is exceeded.
-    ///
-    /// ```ignore
-    /// let (tag, value) = decoder.decode_tagged_value::<Value>()?;
-    /// ```
-    fn decode_tagged_value<T: CborDeserialize>(mut self) -> CborSerializationResult<(u64, T)>
+    /// Decode tag data item. Returns a decoder for the tagged value.
+    fn decode_tagged(self) -> CborSerializationResult<Self::TagDecoder>;
+
+    /// Decode a tag, check it equals `expected_tag`, and return a decoder for its value.
+    fn decode_tagged_expect(self, expected_tag: u64) -> CborSerializationResult<Self::TagDecoder>
     where
         Self: Sized,
     {
-        let tag = self.decode_tag()?;
-        T::deserialize(self).map(|value| (tag, value))
+        let decoder = self.decode_tagged()?;
+        let tag = decoder.tag();
+        if tag != expected_tag {
+            return Err(CborSerializationError::expected_tag(expected_tag, tag));
+        }
+        Ok(decoder)
     }
 
-    /// Decode that and check it equals the given `expected_tag`.
+    /// Decode a tag and check it equals `expected_tag`.
     fn decode_tag_expect(&mut self, expected_tag: u64) -> CborSerializationResult<()> {
         let tag = self.decode_tag()?;
         if tag != expected_tag {
             return Err(CborSerializationError::expected_tag(expected_tag, tag));
         }
         Ok(())
-    }
-
-    /// Decode an expected tag and its tagged value. In general, this should be used over
-    /// `decode_tag_expect`.
-    ///
-    /// Returns an error if the tag differs from `expected_tag`, the tagged value is invalid, or
-    /// the nesting limit specified in the serialzation options is exceeded.
-    ///
-    /// ```ignore
-    /// let value = decoder.decode_tagged_value_expect::<Value>(42)?;
-    /// ```
-    fn decode_tagged_value_expect<T: CborDeserialize>(
-        mut self,
-        expected_tag: u64,
-    ) -> CborSerializationResult<T>
-    where
-        Self: Sized,
-    {
-        self.decode_tag_expect(expected_tag)?;
-        T::deserialize(self)
     }
 
     /// Decode positive integer data item
@@ -787,6 +768,15 @@ pub trait CborDecoder {
 
     /// Serialization options in current context
     fn options(&self) -> SerializationOptions;
+}
+
+/// Decoder of a CBOR tagged value.
+pub trait CborTagDecoder {
+    /// The decoded tag.
+    fn tag(&self) -> u64;
+
+    /// Deserialize the tagged value.
+    fn deserialize<T: CborDeserialize>(self) -> CborSerializationResult<T>;
 }
 
 /// Decoder of CBOR map

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -329,15 +329,38 @@ pub enum UnknownMapKeys {
     Fail,
 }
 
-/// Options applied when serializing and deserializing
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+/// Options applied when serializing and deserializing.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SerializationOptions {
     pub unknown_map_keys: UnknownMapKeys,
+    /// Maximum depth of nested CBOR arrays, maps, and tags.
+    pub max_nesting_depth: usize,
+}
+
+impl Default for SerializationOptions {
+    fn default() -> Self {
+        Self {
+            unknown_map_keys: UnknownMapKeys::default(),
+            max_nesting_depth: 128,
+        }
+    }
 }
 
 impl SerializationOptions {
+    /// Sets how unknown keys in decoded CBOR maps are handled.
     pub fn unknown_map_keys(self, unknown_map_keys: UnknownMapKeys) -> Self {
-        Self { unknown_map_keys }
+        Self {
+            unknown_map_keys,
+            ..self
+        }
+    }
+
+    /// Sets the finite maximum depth of nested CBOR arrays, maps, and tags.
+    pub fn max_nesting_depth(self, max_nesting_depth: usize) -> Self {
+        Self {
+            max_nesting_depth,
+            ..self
+        }
     }
 }
 
@@ -389,6 +412,11 @@ impl CborSerializationError {
         } else {
             anyhow!("expected map size {}, was indefinite", expected).into()
         }
+    }
+
+    /// Returns an error indicating that CBOR nesting exceeded `max_nesting_depth`.
+    pub fn nesting_limit_exceeded(max_nesting_depth: usize) -> Self {
+        anyhow!("maximum nesting depth of {} exceeded", max_nesting_depth).into()
     }
 }
 
@@ -490,6 +518,21 @@ pub trait CborDeserialize {
     fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
     where
         Self: Sized;
+
+    /// Deserialize while preserving the current CBOR structural nesting depth.
+    ///
+    /// Container decoders use this to propagate the current depth when recursively
+    /// decoding dynamic values. The default preserves compatibility for types that
+    /// do not track nesting depth.
+    fn deserialize_with_nesting_depth<C: CborDecoder>(
+        decoder: C,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize(decoder)
+    }
 
     fn deserialize_maybe_known<C: CborDecoder>(
         decoder: C,
@@ -747,8 +790,30 @@ pub trait CborMapDecoder {
     /// all entries in the map has been deserialized.
     fn deserialize_key<K: CborDeserialize>(&mut self) -> CborSerializationResult<Option<K>>;
 
+    /// Deserialize an entry key while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Option<K>> {
+        self.deserialize_key()
+    }
+
     /// Deserialize an entry value.
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V>;
+
+    /// Deserialize an entry value while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<V> {
+        self.deserialize_value()
+    }
 
     /// Skips entry value
     fn skip_value(&mut self) -> CborSerializationResult<()>;
@@ -765,6 +830,17 @@ pub trait CborArrayDecoder {
     /// The total number of elements that can be deserialized is equal
     /// to [`Self::size`].
     fn deserialize_element<T: CborDeserialize>(&mut self) -> CborSerializationResult<Option<T>>;
+
+    /// Deserialize an array element while propagating the current structural nesting depth.
+    ///
+    /// Implementations that support depth-aware dynamic values should forward
+    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
+    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
+        &mut self,
+        _nesting_depth: usize,
+    ) -> CborSerializationResult<Option<T>> {
+        self.deserialize_element()
+    }
 }
 
 impl<T: CborSerialize> CborSerialize for &T {
@@ -940,6 +1016,29 @@ mod test {
 
     use crate::common::cbor::value::Value;
     use std::collections::HashMap;
+
+    #[test]
+    fn serialization_options_default_nesting_depth() {
+        assert_eq!(SerializationOptions::default().max_nesting_depth, 128);
+    }
+
+    #[test]
+    fn serialization_options_custom_nesting_depth() {
+        let options = SerializationOptions::default()
+            .unknown_map_keys(UnknownMapKeys::Fail)
+            .max_nesting_depth(64);
+
+        assert_eq!(options.max_nesting_depth, 64);
+        assert_eq!(options.unknown_map_keys, UnknownMapKeys::Fail);
+    }
+
+    #[test]
+    fn nesting_limit_error_includes_limit() {
+        assert_eq!(
+            CborSerializationError::nesting_limit_exceeded(64).to_string(),
+            "maximum nesting depth of 64 exceeded"
+        );
+    }
 
     /// Struct with named fields encoded as map. Uses field name string literals
     /// as keys.
@@ -1660,8 +1759,7 @@ mod test {
         let err = cbor_decode::<Vec<u64>>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -1683,8 +1781,7 @@ mod test {
         let err = cbor_decode::<HashMap<u64, u64>>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -519,21 +519,6 @@ pub trait CborDeserialize {
     where
         Self: Sized;
 
-    /// Deserialize while preserving the current CBOR structural nesting depth.
-    ///
-    /// Container decoders use this to propagate the current depth when recursively
-    /// decoding dynamic values. The default preserves compatibility for types that
-    /// do not track nesting depth.
-    fn deserialize_with_nesting_depth<C: CborDecoder>(
-        decoder: C,
-        _nesting_depth: usize,
-    ) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
-        Self::deserialize(decoder)
-    }
-
     fn deserialize_maybe_known<C: CborDecoder>(
         decoder: C,
     ) -> CborSerializationResult<CborMaybeKnown<Self>>
@@ -681,13 +666,50 @@ pub trait CborDecoder {
     /// Decode tag data item
     fn decode_tag(&mut self) -> CborSerializationResult<u64>;
 
-    /// Decode that and check it equals the given `expected_tag`
+    /// Decode a tag and its tagged value. In general, this should be used over
+    /// `decode_tag`.
+    ///
+    /// Returns an error if the tag, tagged value, or the nesting limit specified in the
+    /// serialzation options is exceeded.
+    ///
+    /// ```ignore
+    /// let (tag, value) = decoder.decode_tagged_value::<Value>()?;
+    /// ```
+    fn decode_tagged_value<T: CborDeserialize>(mut self) -> CborSerializationResult<(u64, T)>
+    where
+        Self: Sized,
+    {
+        let tag = self.decode_tag()?;
+        T::deserialize(self).map(|value| (tag, value))
+    }
+
+    /// Decode that and check it equals the given `expected_tag`.
     fn decode_tag_expect(&mut self, expected_tag: u64) -> CborSerializationResult<()> {
         let tag = self.decode_tag()?;
         if tag != expected_tag {
             return Err(CborSerializationError::expected_tag(expected_tag, tag));
         }
         Ok(())
+    }
+
+    /// Decode an expected tag and its tagged value. In general, this should be used over
+    /// `decode_tag_expect`.
+    ///
+    /// Returns an error if the tag differs from `expected_tag`, the tagged value is invalid, or
+    /// the nesting limit specified in the serialzation options is exceeded.
+    ///
+    /// ```ignore
+    /// let value = decoder.decode_tagged_value_expect::<Value>(42)?;
+    /// ```
+    fn decode_tagged_value_expect<T: CborDeserialize>(
+        mut self,
+        expected_tag: u64,
+    ) -> CborSerializationResult<T>
+    where
+        Self: Sized,
+    {
+        self.decode_tag_expect(expected_tag)?;
+        T::deserialize(self)
     }
 
     /// Decode positive integer data item
@@ -790,30 +812,8 @@ pub trait CborMapDecoder {
     /// all entries in the map has been deserialized.
     fn deserialize_key<K: CborDeserialize>(&mut self) -> CborSerializationResult<Option<K>>;
 
-    /// Deserialize an entry key while propagating the current structural nesting depth.
-    ///
-    /// Implementations that support depth-aware dynamic values should forward
-    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
-    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
-        &mut self,
-        _nesting_depth: usize,
-    ) -> CborSerializationResult<Option<K>> {
-        self.deserialize_key()
-    }
-
     /// Deserialize an entry value.
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V>;
-
-    /// Deserialize an entry value while propagating the current structural nesting depth.
-    ///
-    /// Implementations that support depth-aware dynamic values should forward
-    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
-    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
-        &mut self,
-        _nesting_depth: usize,
-    ) -> CborSerializationResult<V> {
-        self.deserialize_value()
-    }
 
     /// Skips entry value
     fn skip_value(&mut self) -> CborSerializationResult<()>;
@@ -830,17 +830,6 @@ pub trait CborArrayDecoder {
     /// The total number of elements that can be deserialized is equal
     /// to [`Self::size`].
     fn deserialize_element<T: CborDeserialize>(&mut self) -> CborSerializationResult<Option<T>>;
-
-    /// Deserialize an array element while propagating the current structural nesting depth.
-    ///
-    /// Implementations that support depth-aware dynamic values should forward
-    /// `nesting_depth` to [`CborDeserialize::deserialize_with_nesting_depth`].
-    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
-        &mut self,
-        _nesting_depth: usize,
-    ) -> CborSerializationResult<Option<T>> {
-        self.deserialize_element()
-    }
 }
 
 impl<T: CborSerialize> CborSerialize for &T {
@@ -1016,29 +1005,6 @@ mod test {
 
     use crate::common::cbor::value::Value;
     use std::collections::HashMap;
-
-    #[test]
-    fn serialization_options_default_nesting_depth() {
-        assert_eq!(SerializationOptions::default().max_nesting_depth, 128);
-    }
-
-    #[test]
-    fn serialization_options_custom_nesting_depth() {
-        let options = SerializationOptions::default()
-            .unknown_map_keys(UnknownMapKeys::Fail)
-            .max_nesting_depth(64);
-
-        assert_eq!(options.max_nesting_depth, 64);
-        assert_eq!(options.unknown_map_keys, UnknownMapKeys::Fail);
-    }
-
-    #[test]
-    fn nesting_limit_error_includes_limit() {
-        assert_eq!(
-            CborSerializationError::nesting_limit_exceeded(64).to_string(),
-            "maximum nesting depth of 64 exceeded"
-        );
-    }
 
     /// Struct with named fields encoded as map. Uses field name string literals
     /// as keys.

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -1319,8 +1319,7 @@ mod test {
         assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_ok());
 
         let options = SerializationOptions::default().max_nesting_depth(1);
-        let error = cbor_decode_with_options::<TaggedValue>(cbor, options).unwrap_err();
-        assert_eq!(error.to_string(), "maximum nesting depth of 1 exceeded");
+        assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_err());
     }
 
     #[test]
@@ -1543,8 +1542,7 @@ mod test {
         assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_ok());
 
         let options = SerializationOptions::default().max_nesting_depth(1);
-        let error = cbor_decode_with_options::<TaggedValue>(cbor, options).unwrap_err();
-        assert_eq!(error.to_string(), "maximum nesting depth of 1 exceeded");
+        assert!(cbor_decode_with_options::<TaggedValue>(cbor, options).is_err());
     }
 
     #[test]

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -7,6 +7,9 @@
 //! serialization of primitive Rust types like integers, strings and byte
 //! arrays.
 //!
+//! Deserialization rejects CBOR arrays, maps, and tags nested deeper than
+//! [`SerializationOptions::max_nesting_depth`]. The default limit is 128.
+//!
 //! ## Deriving `CborSerialize` and `CborDeserialize`
 //!
 //! ### Structs
@@ -457,14 +460,18 @@ fn into_ok<T>(res: Result<T, Infallible>) -> T {
     }
 }
 
-/// Decodes value from the given CBOR. If all input is not parsed,
-/// an error is returned.
+/// Decodes a value using the default options.
+///
+/// Returns an error if the input is invalid, contains remaining data, or exceeds the default
+/// nesting limit.
 pub fn cbor_decode<T: CborDeserialize>(cbor: impl AsRef<[u8]>) -> CborSerializationResult<T> {
     cbor_decode_with_options(cbor, SerializationOptions::default())
 }
 
-/// Decodes value from the given CBOR. If all input is not parsed,
-/// an error is returned.
+/// Decodes a value using `options`.
+///
+/// Returns an error if the input is invalid, contains remaining data, or exceeds the configured
+/// nesting limit.
 pub fn cbor_decode_with_options<T: CborDeserialize>(
     cbor: impl AsRef<[u8]>,
     options: SerializationOptions,
@@ -665,10 +672,11 @@ pub trait CborDecoder {
     /// Associated array decoder
     type ArrayDecoder: CborArrayDecoder;
 
-    /// Decode tag data item.
+    /// Decode a tag header. Generally, [`Self::decode_tagged`] should be used instead due
+    /// to counting nesting_depth.
     fn decode_tag(&mut self) -> CborSerializationResult<u64>;
 
-    /// Decode tag data item. Returns a decoder for the tagged value.
+    /// Decode a tag and return a nesting-scoped decoder for its value.
     fn decode_tagged(self) -> CborSerializationResult<Self::TagDecoder>;
 
     /// Decode a tag, check it equals `expected_tag`, and return a decoder for its value.
@@ -684,7 +692,8 @@ pub trait CborDecoder {
         Ok(decoder)
     }
 
-    /// Decode a tag and check it equals `expected_tag`.
+    /// Decode and validate a tag header. Generally, [`Self::decode_tagged`] should be used
+    /// instead due to counting nesting_depth.
     fn decode_tag_expect(&mut self, expected_tag: u64) -> CborSerializationResult<()> {
         let tag = self.decode_tag()?;
         if tag != expected_tag {
@@ -780,9 +789,10 @@ pub trait CborTagDecoder {
     /// The decoded tag.
     fn tag(&self) -> u64;
 
-    /// Borrow the tagged value decoder. In general, this should not be used manually:
-    /// use [`Self::deserialize`] instead.
-    // NOTE: This is needed by derived tagged types that decode their own untagged representation.
+    /// Borrow the tagged value decoder while preserving its nesting scope.
+    ///
+    /// Derived tagged types use this to decode their untagged representation. Other callers should
+    /// normally use [`Self::deserialize`].
     fn decoder(&mut self) -> Self::Decoder<'_>;
 
     /// Deserialize the tagged value.

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -1028,8 +1028,7 @@ mod test {
             nested_tag(129),
         ] {
             let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
-            let error = decoder.skip_data_item().unwrap_err();
-            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+            assert!(decoder.skip_data_item().is_err());
         }
     }
 
@@ -1052,8 +1051,7 @@ mod test {
 
         let cbor = nested_map(4, true);
         let mut decoder = Decoder::new(cbor.as_slice(), options);
-        let error = decoder.skip_data_item().unwrap_err();
-        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
+        assert!(decoder.skip_data_item().is_err());
     }
 
     fn test_skip_data_item_impl(encode_data_item: impl FnOnce(&mut Encoder<&mut Vec<u8>>)) {

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -12,37 +12,45 @@ use std::{io::Cursor, iter};
 pub struct Decoder<R: Read> {
     inner: ciborium_ll::Decoder<R>,
     options: SerializationOptions,
-    nesting_depth: usize,
 }
 
 impl<R: Read> Decoder<R> {
     pub fn new(read: R, options: SerializationOptions) -> Self {
         let inner = ciborium_ll::Decoder::from(read);
 
-        Self {
-            inner,
-            options,
-            nesting_depth: 0,
-        }
+        Self { inner, options }
     }
 }
 
-impl<R: Read> Decoder<R>
+/// A CBOR decoder borrow with its immutable nesting depth.
+pub struct DecoderContext<'a, R: Read> {
+    decoder: &'a mut Decoder<R>,
+    depth: usize,
+}
+
+impl<'a, R: Read> DecoderContext<'a, R>
 where
     R::Error: std::error::Error,
 {
-    fn skip_data_item(mut self: &mut Self) -> CborSerializationResult<()> {
+    fn nested(decoder: &'a mut Decoder<R>, depth: usize) -> CborSerializationResult<Self> {
+        let depth = depth
+            .checked_add(1)
+            .filter(|depth| *depth <= decoder.options.max_nesting_depth)
+            .ok_or_else(|| {
+                CborSerializationError::nesting_limit_exceeded(decoder.options.max_nesting_depth)
+            })?;
+        Ok(Self { decoder, depth })
+    }
+
+    fn skip(mut self) -> CborSerializationResult<()> {
         match self.peek_data_item_header()?.to_type() {
             DataItemType::Positive
             | DataItemType::Negative
             | DataItemType::Simple
             | DataItemType::Float => {
-                self.inner.pull()?;
+                self.decoder.inner.pull()?;
             }
-            DataItemType::Tag => {
-                let tag_decoder = self.decode_tagged()?;
-                tag_decoder.decoder.skip_data_item()?;
-            }
+            DataItemType::Tag => self.decode_tagged()?.decoder().skip_data_item()?,
             DataItemType::Bytes => {
                 self.decode_bytes()?;
             }
@@ -50,67 +58,71 @@ where
                 self.decode_text()?;
             }
             DataItemType::Array => {
-                let array_decoder = self.decode_array()?;
-                // Arrays of definite length encodes "size" number of data item elements,
-                // arrays of indefinite length encodes data item elements until a break is
-                // encountered.
-                if let Some(size) = array_decoder.size() {
+                let array = self.decode_array()?;
+                if let Some(size) = array.declared_size {
                     for _ in 0..size {
-                        array_decoder.decoder.skip_data_item()?;
+                        DecoderContext {
+                            decoder: &mut *array.decoder,
+                            depth: array.depth,
+                        }
+                        .skip()?;
                     }
                 } else {
-                    while !array_decoder.decoder.pull_break()? {
-                        array_decoder.decoder.skip_data_item()?;
+                    while !array.decoder.pull_break()? {
+                        DecoderContext {
+                            decoder: &mut *array.decoder,
+                            depth: array.depth,
+                        }
+                        .skip()?;
                     }
                 }
             }
             DataItemType::Map => {
-                let map_decoder = self.decode_map()?;
-                // Maps of definite length encodes "size" number of data item pairs,
-                // maps of indefinite length encodes data item pairs until a break is
-                // encountered.
-                if let Some(size) = map_decoder.size() {
+                let map = self.decode_map()?;
+                if let Some(size) = map.declared_size {
                     for _ in 0..size {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
+                        DecoderContext {
+                            decoder: &mut *map.decoder,
+                            depth: map.depth,
+                        }
+                        .skip()?;
+                        DecoderContext {
+                            decoder: &mut *map.decoder,
+                            depth: map.depth,
+                        }
+                        .skip()?;
                     }
                 } else {
-                    while !map_decoder.decoder.pull_break()? {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
+                    while !map.decoder.pull_break()? {
+                        DecoderContext {
+                            decoder: &mut *map.decoder,
+                            depth: map.depth,
+                        }
+                        .skip()?;
+                        DecoderContext {
+                            decoder: &mut *map.decoder,
+                            depth: map.depth,
+                        }
+                        .skip()?;
                     }
                 }
             }
-            DataItemType::Break => {
-                return Err(anyhow!("break is not a valid data item").into());
-            }
+            DataItemType::Break => return Err(anyhow!("break is not a valid data item").into()),
         }
-
-        Ok(())
-    }
-
-    fn enter_nesting(&mut self) -> CborSerializationResult<()> {
-        self.nesting_depth = self
-            .nesting_depth
-            .checked_add(1)
-            .filter(|depth| *depth <= self.options.max_nesting_depth)
-            .ok_or_else(|| {
-                CborSerializationError::nesting_limit_exceeded(self.options.max_nesting_depth)
-            })?;
         Ok(())
     }
 }
 
-impl<'a, R: Read> CborDecoder for &'a mut Decoder<R>
+impl<'a, R: Read> CborDecoder for DecoderContext<'a, R>
 where
-    <R as Read>::Error: std::error::Error,
+    R::Error: std::error::Error,
 {
     type TagDecoder = TagDecoder<'a, R>;
     type ArrayDecoder = ArrayDecoder<'a, R>;
     type MapDecoder = MapDecoder<'a, R>;
 
     fn decode_tag(&mut self) -> CborSerializationResult<u64> {
-        match self.inner.pull()? {
+        match self.decoder.inner.pull()? {
             Header::Tag(tag) => Ok(tag),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Tag,
@@ -118,38 +130,34 @@ where
             )),
         }
     }
-
     fn decode_tagged(mut self) -> CborSerializationResult<Self::TagDecoder> {
         let tag = self.decode_tag()?;
-        self.enter_nesting()?;
-        Ok(TagDecoder::new(tag, self))
+        let context = DecoderContext::nested(self.decoder, self.depth)?;
+        Ok(TagDecoder::new(tag, context.decoder, context.depth))
     }
-
     fn decode_positive(self) -> CborSerializationResult<u64> {
-        match self.inner.pull()? {
-            Header::Positive(positive) => Ok(positive),
+        match self.decoder.inner.pull()? {
+            Header::Positive(value) => Ok(value),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Positive,
                 DataItemType::from_header(header),
             )),
         }
     }
-
     fn decode_negative(self) -> CborSerializationResult<u64> {
-        match self.inner.pull()? {
-            Header::Negative(negative) => Ok(negative),
+        match self.decoder.inner.pull()? {
+            Header::Negative(value) => Ok(value),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Negative,
                 DataItemType::from_header(header),
             )),
         }
     }
-
     fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
-        match self.inner.pull()? {
+        match self.decoder.inner.pull()? {
             Header::Map(size) => {
-                self.enter_nesting()?;
-                Ok(MapDecoder::new(size, self))
+                let context = DecoderContext::nested(self.decoder, self.depth)?;
+                Ok(MapDecoder::new(size, context.decoder, context.depth))
             }
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Map,
@@ -157,12 +165,11 @@ where
             )),
         }
     }
-
     fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
-        match self.inner.pull()? {
+        match self.decoder.inner.pull()? {
             Header::Array(size) => {
-                self.enter_nesting()?;
-                Ok(ArrayDecoder::new(size, self))
+                let context = DecoderContext::nested(self.decoder, self.depth)?;
+                Ok(ArrayDecoder::new(size, context.decoder, context.depth))
             }
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Array,
@@ -170,9 +177,8 @@ where
             )),
         }
     }
-
     fn decode_bytes_exact(self, dest: &mut [u8]) -> CborSerializationResult<()> {
-        let size = match self.inner.pull()? {
+        let size = match self.decoder.inner.pull()? {
             Header::Bytes(size) => size,
             header => {
                 return Err(CborSerializationError::expected_data_item(
@@ -181,17 +187,15 @@ where
                 ))
             }
         };
-
         let mut cursor = Cursor::new(dest);
-        self.decode_bytes_impl(&mut cursor, size)?;
+        self.decoder.decode_bytes_impl(&mut cursor, size)?;
         if (cursor.position() as usize) < cursor.get_ref().len() {
             return Err(anyhow!("fixed length byte string destination too long").into());
         }
         Ok(())
     }
-
     fn decode_bytes(self) -> CborSerializationResult<Vec<u8>> {
-        let size = match self.inner.pull()? {
+        let size = match self.decoder.inner.pull()? {
             Header::Bytes(size) => size,
             header => {
                 return Err(CborSerializationError::expected_data_item(
@@ -200,15 +204,14 @@ where
                 ))
             }
         };
-
-        let bytes = Vec::with_capacity(cbor::cap_capacity::<u8>(size.unwrap_or_default()));
-        let mut cursor = Cursor::new(bytes);
-        self.decode_bytes_impl(&mut cursor, size)?;
+        let mut cursor = Cursor::new(Vec::with_capacity(cbor::cap_capacity::<u8>(
+            size.unwrap_or_default(),
+        )));
+        self.decoder.decode_bytes_impl(&mut cursor, size)?;
         Ok(cursor.into_inner())
     }
-
     fn decode_text(self) -> CborSerializationResult<Vec<u8>> {
-        let size = match self.inner.pull()? {
+        let size = match self.decoder.inner.pull()? {
             Header::Text(size) => size,
             header => {
                 return Err(CborSerializationError::expected_data_item(
@@ -217,14 +220,12 @@ where
                 ))
             }
         };
-
         let mut bytes = Vec::with_capacity(cbor::cap_capacity::<u8>(size.unwrap_or_default()));
-        self.decode_text_impl(&mut bytes, size)?;
+        self.decoder.decode_text_impl(&mut bytes, size)?;
         Ok(bytes)
     }
-
     fn decode_simple(self) -> CborSerializationResult<u8> {
-        match self.inner.pull()? {
+        match self.decoder.inner.pull()? {
             Header::Simple(value) => Ok(value),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Simple,
@@ -232,9 +233,8 @@ where
             )),
         }
     }
-
     fn decode_float(self) -> CborSerializationResult<f64> {
-        match self.inner.pull()? {
+        match self.decoder.inner.pull()? {
             Header::Float(value) => Ok(value),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Float,
@@ -242,15 +242,115 @@ where
             )),
         }
     }
-
     fn peek_data_item_header(&mut self) -> CborSerializationResult<DataItemHeader> {
-        DataItemHeader::try_from_header(self.peek_header()?)
+        DataItemHeader::try_from_header(self.decoder.peek_header()?)
     }
-
     fn skip_data_item(self) -> CborSerializationResult<()> {
-        Decoder::skip_data_item(self)
+        self.skip()
     }
+    fn options(&self) -> SerializationOptions {
+        self.decoder.options
+    }
+}
 
+impl<'a, R: Read> CborDecoder for &'a mut Decoder<R>
+where
+    R::Error: std::error::Error,
+{
+    type TagDecoder = TagDecoder<'a, R>;
+    type ArrayDecoder = ArrayDecoder<'a, R>;
+    type MapDecoder = MapDecoder<'a, R>;
+    fn decode_tag(&mut self) -> CborSerializationResult<u64> {
+        DecoderContext {
+            decoder: *self,
+            depth: 0,
+        }
+        .decode_tag()
+    }
+    fn decode_tagged(self) -> CborSerializationResult<Self::TagDecoder> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_tagged()
+    }
+    fn decode_positive(self) -> CborSerializationResult<u64> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_positive()
+    }
+    fn decode_negative(self) -> CborSerializationResult<u64> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_negative()
+    }
+    fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_map()
+    }
+    fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_array()
+    }
+    fn decode_bytes_exact(self, dest: &mut [u8]) -> CborSerializationResult<()> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_bytes_exact(dest)
+    }
+    fn decode_bytes(self) -> CborSerializationResult<Vec<u8>> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_bytes()
+    }
+    fn decode_text(self) -> CborSerializationResult<Vec<u8>> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_text()
+    }
+    fn decode_simple(self) -> CborSerializationResult<u8> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_simple()
+    }
+    fn decode_float(self) -> CborSerializationResult<f64> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .decode_float()
+    }
+    fn peek_data_item_header(&mut self) -> CborSerializationResult<DataItemHeader> {
+        DecoderContext {
+            decoder: *self,
+            depth: 0,
+        }
+        .peek_data_item_header()
+    }
+    fn skip_data_item(self) -> CborSerializationResult<()> {
+        DecoderContext {
+            decoder: self,
+            depth: 0,
+        }
+        .skip_data_item()
+    }
     fn options(&self) -> SerializationOptions {
         self.options
     }
@@ -390,18 +490,16 @@ where
 pub struct TagDecoder<'a, R: Read> {
     tag: u64,
     decoder: &'a mut Decoder<R>,
+    depth: usize,
 }
 
 impl<'a, R: Read> TagDecoder<'a, R> {
-    fn new(tag: u64, decoder: &'a mut Decoder<R>) -> Self {
-        Self { tag, decoder }
-    }
-}
-
-impl<R: Read> Drop for TagDecoder<'_, R> {
-    fn drop(&mut self) {
-        debug_assert!(self.decoder.nesting_depth > 0);
-        self.decoder.nesting_depth -= 1;
+    fn new(tag: u64, decoder: &'a mut Decoder<R>, depth: usize) -> Self {
+        Self {
+            tag,
+            decoder,
+            depth,
+        }
     }
 }
 
@@ -410,7 +508,7 @@ where
     R::Error: std::error::Error,
 {
     type Decoder<'a>
-        = &'a mut Decoder<R>
+        = DecoderContext<'a, R>
     where
         Self: 'a;
 
@@ -419,11 +517,17 @@ where
     }
 
     fn decoder(&mut self) -> Self::Decoder<'_> {
-        &mut *self.decoder
+        DecoderContext {
+            decoder: &mut *self.decoder,
+            depth: self.depth,
+        }
     }
 
     fn deserialize<T: CborDeserialize>(self) -> CborSerializationResult<T> {
-        T::deserialize(&mut *self.decoder)
+        T::deserialize(DecoderContext {
+            decoder: self.decoder,
+            depth: self.depth,
+        })
     }
 }
 
@@ -439,24 +543,19 @@ pub struct MapDecoder<'a, R: Read> {
     declared_size: Option<usize>,
     decoded_entries: usize,
     decoder: &'a mut Decoder<R>,
+    depth: usize,
     state: MapDecoderStateEnum,
 }
 
 impl<'a, R: Read> MapDecoder<'a, R> {
-    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> Self {
+    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>, depth: usize) -> Self {
         Self {
             declared_size: size,
             decoded_entries: 0,
             decoder,
+            depth,
             state: MapDecoderStateEnum::ExpectKey,
         }
-    }
-}
-
-impl<R: Read> Drop for MapDecoder<'_, R> {
-    fn drop(&mut self) {
-        debug_assert!(self.decoder.nesting_depth > 0);
-        self.decoder.nesting_depth -= 1;
     }
 }
 
@@ -492,7 +591,10 @@ where
 
         self.decoded_entries += 1;
 
-        Ok(Some(K::deserialize(&mut *self.decoder)?))
+        Ok(Some(K::deserialize(DecoderContext {
+            decoder: &mut *self.decoder,
+            depth: self.depth,
+        })?))
     }
 
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V> {
@@ -506,7 +608,10 @@ where
             MapDecoderStateEnum::ExpectValue => MapDecoderStateEnum::ExpectKey,
         };
 
-        V::deserialize(&mut *self.decoder)
+        V::deserialize(DecoderContext {
+            decoder: &mut *self.decoder,
+            depth: self.depth,
+        })
     }
 
     fn skip_value(&mut self) -> CborSerializationResult<()> {
@@ -520,7 +625,11 @@ where
             MapDecoderStateEnum::ExpectValue => MapDecoderStateEnum::ExpectKey,
         };
 
-        self.decoder.skip_data_item()
+        DecoderContext {
+            decoder: &mut *self.decoder,
+            depth: self.depth,
+        }
+        .skip_data_item()
     }
 }
 
@@ -530,22 +639,17 @@ pub struct ArrayDecoder<'a, R: Read> {
     declared_size: Option<usize>,
     decoded_elements: usize,
     decoder: &'a mut Decoder<R>,
+    depth: usize,
 }
 
 impl<'a, R: Read> ArrayDecoder<'a, R> {
-    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> Self {
+    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>, depth: usize) -> Self {
         Self {
             declared_size: size,
             decoded_elements: 0,
             decoder,
+            depth,
         }
-    }
-}
-
-impl<R: Read> Drop for ArrayDecoder<'_, R> {
-    fn drop(&mut self) {
-        debug_assert!(self.decoder.nesting_depth > 0);
-        self.decoder.nesting_depth -= 1;
     }
 }
 
@@ -571,7 +675,10 @@ where
 
         self.decoded_elements += 1;
 
-        Ok(Some(T::deserialize(&mut *self.decoder)?))
+        Ok(Some(T::deserialize(DecoderContext {
+            decoder: &mut *self.decoder,
+            depth: self.depth,
+        })?))
     }
 }
 
@@ -606,8 +713,7 @@ mod test {
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
         assert_eq!(array_decoder.size(), Some(2));
-        drop(array_decoder);
-        assert_eq!(decoder.inner.offset(), bytes.len());
+        assert_eq!(array_decoder.decoder.inner.offset(), bytes.len());
     }
 
     #[test]
@@ -622,8 +728,7 @@ mod test {
         assert_eq!(elm2, 2);
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
-        drop(array_decoder);
-        assert_eq!(decoder.inner.offset(), bytes.len());
+        assert_eq!(array_decoder.decoder.inner.offset(), bytes.len());
     }
 
     #[test]
@@ -639,8 +744,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), Some(2));
-        drop(map_decoder);
-        assert_eq!(decoder.inner.offset(), bytes.len());
+        assert_eq!(map_decoder.decoder.inner.offset(), bytes.len());
     }
 
     #[test]
@@ -656,8 +760,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), None);
-        drop(map_decoder);
-        assert_eq!(decoder.inner.offset(), bytes.len());
+        assert_eq!(map_decoder.decoder.inner.offset(), bytes.len());
     }
 
     #[test]

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -12,13 +12,18 @@ use std::{io::Cursor, iter};
 pub struct Decoder<R: Read> {
     inner: ciborium_ll::Decoder<R>,
     options: SerializationOptions,
+    nesting_depth: usize,
 }
 
 impl<R: Read> Decoder<R> {
     pub fn new(read: R, options: SerializationOptions) -> Self {
         let inner = ciborium_ll::Decoder::from(read);
 
-        Self { inner, options }
+        Self {
+            inner,
+            options,
+            nesting_depth: 0,
+        }
     }
 }
 
@@ -26,10 +31,7 @@ impl<R: Read> Decoder<R>
 where
     R::Error: std::error::Error,
 {
-    fn skip_data_item_at_nesting_depth(
-        mut self: &mut Self,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<()> {
+    fn skip_data_item(mut self: &mut Self) -> CborSerializationResult<()> {
         match self.peek_data_item_header()?.to_type() {
             DataItemType::Positive
             | DataItemType::Negative
@@ -38,9 +40,11 @@ where
                 self.inner.pull()?;
             }
             DataItemType::Tag => {
-                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
                 self.inner.pull()?;
-                self.skip_data_item_at_nesting_depth(nesting_depth)?;
+                self.enter_nesting()?;
+                let result = self.skip_data_item();
+                self.leave_nesting();
+                result?;
             }
             DataItemType::Bytes => {
                 self.decode_bytes()?;
@@ -49,48 +53,34 @@ where
                 self.decode_text()?;
             }
             DataItemType::Array => {
-                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
                 let array_decoder = self.decode_array()?;
                 // Arrays of definite length encodes "size" number of data item elements,
                 // arrays of indefinite length encodes data item elements until a break is
                 // encountered.
                 if let Some(size) = array_decoder.size() {
                     for _ in 0..size {
-                        array_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        array_decoder.decoder.skip_data_item()?;
                     }
                 } else {
                     while !array_decoder.decoder.pull_break()? {
-                        array_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        array_decoder.decoder.skip_data_item()?;
                     }
                 }
             }
             DataItemType::Map => {
-                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
                 let map_decoder = self.decode_map()?;
                 // Maps of definite length encodes "size" number of data item pairs,
                 // maps of indefinite length encodes data item pairs until a break is
                 // encountered.
                 if let Some(size) = map_decoder.size() {
                     for _ in 0..size {
-                        map_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
-                        map_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder.decoder.skip_data_item()?;
+                        map_decoder.decoder.skip_data_item()?;
                     }
                 } else {
                     while !map_decoder.decoder.pull_break()? {
-                        map_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
-                        map_decoder
-                            .decoder
-                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder.decoder.skip_data_item()?;
+                        map_decoder.decoder.skip_data_item()?;
                     }
                 }
             }
@@ -102,13 +92,20 @@ where
         Ok(())
     }
 
-    fn next_nesting_depth(&self, nesting_depth: usize) -> CborSerializationResult<usize> {
-        nesting_depth
+    fn enter_nesting(&mut self) -> CborSerializationResult<()> {
+        self.nesting_depth = self
+            .nesting_depth
             .checked_add(1)
             .filter(|depth| *depth <= self.options.max_nesting_depth)
             .ok_or_else(|| {
                 CborSerializationError::nesting_limit_exceeded(self.options.max_nesting_depth)
-            })
+            })?;
+        Ok(())
+    }
+
+    fn leave_nesting(&mut self) {
+        debug_assert!(self.nesting_depth > 0);
+        self.nesting_depth -= 1;
     }
 }
 
@@ -127,6 +124,25 @@ where
                 DataItemType::from_header(header),
             )),
         }
+    }
+
+    fn decode_tagged_value<T: CborDeserialize>(mut self) -> CborSerializationResult<(u64, T)> {
+        let tag = self.decode_tag()?;
+        self.enter_nesting()?;
+        let result = T::deserialize(&mut *self);
+        self.leave_nesting();
+        result.map(|value| (tag, value))
+    }
+
+    fn decode_tagged_value_expect<T: CborDeserialize>(
+        mut self,
+        expected_tag: u64,
+    ) -> CborSerializationResult<T> {
+        self.decode_tag_expect(expected_tag)?;
+        self.enter_nesting()?;
+        let result = T::deserialize(&mut *self);
+        self.leave_nesting();
+        result
     }
 
     fn decode_positive(self) -> CborSerializationResult<u64> {
@@ -151,7 +167,10 @@ where
 
     fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
         match self.inner.pull()? {
-            Header::Map(size) => Ok(MapDecoder::new(size, self)),
+            Header::Map(size) => {
+                self.enter_nesting()?;
+                Ok(MapDecoder::new(size, self))
+            }
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Map,
                 DataItemType::from_header(header),
@@ -161,7 +180,10 @@ where
 
     fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
         match self.inner.pull()? {
-            Header::Array(size) => Ok(ArrayDecoder::new(size, self)),
+            Header::Array(size) => {
+                self.enter_nesting()?;
+                Ok(ArrayDecoder::new(size, self))
+            }
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Array,
                 DataItemType::from_header(header),
@@ -246,7 +268,7 @@ where
     }
 
     fn skip_data_item(self) -> CborSerializationResult<()> {
-        self.skip_data_item_at_nesting_depth(0)
+        Decoder::skip_data_item(self)
     }
 
     fn options(&self) -> SerializationOptions {
@@ -409,6 +431,13 @@ impl<'a, R: Read> MapDecoder<'a, R> {
     }
 }
 
+impl<R: Read> Drop for MapDecoder<'_, R> {
+    fn drop(&mut self) {
+        debug_assert!(self.decoder.nesting_depth > 0);
+        self.decoder.nesting_depth -= 1;
+    }
+}
+
 impl<R: Read> CborMapDecoder for MapDecoder<'_, R>
 where
     <R as Read>::Error: std::error::Error,
@@ -444,36 +473,6 @@ where
         Ok(Some(K::deserialize(&mut *self.decoder)?))
     }
 
-    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
-        &mut self,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<Option<K>> {
-        self.state = match self.state {
-            MapDecoderStateEnum::ExpectKey => MapDecoderStateEnum::ExpectValue,
-            MapDecoderStateEnum::ExpectValue => {
-                return Err(anyhow!(
-                    "map decoder expected to decode entry value since entry key was decoded last"
-                )
-                .into());
-            }
-        };
-
-        if let Some(declared_size) = self.declared_size {
-            if self.decoded_entries == declared_size {
-                return Ok(None);
-            }
-        } else if self.decoder.pull_break()? {
-            return Ok(None);
-        }
-
-        self.decoded_entries += 1;
-
-        Ok(Some(K::deserialize_with_nesting_depth(
-            &mut *self.decoder,
-            nesting_depth,
-        )?))
-    }
-
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V> {
         self.state = match self.state {
             MapDecoderStateEnum::ExpectKey => {
@@ -486,23 +485,6 @@ where
         };
 
         V::deserialize(&mut *self.decoder)
-    }
-
-    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
-        &mut self,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<V> {
-        self.state = match self.state {
-            MapDecoderStateEnum::ExpectKey => {
-                return Err(anyhow!(
-                    "map decoder expected to decode entry key since entry value was decoded last"
-                )
-                .into());
-            }
-            MapDecoderStateEnum::ExpectValue => MapDecoderStateEnum::ExpectKey,
-        };
-
-        V::deserialize_with_nesting_depth(&mut *self.decoder, nesting_depth)
     }
 
     fn skip_value(&mut self) -> CborSerializationResult<()> {
@@ -538,6 +520,13 @@ impl<'a, R: Read> ArrayDecoder<'a, R> {
     }
 }
 
+impl<R: Read> Drop for ArrayDecoder<'_, R> {
+    fn drop(&mut self) {
+        debug_assert!(self.decoder.nesting_depth > 0);
+        self.decoder.nesting_depth -= 1;
+    }
+}
+
 impl<R: Read> CborArrayDecoder for ArrayDecoder<'_, R>
 where
     <R as Read>::Error: std::error::Error,
@@ -562,35 +551,23 @@ where
 
         Ok(Some(T::deserialize(&mut *self.decoder)?))
     }
-
-    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
-        &mut self,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<Option<T>> {
-        if let Some(declared_size) = self.declared_size {
-            if self.decoded_elements == declared_size {
-                return Ok(None);
-            }
-        } else if self.decoder.pull_break()? {
-            return Ok(None);
-        }
-
-        self.decoded_elements += 1;
-
-        Ok(Some(T::deserialize_with_nesting_depth(
-            &mut *self.decoder,
-            nesting_depth,
-        )?))
-    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
     use crate::common::cbor::{
-        CborArrayEncoder, CborDecoder, CborEncoder, CborMapEncoder, Encoder,
+        value::Value, CborArrayEncoder, CborDecoder, CborEncoder, CborMapEncoder, Encoder,
     };
     use ciborium_ll::simple;
+
+    #[test]
+    fn test_decode_tagged_value_expect() {
+        let bytes = [0xc0, 0x81, 0x00];
+        let mut decoder = Decoder::new(bytes.as_slice(), SerializationOptions::default());
+        let value = decoder.decode_tagged_value_expect::<Value>(0).unwrap();
+        assert_eq!(value, Value::Array(vec![Value::Positive(0)]));
+    }
 
     #[test]
     fn test_array_definite_length() {
@@ -605,6 +582,7 @@ mod test {
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
         assert_eq!(array_decoder.size(), Some(2));
+        drop(array_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -620,6 +598,7 @@ mod test {
         assert_eq!(elm2, 2);
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
+        drop(array_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -636,6 +615,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), Some(2));
+        drop(map_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -652,6 +632,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), None);
+        drop(map_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -409,8 +409,17 @@ impl<R: Read> CborTagDecoder for TagDecoder<'_, R>
 where
     R::Error: std::error::Error,
 {
+    type Decoder<'a>
+        = &'a mut Decoder<R>
+    where
+        Self: 'a;
+
     fn tag(&self) -> u64 {
         self.tag
+    }
+
+    fn decoder(&mut self) -> Self::Decoder<'_> {
+        &mut *self.decoder
     }
 
     fn deserialize<T: CborDeserialize>(self) -> CborSerializationResult<T> {

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -22,6 +22,96 @@ impl<R: Read> Decoder<R> {
     }
 }
 
+impl<R: Read> Decoder<R>
+where
+    R::Error: std::error::Error,
+{
+    fn skip_data_item_at_nesting_depth(
+        mut self: &mut Self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<()> {
+        match self.peek_data_item_header()?.to_type() {
+            DataItemType::Positive
+            | DataItemType::Negative
+            | DataItemType::Simple
+            | DataItemType::Float => {
+                self.inner.pull()?;
+            }
+            DataItemType::Tag => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                self.inner.pull()?;
+                self.skip_data_item_at_nesting_depth(nesting_depth)?;
+            }
+            DataItemType::Bytes => {
+                self.decode_bytes()?;
+            }
+            DataItemType::Text => {
+                self.decode_text()?;
+            }
+            DataItemType::Array => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                let array_decoder = self.decode_array()?;
+                // Arrays of definite length encodes "size" number of data item elements,
+                // arrays of indefinite length encodes data item elements until a break is
+                // encountered.
+                if let Some(size) = array_decoder.size() {
+                    for _ in 0..size {
+                        array_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                } else {
+                    while !array_decoder.decoder.pull_break()? {
+                        array_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                }
+            }
+            DataItemType::Map => {
+                let nesting_depth = self.next_nesting_depth(nesting_depth)?;
+                let map_decoder = self.decode_map()?;
+                // Maps of definite length encodes "size" number of data item pairs,
+                // maps of indefinite length encodes data item pairs until a break is
+                // encountered.
+                if let Some(size) = map_decoder.size() {
+                    for _ in 0..size {
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                } else {
+                    while !map_decoder.decoder.pull_break()? {
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                        map_decoder
+                            .decoder
+                            .skip_data_item_at_nesting_depth(nesting_depth)?;
+                    }
+                }
+            }
+            DataItemType::Break => {
+                return Err(anyhow!("break is not a valid data item").into());
+            }
+        }
+
+        Ok(())
+    }
+
+    fn next_nesting_depth(&self, nesting_depth: usize) -> CborSerializationResult<usize> {
+        nesting_depth
+            .checked_add(1)
+            .filter(|depth| *depth <= self.options.max_nesting_depth)
+            .ok_or_else(|| {
+                CborSerializationError::nesting_limit_exceeded(self.options.max_nesting_depth)
+            })
+    }
+}
+
 impl<'a, R: Read> CborDecoder for &'a mut Decoder<R>
 where
     <R as Read>::Error: std::error::Error,
@@ -155,62 +245,8 @@ where
         DataItemHeader::try_from_header(self.peek_header()?)
     }
 
-    fn skip_data_item(mut self) -> CborSerializationResult<()> {
-        match self.peek_data_item_header()?.to_type() {
-            DataItemType::Positive
-            | DataItemType::Negative
-            | DataItemType::Simple
-            | DataItemType::Float => {
-                self.inner.pull()?;
-            }
-            DataItemType::Tag => {
-                self.inner.pull()?;
-                self.skip_data_item()?;
-            }
-            DataItemType::Bytes => {
-                self.decode_bytes()?;
-            }
-            DataItemType::Text => {
-                self.decode_text()?;
-            }
-            DataItemType::Array => {
-                let array_decoder = self.decode_array()?;
-                // Arrays of definite length encodes "size" number of data item elements,
-                // arrays of indefinite length encodes data item elements until a break is
-                // encountered.
-                if let Some(size) = array_decoder.size() {
-                    for _ in 0..size {
-                        array_decoder.decoder.skip_data_item()?;
-                    }
-                } else {
-                    while !array_decoder.decoder.pull_break()? {
-                        array_decoder.decoder.skip_data_item()?;
-                    }
-                }
-            }
-            DataItemType::Map => {
-                let map_decoder = self.decode_map()?;
-                // Maps of definite length encodes "size" number of data item pairs,
-                // maps of indefinite length encodes data item pairs until a break is
-                // encountered.
-                if let Some(size) = map_decoder.size() {
-                    for _ in 0..size {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
-                    }
-                } else {
-                    while !map_decoder.decoder.pull_break()? {
-                        map_decoder.decoder.skip_data_item()?;
-                        map_decoder.decoder.skip_data_item()?;
-                    }
-                }
-            }
-            DataItemType::Break => {
-                return Err(anyhow!("break is not a valid data item").into());
-            }
-        }
-
-        Ok(())
+    fn skip_data_item(self) -> CborSerializationResult<()> {
+        self.skip_data_item_at_nesting_depth(0)
     }
 
     fn options(&self) -> SerializationOptions {
@@ -408,6 +444,36 @@ where
         Ok(Some(K::deserialize(&mut *self.decoder)?))
     }
 
+    fn deserialize_key_with_nesting_depth<K: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Option<K>> {
+        self.state = match self.state {
+            MapDecoderStateEnum::ExpectKey => MapDecoderStateEnum::ExpectValue,
+            MapDecoderStateEnum::ExpectValue => {
+                return Err(anyhow!(
+                    "map decoder expected to decode entry value since entry key was decoded last"
+                )
+                .into());
+            }
+        };
+
+        if let Some(declared_size) = self.declared_size {
+            if self.decoded_entries == declared_size {
+                return Ok(None);
+            }
+        } else if self.decoder.pull_break()? {
+            return Ok(None);
+        }
+
+        self.decoded_entries += 1;
+
+        Ok(Some(K::deserialize_with_nesting_depth(
+            &mut *self.decoder,
+            nesting_depth,
+        )?))
+    }
+
     fn deserialize_value<V: CborDeserialize>(&mut self) -> CborSerializationResult<V> {
         self.state = match self.state {
             MapDecoderStateEnum::ExpectKey => {
@@ -420,6 +486,23 @@ where
         };
 
         V::deserialize(&mut *self.decoder)
+    }
+
+    fn deserialize_value_with_nesting_depth<V: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<V> {
+        self.state = match self.state {
+            MapDecoderStateEnum::ExpectKey => {
+                return Err(anyhow!(
+                    "map decoder expected to decode entry key since entry value was decoded last"
+                )
+                .into());
+            }
+            MapDecoderStateEnum::ExpectValue => MapDecoderStateEnum::ExpectKey,
+        };
+
+        V::deserialize_with_nesting_depth(&mut *self.decoder, nesting_depth)
     }
 
     fn skip_value(&mut self) -> CborSerializationResult<()> {
@@ -478,6 +561,26 @@ where
         self.decoded_elements += 1;
 
         Ok(Some(T::deserialize(&mut *self.decoder)?))
+    }
+
+    fn deserialize_element_with_nesting_depth<T: CborDeserialize>(
+        &mut self,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Option<T>> {
+        if let Some(declared_size) = self.declared_size {
+            if self.decoded_elements == declared_size {
+                return Ok(None);
+            }
+        } else if self.decoder.pull_break()? {
+            return Ok(None);
+        }
+
+        self.decoded_elements += 1;
+
+        Ok(Some(T::deserialize_with_nesting_depth(
+            &mut *self.decoder,
+            nesting_depth,
+        )?))
     }
 }
 
@@ -847,6 +950,105 @@ mod test {
             encoder.push(Header::Positive(2)).unwrap();
             encoder.push(Header::Break).unwrap();
         });
+    }
+
+    fn nested_array(depth: usize, indefinite: bool) -> Vec<u8> {
+        let mut cbor = vec![if indefinite { 0x9f } else { 0x81 }; depth];
+        cbor.push(0);
+        if indefinite {
+            cbor.extend(std::iter::repeat_n(0xff, depth));
+        }
+        cbor
+    }
+
+    fn nested_map(depth: usize, indefinite: bool) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(3 * depth + 1);
+        for _ in 0..depth {
+            cbor.extend([if indefinite { 0xbf } else { 0xa1 }, 0]);
+        }
+        cbor.push(0);
+        if indefinite {
+            cbor.extend(std::iter::repeat_n(0xff, depth));
+        }
+        cbor
+    }
+
+    fn nested_tag(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0xc0; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    fn mixed_nested_structures(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(3 * depth + 1);
+        let mut breaks = 0;
+        for index in 0..depth {
+            match index % 5 {
+                0 => cbor.push(0x81),
+                1 => {
+                    cbor.push(0x9f);
+                    breaks += 1;
+                }
+                2 => cbor.extend([0xa1, 0]),
+                3 => {
+                    cbor.extend([0xbf, 0]);
+                    breaks += 1;
+                }
+                _ => cbor.push(0xc0),
+            }
+        }
+        cbor.push(0);
+        cbor.extend(std::iter::repeat_n(0xff, breaks));
+        cbor
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_boundary() {
+        for cbor in [
+            nested_array(128, false),
+            nested_array(128, true),
+            nested_map(128, false),
+            nested_map(128, true),
+            nested_tag(128),
+        ] {
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            decoder.skip_data_item().unwrap();
+        }
+
+        for cbor in [
+            nested_array(129, false),
+            nested_array(129, true),
+            nested_map(129, false),
+            nested_map(129, true),
+            nested_tag(129),
+        ] {
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            let error = decoder.skip_data_item().unwrap_err();
+            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+        }
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_mixed_structures() {
+        for depth in [128, 129] {
+            let cbor = mixed_nested_structures(depth);
+            let mut decoder = Decoder::new(cbor.as_slice(), SerializationOptions::default());
+            let result = decoder.skip_data_item();
+            assert_eq!(result.is_ok(), depth <= 128);
+        }
+    }
+
+    #[test]
+    fn skip_data_item_nesting_limit_uses_custom_option() {
+        let options = SerializationOptions::default().max_nesting_depth(3);
+        let cbor = nested_map(3, true);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder.skip_data_item().unwrap();
+
+        let cbor = nested_map(4, true);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        let error = decoder.skip_data_item().unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
     }
 
     fn test_skip_data_item_impl(encode_data_item: impl FnOnce(&mut Encoder<&mut Vec<u8>>)) {

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -41,76 +41,6 @@ where
             })?;
         Ok(Self { decoder, depth })
     }
-
-    fn skip(mut self) -> CborSerializationResult<()> {
-        match self.peek_data_item_header()?.to_type() {
-            DataItemType::Positive
-            | DataItemType::Negative
-            | DataItemType::Simple
-            | DataItemType::Float => {
-                self.decoder.inner.pull()?;
-            }
-            DataItemType::Tag => self.decode_tagged()?.decoder().skip_data_item()?,
-            DataItemType::Bytes => {
-                self.decode_bytes()?;
-            }
-            DataItemType::Text => {
-                self.decode_text()?;
-            }
-            DataItemType::Array => {
-                let array = self.decode_array()?;
-                if let Some(size) = array.declared_size {
-                    for _ in 0..size {
-                        DecoderContext {
-                            decoder: &mut *array.decoder,
-                            depth: array.depth,
-                        }
-                        .skip()?;
-                    }
-                } else {
-                    while !array.decoder.pull_break()? {
-                        DecoderContext {
-                            decoder: &mut *array.decoder,
-                            depth: array.depth,
-                        }
-                        .skip()?;
-                    }
-                }
-            }
-            DataItemType::Map => {
-                let map = self.decode_map()?;
-                if let Some(size) = map.declared_size {
-                    for _ in 0..size {
-                        DecoderContext {
-                            decoder: &mut *map.decoder,
-                            depth: map.depth,
-                        }
-                        .skip()?;
-                        DecoderContext {
-                            decoder: &mut *map.decoder,
-                            depth: map.depth,
-                        }
-                        .skip()?;
-                    }
-                } else {
-                    while !map.decoder.pull_break()? {
-                        DecoderContext {
-                            decoder: &mut *map.decoder,
-                            depth: map.depth,
-                        }
-                        .skip()?;
-                        DecoderContext {
-                            decoder: &mut *map.decoder,
-                            depth: map.depth,
-                        }
-                        .skip()?;
-                    }
-                }
-            }
-            DataItemType::Break => return Err(anyhow!("break is not a valid data item").into()),
-        }
-        Ok(())
-    }
 }
 
 impl<'a, R: Read> CborDecoder for DecoderContext<'a, R>
@@ -130,11 +60,13 @@ where
             )),
         }
     }
+
     fn decode_tagged(mut self) -> CborSerializationResult<Self::TagDecoder> {
         let tag = self.decode_tag()?;
         let context = DecoderContext::nested(self.decoder, self.depth)?;
         Ok(TagDecoder::new(tag, context.decoder, context.depth))
     }
+
     fn decode_positive(self) -> CborSerializationResult<u64> {
         match self.decoder.inner.pull()? {
             Header::Positive(value) => Ok(value),
@@ -144,6 +76,7 @@ where
             )),
         }
     }
+
     fn decode_negative(self) -> CborSerializationResult<u64> {
         match self.decoder.inner.pull()? {
             Header::Negative(value) => Ok(value),
@@ -153,6 +86,7 @@ where
             )),
         }
     }
+
     fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
         match self.decoder.inner.pull()? {
             Header::Map(size) => {
@@ -165,6 +99,7 @@ where
             )),
         }
     }
+
     fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
         match self.decoder.inner.pull()? {
             Header::Array(size) => {
@@ -177,6 +112,7 @@ where
             )),
         }
     }
+
     fn decode_bytes_exact(self, dest: &mut [u8]) -> CborSerializationResult<()> {
         let size = match self.decoder.inner.pull()? {
             Header::Bytes(size) => size,
@@ -194,6 +130,7 @@ where
         }
         Ok(())
     }
+
     fn decode_bytes(self) -> CborSerializationResult<Vec<u8>> {
         let size = match self.decoder.inner.pull()? {
             Header::Bytes(size) => size,
@@ -204,12 +141,12 @@ where
                 ))
             }
         };
-        let mut cursor = Cursor::new(Vec::with_capacity(cbor::cap_capacity::<u8>(
-            size.unwrap_or_default(),
-        )));
+        let bytes = Vec::with_capacity(cbor::cap_capacity::<u8>(size.unwrap_or_default()));
+        let mut cursor = Cursor::new(bytes);
         self.decoder.decode_bytes_impl(&mut cursor, size)?;
         Ok(cursor.into_inner())
     }
+
     fn decode_text(self) -> CborSerializationResult<Vec<u8>> {
         let size = match self.decoder.inner.pull()? {
             Header::Text(size) => size,
@@ -224,6 +161,7 @@ where
         self.decoder.decode_text_impl(&mut bytes, size)?;
         Ok(bytes)
     }
+
     fn decode_simple(self) -> CborSerializationResult<u8> {
         match self.decoder.inner.pull()? {
             Header::Simple(value) => Ok(value),
@@ -233,6 +171,7 @@ where
             )),
         }
     }
+
     fn decode_float(self) -> CborSerializationResult<f64> {
         match self.decoder.inner.pull()? {
             Header::Float(value) => Ok(value),
@@ -242,11 +181,85 @@ where
             )),
         }
     }
+
     fn peek_data_item_header(&mut self) -> CborSerializationResult<DataItemHeader> {
         DataItemHeader::try_from_header(self.decoder.peek_header()?)
     }
-    fn skip_data_item(self) -> CborSerializationResult<()> {
-        self.skip()
+
+    fn skip_data_item(mut self) -> CborSerializationResult<()> {
+        match self.peek_data_item_header()?.to_type() {
+            DataItemType::Positive
+            | DataItemType::Negative
+            | DataItemType::Simple
+            | DataItemType::Float => {
+                self.decoder.inner.pull()?;
+            }
+            DataItemType::Tag => self.decode_tagged()?.decoder().skip_data_item()?,
+            DataItemType::Bytes => {
+                self.decode_bytes()?;
+            }
+            DataItemType::Text => {
+                self.decode_text()?;
+            }
+            DataItemType::Array => {
+                let array_decoder = self.decode_array()?;
+                // Arrays of definite length encodes "size" number of data item elements,
+                // arrays of indefinite length encodes data item elements until a break is
+                // encountered.
+                if let Some(size) = array_decoder.size() {
+                    for _ in 0..size {
+                        DecoderContext {
+                            decoder: &mut *array_decoder.decoder,
+                            depth: array_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                    }
+                } else {
+                    while !array_decoder.decoder.pull_break()? {
+                        DecoderContext {
+                            decoder: &mut *array_decoder.decoder,
+                            depth: array_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                    }
+                }
+            }
+            DataItemType::Map => {
+                let map_decoder = self.decode_map()?;
+                // Maps of definite length encodes "size" number of data item pairs,
+                // maps of indefinite length encodes data item pairs until a break is
+                // encountered.
+                if let Some(size) = map_decoder.size() {
+                    for _ in 0..size {
+                        DecoderContext {
+                            decoder: &mut *map_decoder.decoder,
+                            depth: map_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                        DecoderContext {
+                            decoder: &mut *map_decoder.decoder,
+                            depth: map_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                    }
+                } else {
+                    while !map_decoder.decoder.pull_break()? {
+                        DecoderContext {
+                            decoder: &mut *map_decoder.decoder,
+                            depth: map_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                        DecoderContext {
+                            decoder: &mut *map_decoder.decoder,
+                            depth: map_decoder.depth,
+                        }
+                        .skip_data_item()?;
+                    }
+                }
+            }
+            DataItemType::Break => return Err(anyhow!("break is not a valid data item").into()),
+        }
+        Ok(())
     }
     fn options(&self) -> SerializationOptions {
         self.decoder.options
@@ -267,6 +280,7 @@ where
         }
         .decode_tag()
     }
+
     fn decode_tagged(self) -> CborSerializationResult<Self::TagDecoder> {
         DecoderContext {
             decoder: self,
@@ -274,6 +288,7 @@ where
         }
         .decode_tagged()
     }
+
     fn decode_positive(self) -> CborSerializationResult<u64> {
         DecoderContext {
             decoder: self,
@@ -281,6 +296,7 @@ where
         }
         .decode_positive()
     }
+
     fn decode_negative(self) -> CborSerializationResult<u64> {
         DecoderContext {
             decoder: self,
@@ -288,6 +304,7 @@ where
         }
         .decode_negative()
     }
+
     fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
         DecoderContext {
             decoder: self,
@@ -295,6 +312,7 @@ where
         }
         .decode_map()
     }
+
     fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
         DecoderContext {
             decoder: self,
@@ -302,6 +320,7 @@ where
         }
         .decode_array()
     }
+
     fn decode_bytes_exact(self, dest: &mut [u8]) -> CborSerializationResult<()> {
         DecoderContext {
             decoder: self,
@@ -309,6 +328,7 @@ where
         }
         .decode_bytes_exact(dest)
     }
+
     fn decode_bytes(self) -> CborSerializationResult<Vec<u8>> {
         DecoderContext {
             decoder: self,
@@ -316,6 +336,7 @@ where
         }
         .decode_bytes()
     }
+
     fn decode_text(self) -> CborSerializationResult<Vec<u8>> {
         DecoderContext {
             decoder: self,
@@ -323,6 +344,7 @@ where
         }
         .decode_text()
     }
+
     fn decode_simple(self) -> CborSerializationResult<u8> {
         DecoderContext {
             decoder: self,
@@ -330,6 +352,7 @@ where
         }
         .decode_simple()
     }
+
     fn decode_float(self) -> CborSerializationResult<f64> {
         DecoderContext {
             decoder: self,
@@ -337,6 +360,7 @@ where
         }
         .decode_float()
     }
+
     fn peek_data_item_header(&mut self) -> CborSerializationResult<DataItemHeader> {
         DecoderContext {
             decoder: *self,
@@ -344,6 +368,7 @@ where
         }
         .peek_data_item_header()
     }
+
     fn skip_data_item(self) -> CborSerializationResult<()> {
         DecoderContext {
             decoder: self,
@@ -351,6 +376,7 @@ where
         }
         .skip_data_item()
     }
+
     fn options(&self) -> SerializationOptions {
         self.options
     }
@@ -838,8 +864,7 @@ mod test {
             error
                 .to_string()
                 .contains("fixed size deserialization type too short"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 
@@ -854,8 +879,7 @@ mod test {
             error
                 .to_string()
                 .contains("byte string destination too long"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 
@@ -910,8 +934,7 @@ mod test {
         let error = decoder.decode_bytes().unwrap_err();
         assert!(
             error.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 
@@ -924,8 +947,7 @@ mod test {
         let err = decoder.decode_bytes().unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -947,8 +969,7 @@ mod test {
         let error = decoder.decode_text().unwrap_err();
         assert!(
             error.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 
@@ -961,8 +982,7 @@ mod test {
         let err = decoder.decode_text().unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -993,8 +1013,7 @@ mod test {
         let error = decoder.decode_text().unwrap_err();
         assert!(
             error.to_string().contains("CBOR syntax error"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 
@@ -1006,8 +1025,7 @@ mod test {
         let error = decoder.decode_text().unwrap_err();
         assert!(
             error.to_string().contains("CBOR syntax error"),
-            "message: {}",
-            error.to_string()
+            "message: {error}"
         );
     }
 

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -1,6 +1,6 @@
 use crate::common::cbor::{
     self, CborArrayDecoder, CborDecoder, CborDeserialize, CborMapDecoder, CborSerializationError,
-    CborSerializationResult, DataItemHeader, DataItemType, SerializationOptions,
+    CborSerializationResult, CborTagDecoder, DataItemHeader, DataItemType, SerializationOptions,
     MAX_PRE_ALLOCATED_SIZE,
 };
 use anyhow::anyhow;
@@ -40,11 +40,8 @@ where
                 self.inner.pull()?;
             }
             DataItemType::Tag => {
-                self.inner.pull()?;
-                self.enter_nesting()?;
-                let result = self.skip_data_item();
-                self.leave_nesting();
-                result?;
+                let tag_decoder = self.decode_tagged()?;
+                tag_decoder.decoder.skip_data_item()?;
             }
             DataItemType::Bytes => {
                 self.decode_bytes()?;
@@ -102,17 +99,13 @@ where
             })?;
         Ok(())
     }
-
-    fn leave_nesting(&mut self) {
-        debug_assert!(self.nesting_depth > 0);
-        self.nesting_depth -= 1;
-    }
 }
 
 impl<'a, R: Read> CborDecoder for &'a mut Decoder<R>
 where
     <R as Read>::Error: std::error::Error,
 {
+    type TagDecoder = TagDecoder<'a, R>;
     type ArrayDecoder = ArrayDecoder<'a, R>;
     type MapDecoder = MapDecoder<'a, R>;
 
@@ -126,23 +119,10 @@ where
         }
     }
 
-    fn decode_tagged_value<T: CborDeserialize>(mut self) -> CborSerializationResult<(u64, T)> {
+    fn decode_tagged(mut self) -> CborSerializationResult<Self::TagDecoder> {
         let tag = self.decode_tag()?;
         self.enter_nesting()?;
-        let result = T::deserialize(&mut *self);
-        self.leave_nesting();
-        result.map(|value| (tag, value))
-    }
-
-    fn decode_tagged_value_expect<T: CborDeserialize>(
-        mut self,
-        expected_tag: u64,
-    ) -> CborSerializationResult<T> {
-        self.decode_tag_expect(expected_tag)?;
-        self.enter_nesting()?;
-        let result = T::deserialize(&mut *self);
-        self.leave_nesting();
-        result
+        Ok(TagDecoder::new(tag, self))
     }
 
     fn decode_positive(self) -> CborSerializationResult<u64> {
@@ -405,6 +385,39 @@ where
     }
 }
 
+/// Decoder of a CBOR tagged value.
+#[must_use]
+pub struct TagDecoder<'a, R: Read> {
+    tag: u64,
+    decoder: &'a mut Decoder<R>,
+}
+
+impl<'a, R: Read> TagDecoder<'a, R> {
+    fn new(tag: u64, decoder: &'a mut Decoder<R>) -> Self {
+        Self { tag, decoder }
+    }
+}
+
+impl<R: Read> Drop for TagDecoder<'_, R> {
+    fn drop(&mut self) {
+        debug_assert!(self.decoder.nesting_depth > 0);
+        self.decoder.nesting_depth -= 1;
+    }
+}
+
+impl<R: Read> CborTagDecoder for TagDecoder<'_, R>
+where
+    R::Error: std::error::Error,
+{
+    fn tag(&self) -> u64 {
+        self.tag
+    }
+
+    fn deserialize<T: CborDeserialize>(self) -> CborSerializationResult<T> {
+        T::deserialize(&mut *self.decoder)
+    }
+}
+
 #[derive(Debug)]
 enum MapDecoderStateEnum {
     ExpectKey,
@@ -562,10 +575,12 @@ mod test {
     use ciborium_ll::simple;
 
     #[test]
-    fn test_decode_tagged_value_expect() {
+    fn test_decode_tagged_value() {
         let bytes = [0xc0, 0x81, 0x00];
         let mut decoder = Decoder::new(bytes.as_slice(), SerializationOptions::default());
-        let value = decoder.decode_tagged_value_expect::<Value>(0).unwrap();
+        let tag_decoder = decoder.decode_tagged_expect(0).unwrap();
+        assert_eq!(tag_decoder.tag(), 0);
+        let value = tag_decoder.deserialize::<Value>().unwrap();
         assert_eq!(value, Value::Array(vec![Value::Positive(0)]));
     }
 

--- a/rust-src/concordium_base/src/common/cbor/primitives.rs
+++ b/rust-src/concordium_base/src/common/cbor/primitives.rs
@@ -1,6 +1,6 @@
 use crate::common::cbor::{
     CborDecoder, CborDeserialize, CborEncoder, CborSerializationError, CborSerializationResult,
-    CborSerialize, DataItemHeader, DataItemType,
+    CborSerialize, CborTagDecoder, DataItemHeader, DataItemType,
 };
 use anyhow::{anyhow, Context};
 use ciborium_ll::simple;
@@ -324,14 +324,14 @@ impl CborSerialize for MapKey {
     }
 }
 
-fn decode_unsigned_bignum_to_u64<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<u64> {
-    decoder.decode_tag_expect(UNSIGNED_BIGNUM_TAG)?;
-    decode_ne_bytes_to_u64(&decoder.decode_bytes()?)
+fn decode_unsigned_bignum_to_u64<C: CborDecoder>(decoder: C) -> CborSerializationResult<u64> {
+    let mut tag_decoder = decoder.decode_tagged_expect(UNSIGNED_BIGNUM_TAG)?;
+    decode_ne_bytes_to_u64(&tag_decoder.decoder().decode_bytes()?)
 }
 
-fn decode_negative_bignum_to_u64<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<u64> {
-    decoder.decode_tag_expect(NEGATIVE_BIGNUM_TAG)?;
-    decode_ne_bytes_to_u64(&decoder.decode_bytes()?)
+fn decode_negative_bignum_to_u64<C: CborDecoder>(decoder: C) -> CborSerializationResult<u64> {
+    let mut tag_decoder = decoder.decode_tagged_expect(NEGATIVE_BIGNUM_TAG)?;
+    decode_ne_bytes_to_u64(&tag_decoder.decoder().decode_bytes()?)
 }
 
 /// Decode the given bytes as a bignum represented in network byte order
@@ -358,7 +358,9 @@ fn decode_ne_bytes_to_u64(bytes: &[u8]) -> CborSerializationResult<u64> {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::common::cbor::{cbor_decode, cbor_encode};
+    use crate::common::cbor::{
+        cbor_decode, cbor_decode_with_options, cbor_encode, SerializationOptions,
+    };
 
     #[test]
     fn test_u64() {
@@ -406,6 +408,17 @@ mod test {
         assert_eq!(hex::encode(&cbor), "18ff");
         let value_decoded: u8 = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
+    }
+
+    #[test]
+    fn test_bignum_tags_count_towards_nesting_limit() {
+        let options = SerializationOptions::default().max_nesting_depth(2);
+        assert!(cbor_decode_with_options::<Vec<u64>>([0x81, 0xc2, 0x41, 0], options).is_ok());
+        assert!(cbor_decode_with_options::<Vec<i64>>([0x81, 0xc3, 0x41, 0], options).is_ok());
+
+        let options = SerializationOptions::default().max_nesting_depth(1);
+        assert!(cbor_decode_with_options::<Vec<u64>>([0x81, 0xc2, 0x41, 0], options).is_err());
+        assert!(cbor_decode_with_options::<Vec<i64>>([0x81, 0xc3, 0x41, 0], options).is_err());
     }
 
     /// Tests decoding tag 2 bignums into u64

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -1,6 +1,7 @@
 use crate::common::cbor::{
     self, Bytes, CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
-    CborMapDecoder, CborMapEncoder, CborSerializationResult, CborSerialize, DataItemHeader,
+    CborMapDecoder, CborMapEncoder, CborSerializationError, CborSerializationResult, CborSerialize,
+    DataItemHeader,
 };
 use anyhow::Context;
 use ciborium_ll::simple;
@@ -76,11 +77,11 @@ impl CborSerialize for Value {
     }
 }
 
-impl CborDeserialize for Value {
-    fn deserialize<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
+impl Value {
+    fn deserialize_at_nesting_depth<C: CborDecoder>(
+        mut decoder: C,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Self> {
         Ok(match decoder.peek_data_item_header()? {
             DataItemHeader::Positive(_) => Value::Positive(decoder.decode_positive()?),
             DataItemHeader::Negative(_) => Value::Negative(decoder.decode_negative()?),
@@ -90,29 +91,37 @@ impl CborDeserialize for Value {
                     .context("text data item not valid UTF8 encoding")?,
             ),
             DataItemHeader::Array(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut array_decoder = decoder.decode_array()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     array_decoder.size().unwrap_or_default(),
                 ));
-                while let Some(element) = array_decoder.deserialize_element()? {
+                while let Some(element) =
+                    array_decoder.deserialize_element_with_nesting_depth(nesting_depth)?
+                {
                     vec.push(element);
                 }
                 Value::Array(vec)
             }
             DataItemHeader::Map(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut map_decoder = decoder.decode_map()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     map_decoder.size().unwrap_or_default(),
                 ));
 
-                while let Some(entry) = map_decoder.deserialize_entry()? {
-                    vec.push(entry);
+                while let Some(key) =
+                    map_decoder.deserialize_key_with_nesting_depth(nesting_depth)?
+                {
+                    let value = map_decoder.deserialize_value_with_nesting_depth(nesting_depth)?;
+                    vec.push((key, value));
                 }
                 Value::Map(vec)
             }
             DataItemHeader::Tag(_) => {
+                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let tag = decoder.decode_tag()?;
-                let value = Value::deserialize(decoder)?;
+                let value = Self::deserialize_at_nesting_depth(decoder, nesting_depth)?;
                 Value::Tag(tag, Box::new(value))
             }
             DataItemHeader::Simple(_) => match decoder.decode_simple()? {
@@ -123,6 +132,37 @@ impl CborDeserialize for Value {
             },
             DataItemHeader::Float(_) => Value::Float(decoder.decode_float()?),
         })
+    }
+}
+
+fn next_nesting_depth<C: CborDecoder>(
+    decoder: &C,
+    nesting_depth: usize,
+) -> CborSerializationResult<usize> {
+    nesting_depth
+        .checked_add(1)
+        .filter(|depth| *depth <= decoder.options().max_nesting_depth)
+        .ok_or_else(|| {
+            CborSerializationError::nesting_limit_exceeded(decoder.options().max_nesting_depth)
+        })
+}
+
+impl CborDeserialize for Value {
+    fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize_at_nesting_depth(decoder, 0)
+    }
+
+    fn deserialize_with_nesting_depth<C: CborDecoder>(
+        decoder: C,
+        nesting_depth: usize,
+    ) -> CborSerializationResult<Self>
+    where
+        Self: Sized,
+    {
+        Self::deserialize_at_nesting_depth(decoder, nesting_depth)
     }
 
     fn null() -> Option<Self>
@@ -136,7 +176,9 @@ impl CborDeserialize for Value {
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::common::cbor::{cbor_decode, cbor_encode};
+    use crate::common::cbor::{
+        cbor_decode, cbor_decode_with_options, cbor_encode, SerializationOptions,
+    };
 
     #[test]
     fn test_positive() {
@@ -309,5 +351,49 @@ mod test {
         let cbor = cbor_encode(&value);
         let value_decoded: Value = cbor_decode(&cbor).unwrap();
         assert_eq!(value_decoded, value);
+    }
+
+    fn nested_array(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0x81; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    fn nested_map(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(depth * 2 + 1);
+        for _ in 0..depth {
+            cbor.extend([0xa1, 0]);
+        }
+        cbor.push(0);
+        cbor
+    }
+
+    fn nested_tag(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0xc0; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    #[test]
+    fn nesting_limit_accepts_128_structural_items() {
+        for cbor in [nested_array(128), nested_map(128), nested_tag(128)] {
+            assert!(cbor_decode::<Value>(cbor).is_ok());
+        }
+    }
+
+    #[test]
+    fn nesting_limit_rejects_129_structural_items() {
+        for cbor in [nested_array(129), nested_map(129), nested_tag(129)] {
+            let error = cbor_decode::<Value>(cbor).unwrap_err();
+            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+        }
+    }
+
+    #[test]
+    fn nesting_limit_uses_custom_option() {
+        let options = SerializationOptions::default().max_nesting_depth(3);
+        assert!(cbor_decode_with_options::<Value>(nested_array(3), options).is_ok());
+        let error = cbor_decode_with_options::<Value>(nested_array(4), options).unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
     }
 }

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -1,6 +1,7 @@
 use crate::common::cbor::{
     self, Bytes, CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
-    CborMapDecoder, CborMapEncoder, CborSerializationResult, CborSerialize, DataItemHeader,
+    CborMapDecoder, CborMapEncoder, CborSerializationResult, CborSerialize, CborTagDecoder,
+    DataItemHeader,
 };
 use anyhow::Context;
 use ciborium_ll::simple;
@@ -109,7 +110,9 @@ impl Value {
                 Value::Map(vec)
             }
             DataItemHeader::Tag(_) => {
-                let (tag, value) = decoder.decode_tagged_value()?;
+                let tag_decoder = decoder.decode_tagged()?;
+                let tag = tag_decoder.tag();
+                let value = tag_decoder.deserialize()?;
                 Value::Tag(tag, Box::new(value))
             }
             DataItemHeader::Simple(_) => match decoder.decode_simple()? {

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -1,7 +1,6 @@
 use crate::common::cbor::{
     self, Bytes, CborArrayDecoder, CborArrayEncoder, CborDecoder, CborDeserialize, CborEncoder,
-    CborMapDecoder, CborMapEncoder, CborSerializationError, CborSerializationResult, CborSerialize,
-    DataItemHeader,
+    CborMapDecoder, CborMapEncoder, CborSerializationResult, CborSerialize, DataItemHeader,
 };
 use anyhow::Context;
 use ciborium_ll::simple;
@@ -78,10 +77,7 @@ impl CborSerialize for Value {
 }
 
 impl Value {
-    fn deserialize_at_nesting_depth<C: CborDecoder>(
-        mut decoder: C,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<Self> {
+    fn deserialize_value<C: CborDecoder>(mut decoder: C) -> CborSerializationResult<Self> {
         Ok(match decoder.peek_data_item_header()? {
             DataItemHeader::Positive(_) => Value::Positive(decoder.decode_positive()?),
             DataItemHeader::Negative(_) => Value::Negative(decoder.decode_negative()?),
@@ -91,37 +87,29 @@ impl Value {
                     .context("text data item not valid UTF8 encoding")?,
             ),
             DataItemHeader::Array(_) => {
-                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut array_decoder = decoder.decode_array()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     array_decoder.size().unwrap_or_default(),
                 ));
-                while let Some(element) =
-                    array_decoder.deserialize_element_with_nesting_depth(nesting_depth)?
-                {
+                while let Some(element) = array_decoder.deserialize_element()? {
                     vec.push(element);
                 }
                 Value::Array(vec)
             }
             DataItemHeader::Map(_) => {
-                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
                 let mut map_decoder = decoder.decode_map()?;
                 let mut vec = Vec::with_capacity(cbor::cap_capacity::<Value>(
                     map_decoder.size().unwrap_or_default(),
                 ));
 
-                while let Some(key) =
-                    map_decoder.deserialize_key_with_nesting_depth(nesting_depth)?
-                {
-                    let value = map_decoder.deserialize_value_with_nesting_depth(nesting_depth)?;
+                while let Some(key) = map_decoder.deserialize_key()? {
+                    let value = map_decoder.deserialize_value()?;
                     vec.push((key, value));
                 }
                 Value::Map(vec)
             }
             DataItemHeader::Tag(_) => {
-                let nesting_depth = next_nesting_depth(&decoder, nesting_depth)?;
-                let tag = decoder.decode_tag()?;
-                let value = Self::deserialize_at_nesting_depth(decoder, nesting_depth)?;
+                let (tag, value) = decoder.decode_tagged_value()?;
                 Value::Tag(tag, Box::new(value))
             }
             DataItemHeader::Simple(_) => match decoder.decode_simple()? {
@@ -135,34 +123,12 @@ impl Value {
     }
 }
 
-fn next_nesting_depth<C: CborDecoder>(
-    decoder: &C,
-    nesting_depth: usize,
-) -> CborSerializationResult<usize> {
-    nesting_depth
-        .checked_add(1)
-        .filter(|depth| *depth <= decoder.options().max_nesting_depth)
-        .ok_or_else(|| {
-            CborSerializationError::nesting_limit_exceeded(decoder.options().max_nesting_depth)
-        })
-}
-
 impl CborDeserialize for Value {
     fn deserialize<C: CborDecoder>(decoder: C) -> CborSerializationResult<Self>
     where
         Self: Sized,
     {
-        Self::deserialize_at_nesting_depth(decoder, 0)
-    }
-
-    fn deserialize_with_nesting_depth<C: CborDecoder>(
-        decoder: C,
-        nesting_depth: usize,
-    ) -> CborSerializationResult<Self>
-    where
-        Self: Sized,
-    {
-        Self::deserialize_at_nesting_depth(decoder, nesting_depth)
+        Self::deserialize_value(decoder)
     }
 
     fn null() -> Option<Self>
@@ -394,6 +360,15 @@ mod test {
         let options = SerializationOptions::default().max_nesting_depth(3);
         assert!(cbor_decode_with_options::<Value>(nested_array(3), options).is_ok());
         let error = cbor_decode_with_options::<Value>(nested_array(4), options).unwrap_err();
+        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
+    }
+
+    #[test]
+    fn nesting_limit_counts_mixed_structures() {
+        let options = SerializationOptions::default().max_nesting_depth(3);
+        assert!(cbor_decode_with_options::<Value>([0x81, 0xc0, 0x81, 0], options).is_ok());
+        let error =
+            cbor_decode_with_options::<Value>([0x81, 0xc0, 0x81, 0xc0, 0], options).unwrap_err();
         assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
     }
 }

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -271,8 +271,7 @@ mod test {
         let err = cbor_decode::<Value>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -307,8 +306,7 @@ mod test {
         let err = cbor_decode::<Value>(&cbor).unwrap_err();
         assert!(
             err.to_string().contains("failed to fill whole buffer"),
-            "message: {}",
-            err.to_string()
+            "message: {err}"
         );
     }
 
@@ -337,6 +335,23 @@ mod test {
         cbor
     }
 
+    fn nested_indefinite_array(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0x9f; depth];
+        cbor.push(0);
+        cbor.extend(std::iter::repeat(0xff).take(depth));
+        cbor
+    }
+
+    fn nested_indefinite_map(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(depth * 3 + 1);
+        for _ in 0..depth {
+            cbor.extend([0xbf, 0]);
+        }
+        cbor.push(0);
+        cbor.extend(std::iter::repeat(0xff).take(depth));
+        cbor
+    }
+
     fn nested_tag(depth: usize) -> Vec<u8> {
         let mut cbor = vec![0xc0; depth];
         cbor.push(0);
@@ -345,14 +360,26 @@ mod test {
 
     #[test]
     fn nesting_limit_accepts_128_structural_items() {
-        for cbor in [nested_array(128), nested_map(128), nested_tag(128)] {
+        for cbor in [
+            nested_array(128),
+            nested_indefinite_array(128),
+            nested_map(128),
+            nested_indefinite_map(128),
+            nested_tag(128),
+        ] {
             assert!(cbor_decode::<Value>(cbor).is_ok());
         }
     }
 
     #[test]
     fn nesting_limit_rejects_129_structural_items() {
-        for cbor in [nested_array(129), nested_map(129), nested_tag(129)] {
+        for cbor in [
+            nested_array(129),
+            nested_indefinite_array(129),
+            nested_map(129),
+            nested_indefinite_map(129),
+            nested_tag(129),
+        ] {
             assert!(cbor_decode::<Value>(cbor).is_err());
         }
     }

--- a/rust-src/concordium_base/src/common/cbor/value.rs
+++ b/rust-src/concordium_base/src/common/cbor/value.rs
@@ -353,8 +353,7 @@ mod test {
     #[test]
     fn nesting_limit_rejects_129_structural_items() {
         for cbor in [nested_array(129), nested_map(129), nested_tag(129)] {
-            let error = cbor_decode::<Value>(cbor).unwrap_err();
-            assert_eq!(error.to_string(), "maximum nesting depth of 128 exceeded");
+            assert!(cbor_decode::<Value>(cbor).is_err());
         }
     }
 
@@ -362,16 +361,13 @@ mod test {
     fn nesting_limit_uses_custom_option() {
         let options = SerializationOptions::default().max_nesting_depth(3);
         assert!(cbor_decode_with_options::<Value>(nested_array(3), options).is_ok());
-        let error = cbor_decode_with_options::<Value>(nested_array(4), options).unwrap_err();
-        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
+        assert!(cbor_decode_with_options::<Value>(nested_array(4), options).is_err());
     }
 
     #[test]
     fn nesting_limit_counts_mixed_structures() {
         let options = SerializationOptions::default().max_nesting_depth(3);
         assert!(cbor_decode_with_options::<Value>([0x81, 0xc0, 0x81, 0], options).is_ok());
-        let error =
-            cbor_decode_with_options::<Value>([0x81, 0xc0, 0x81, 0xc0, 0], options).unwrap_err();
-        assert_eq!(error.to_string(), "maximum nesting depth of 3 exceeded");
+        assert!(cbor_decode_with_options::<Value>([0x81, 0xc0, 0x81, 0xc0, 0], options).is_err());
     }
 }

--- a/rust-src/concordium_base_derive/src/cbor.rs
+++ b/rust-src/concordium_base_derive/src/cbor.rs
@@ -603,7 +603,8 @@ fn cbor_deserialize_enum_body(
                 let tag = tag.into_iter();
                 quote! {
                     #(
-                        #cbor_module::CborDecoder::decode_tag_expect(&mut decoder, #tag)?;
+                        let mut tag_decoder = #cbor_module::CborDecoder::decode_tagged_expect(decoder, #tag)?;
+                        let decoder = #cbor_module::CborTagDecoder::decoder(&mut tag_decoder);
                     )*
                 }
             })
@@ -654,7 +655,8 @@ fn cbor_deserialize_enum_body(
                             }
                         )*
                         #cbor_module::DataItemHeader::Tag(tag) => {
-                            #cbor_module::CborDecoder::decode_tag_expect(&mut decoder, tag)?;
+                            let mut tag_decoder = #cbor_module::CborDecoder::decode_tagged_expect(decoder, tag)?;
+                            let decoder = #cbor_module::CborTagDecoder::decoder(&mut tag_decoder);
                             #deserialize_unknown
                         }
                         _ => {
@@ -696,7 +698,8 @@ pub fn impl_cbor_deserialize(ast: &syn::DeriveInput) -> syn::Result<TokenStream>
 
     let decode_tag = if let Some(tag) = opts.tag {
         quote!(
-            #cbor_module::CborDecoder::decode_tag_expect(&mut decoder, #tag)?;
+            let mut tag_decoder = #cbor_module::CborDecoder::decode_tagged_expect(decoder, #tag)?;
+            let mut decoder = #cbor_module::CborTagDecoder::decoder(&mut tag_decoder);
         )
     } else {
         quote!()


### PR DESCRIPTION
Replaces #955 

## Purpose

Add a nesting limit to the cbor decoder. 128 was chosen as the value, as this is also used as a nesting limit in `serde_json`, and it seems like a reasonable upper bound.

## Changes

- Added a configurable nesting limit for CBOR arrays, maps, and tags, defaulting to 128.
- Added scoped tag decoding through `CborTagDecoder`.
- Applied the limit to derived, custom, dynamic `Value`, and skipped-item decoding.

`Decoder` could not carry the nesting depth directly because the decoding flow shares the same decoder reference across nested scopes. Instead, a `DecoderContext` wraps the decoder reference and carries the depth for each scope. DecoderContext implements the same `CborDecoder` API, limiting user-facing changes.

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.