### PR TITLE
Csec 68 concordium nodeplt limit cbor nesting while decoding

### DIFF
--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -329,15 +329,38 @@ pub enum UnknownMapKeys {
     Fail,
 }
 
-/// Options applied when serializing and deserializing
-#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash, Default)]
+/// Options applied when serializing and deserializing.
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
 pub struct SerializationOptions {
     pub unknown_map_keys: UnknownMapKeys,
+    /// Maximum depth of nested CBOR arrays, maps, and tags.
+    pub max_nesting_depth: usize,
+}
+
+impl Default for SerializationOptions {
+    fn default() -> Self {
+        Self {
+            unknown_map_keys: UnknownMapKeys::default(),
+            max_nesting_depth: 128,
+        }
+    }
 }
 
 impl SerializationOptions {
+    /// Sets how unknown keys in decoded CBOR maps are handled.
     pub fn unknown_map_keys(self, unknown_map_keys: UnknownMapKeys) -> Self {
-        Self { unknown_map_keys }
+        Self {
+            unknown_map_keys,
+            ..self
+        }
+    }
+
+    /// Sets the finite maximum depth of nested CBOR arrays, maps, and tags.
+    pub fn max_nesting_depth(self, max_nesting_depth: usize) -> Self {
+        Self {
+            max_nesting_depth,
+            ..self
+        }
     }
 }
 
@@ -389,6 +412,12 @@ impl CborSerializationError {
         } else {
             anyhow!("expected map size {}, was indefinite", expected).into()
         }
+    }
+
+
+    /// Returns an error indicating that CBOR nesting exceeded `max_nesting_depth`.
+    pub fn nesting_limit_exceeded(max_nesting_depth: usize) -> Self {
+        anyhow!("maximum nesting depth of {} exceeded", max_nesting_depth).into()
     }
 }
 

--- a/rust-src/concordium_base/src/common/cbor.rs
+++ b/rust-src/concordium_base/src/common/cbor.rs
@@ -414,7 +414,6 @@ impl CborSerializationError {
         }
     }
 
-
     /// Returns an error indicating that CBOR nesting exceeded `max_nesting_depth`.
     pub fn nesting_limit_exceeded(max_nesting_depth: usize) -> Self {
         anyhow!("maximum nesting depth of {} exceeded", max_nesting_depth).into()

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -12,13 +12,37 @@ use std::{io::Cursor, iter};
 pub struct Decoder<R: Read> {
     inner: ciborium_ll::Decoder<R>,
     options: SerializationOptions,
+    /// Current serialization depth
+    depth: usize,
 }
 
 impl<R: Read> Decoder<R> {
     pub fn new(read: R, options: SerializationOptions) -> Self {
         let inner = ciborium_ll::Decoder::from(read);
 
-        Self { inner, options }
+        Self {
+            inner,
+            options,
+            depth: 0,
+        }
+    }
+
+    fn increment_nesting_depth(&mut self) -> CborSerializationResult<()> {
+        self.depth = self
+            .depth
+            .checked_add(1)
+            .filter(|depth| *depth <= self.options.max_nesting_depth)
+            .ok_or_else(|| {
+                CborSerializationError::nesting_limit_exceeded(self.options.max_nesting_depth)
+            })?;
+
+        Ok(())
+    }
+
+    fn decrement_nesting_depth(&mut self) {
+        self.depth
+            .checked_sub(1)
+            .expect("non-negative depth invariant broken");
     }
 }
 
@@ -61,7 +85,7 @@ where
 
     fn decode_map(self) -> CborSerializationResult<Self::MapDecoder> {
         match self.inner.pull()? {
-            Header::Map(size) => Ok(MapDecoder::new(size, self)),
+            Header::Map(size) => MapDecoder::try_new(size, self),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Map,
                 DataItemType::from_header(header),
@@ -71,7 +95,7 @@ where
 
     fn decode_array(self) -> CborSerializationResult<Self::ArrayDecoder> {
         match self.inner.pull()? {
-            Header::Array(size) => Ok(ArrayDecoder::new(size, self)),
+            Header::Array(size) => ArrayDecoder::try_new(size, self),
             header => Err(CborSerializationError::expected_data_item(
                 DataItemType::Array,
                 DataItemType::from_header(header),
@@ -363,13 +387,21 @@ pub struct MapDecoder<'a, R: Read> {
 }
 
 impl<'a, R: Read> MapDecoder<'a, R> {
-    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> Self {
-        Self {
+    fn try_new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> CborSerializationResult<Self> {
+        decoder.increment_nesting_depth()?;
+
+        Ok(Self {
             declared_size: size,
             decoded_entries: 0,
             decoder,
             state: MapDecoderStateEnum::ExpectKey,
-        }
+        })
+    }
+}
+
+impl<'a, R: Read> Drop for MapDecoder<'a, R> {
+    fn drop(&mut self) {
+        self.decoder.decrement_nesting_depth();
     }
 }
 
@@ -446,12 +478,20 @@ pub struct ArrayDecoder<'a, R: Read> {
 }
 
 impl<'a, R: Read> ArrayDecoder<'a, R> {
-    fn new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> Self {
-        Self {
+    fn try_new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> CborSerializationResult<Self> {
+        decoder.increment_nesting_depth()?; // todo ar
+
+        Ok(Self {
             declared_size: size,
             decoded_elements: 0,
             decoder,
-        }
+        })
+    }
+}
+
+impl<'a, R: Read> Drop for ArrayDecoder<'a, R> {
+    fn drop(&mut self) {
+        self.decoder.decrement_nesting_depth();
     }
 }
 
@@ -502,6 +542,7 @@ mod test {
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
         assert_eq!(array_decoder.size(), Some(2));
+        drop(array_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -517,6 +558,7 @@ mod test {
         assert_eq!(elm2, 2);
         let elm3: Option<u32> = array_decoder.deserialize_element().unwrap();
         assert_eq!(elm3, None);
+        drop(array_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -533,6 +575,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), Some(2));
+        drop(map_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 
@@ -549,6 +592,7 @@ mod test {
         let entry3: Option<(u32, u32)> = map_decoder.deserialize_entry().unwrap();
         assert_eq!(entry3, None);
         assert_eq!(map_decoder.size(), None);
+        drop(map_decoder);
         assert_eq!(decoder.inner.offset(), bytes.len());
     }
 

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -1020,6 +1020,22 @@ mod test {
         cbor
     }
 
+    /// Create CBOR with `count` empty arrays in series.
+    fn series_array(count: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(count + 1);
+        cbor.push(0x80 | (count as u8));
+        cbor.extend(iter::repeat_n(0x80, count));
+        cbor
+    }
+
+    /// Create CBOR with `count` empty maps in series.
+    fn series_map(count: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(count + 1);
+        cbor.push(0x80 | (count as u8));
+        cbor.extend(iter::repeat_n(0xa0, count));
+        cbor
+    }
+
     /// Tests that deserializing an array has a nesting limit.
     #[test]
     fn test_deserialize_array_nesting_limit() {
@@ -1029,9 +1045,18 @@ mod test {
         let mut decoder = Decoder::new(cbor.as_slice(), options);
         Value::deserialize(&mut decoder).expect("should not hit nesting limit");
 
+        let cbor = series_array(20);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect("should not hit nesting limit");
+
         let cbor = nested_array(11);
         let mut decoder = Decoder::new(cbor.as_slice(), options);
-        Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+        let error = Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+        assert!(
+            error.to_string().contains("nesting depth"),
+            "message: {}",
+            error.to_string()
+        );
     }
 
     /// Tests that deserializing a map has a nesting limit.
@@ -1043,9 +1068,18 @@ mod test {
         let mut decoder = Decoder::new(cbor.as_slice(), options);
         Value::deserialize(&mut decoder).expect("should not hit nesting limit");
 
+        let cbor = series_map(20);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect("should not hit nesting limit");
+
         let cbor = nested_map(11);
         let mut decoder = Decoder::new(cbor.as_slice(), options);
-        Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+        let error = Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+        assert!(
+            error.to_string().contains("nesting depth"),
+            "message: {}",
+            error.to_string()
+        );
     }
 
     /// Tests that deserializing an array has a nesting limit, also when just skipping the array.
@@ -1061,9 +1095,14 @@ mod test {
 
         let cbor = nested_array(11);
         let mut decoder = Decoder::new(cbor.as_slice(), options);
-        decoder
+        let error = decoder
             .skip_data_item()
             .expect_err("should hit nesting limit");
+        assert!(
+            error.to_string().contains("nesting depth"),
+            "message: {}",
+            error.to_string()
+        );
     }
 
     /// Tests that deserializing a map has a nesting limit, also when just skipping the map.
@@ -1079,8 +1118,13 @@ mod test {
 
         let cbor = nested_map(11);
         let mut decoder = Decoder::new(cbor.as_slice(), options);
-        decoder
+        let error = decoder
             .skip_data_item()
             .expect_err("should hit nesting limit");
+        assert!(
+            error.to_string().contains("nesting depth"),
+            "message: {}",
+            error.to_string()
+        );
     }
 }

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -40,7 +40,8 @@ impl<R: Read> Decoder<R> {
     }
 
     fn decrement_nesting_depth(&mut self) {
-        self.depth
+        self.depth = self
+            .depth
             .checked_sub(1)
             .expect("non-negative depth invariant broken");
     }
@@ -479,7 +480,7 @@ pub struct ArrayDecoder<'a, R: Read> {
 
 impl<'a, R: Read> ArrayDecoder<'a, R> {
     fn try_new(size: Option<usize>, decoder: &'a mut Decoder<R>) -> CborSerializationResult<Self> {
-        decoder.increment_nesting_depth()?; // todo ar
+        decoder.increment_nesting_depth()?;
 
         Ok(Self {
             declared_size: size,

--- a/rust-src/concordium_base/src/common/cbor/decoder.rs
+++ b/rust-src/concordium_base/src/common/cbor/decoder.rs
@@ -524,6 +524,7 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::common::cbor::value::Value;
     use crate::common::cbor::{
         CborArrayEncoder, CborDecoder, CborEncoder, CborMapEncoder, Encoder,
     };
@@ -999,5 +1000,86 @@ mod test {
         assert_eq!(cursor.position(), 4);
 
         assert_eq!(array, [1, 2, 3, 4]);
+    }
+
+    /// Create CBOR with arrays nested to `depth`
+    fn nested_array(depth: usize) -> Vec<u8> {
+        let mut cbor = vec![0x81; depth];
+        cbor.push(0);
+        cbor
+    }
+
+    /// Create CBOR with maps nested to `depth`
+    fn nested_map(depth: usize) -> Vec<u8> {
+        let mut cbor = Vec::with_capacity(3 * depth + 1);
+        for _ in 0..depth {
+            cbor.extend([0xa1, 0]);
+        }
+        cbor.push(0);
+        cbor
+    }
+
+    /// Tests that deserializing an array has a nesting limit.
+    #[test]
+    fn test_deserialize_array_nesting_limit() {
+        let options = SerializationOptions::default().max_nesting_depth(10);
+
+        let cbor = nested_array(10);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect("should not hit nesting limit");
+
+        let cbor = nested_array(11);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+    }
+
+    /// Tests that deserializing a map has a nesting limit.
+    #[test]
+    fn test_deserialize_map_nesting_limit() {
+        let options = SerializationOptions::default().max_nesting_depth(10);
+
+        let cbor = nested_map(10);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect("should not hit nesting limit");
+
+        let cbor = nested_map(11);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        Value::deserialize(&mut decoder).expect_err("should hit nesting limit");
+    }
+
+    /// Tests that deserializing an array has a nesting limit, also when just skipping the array.
+    #[test]
+    fn test_skip_data_item_array_nesting_limit() {
+        let options = SerializationOptions::default().max_nesting_depth(10);
+
+        let cbor = nested_array(10);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder
+            .skip_data_item()
+            .expect("should not hit nesting limit");
+
+        let cbor = nested_array(11);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder
+            .skip_data_item()
+            .expect_err("should hit nesting limit");
+    }
+
+    /// Tests that deserializing a map has a nesting limit, also when just skipping the map.
+    #[test]
+    fn test_skip_data_item_map_nesting_limit() {
+        let options = SerializationOptions::default().max_nesting_depth(10);
+
+        let cbor = nested_map(10);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder
+            .skip_data_item()
+            .expect("should not hit nesting limit");
+
+        let cbor = nested_map(11);
+        let mut decoder = Decoder::new(cbor.as_slice(), options);
+        decoder
+            .skip_data_item()
+            .expect_err("should hit nesting limit");
     }
 }


### PR DESCRIPTION
## Purpose

Implement CBOR deserialization nesting limit.

## Changes

_Describe the changes that were needed.

## Checklist

- [ ] My code follows the style of this project.
- [ ] The code compiles without warnings.
- [ ] I have performed a self-review of the changes.
- [ ] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [ ] (If necessary) I have updated the CHANGELOG.


