### PR TITLE
Lock return -> release

### DIFF
--- a/cddl/cis-7.cddl
+++ b/cddl/cis-7.cddl
@@ -377,7 +377,7 @@ meta-token-unpause = {
 meta-token-lock-operation =
     meta-lock-fund
     / meta-lock-send
-    / meta-lock-return
+    / meta-lock-release
 
 ; Fund a lock by locking the specified amount on the sender account (implicit)
 ; under the control of a specified lock.
@@ -419,17 +419,17 @@ lock-send-body = (
     ? "memo": memo
 )
 
-; Return funds under the control of a lock to the owner account.
+; Release funds under the control of a lock to the owner account.
 ; The funds are moved from the locked balance to the available balance of the
 ; owner.
-meta-lock-return = {
-    "lockReturn": {
+meta-lock-release = {
+    "lockRelease": {
         "token": token-id,
-        lock-return-body
+        lock-release-body
     }
 }
 
-lock-return-body = (
+lock-release-body = (
     ; The lock controlling the funds.
     "lock": lock-ref,
     ; The account holding the funds.
@@ -483,7 +483,7 @@ lock-metadata = {
 ; A capability to perform a certain operation on a lock.
 lock-controller-simple-capability =
     "fund"      ; Capability to perform "lockFund"
-    / "return"  ; Capability to perform "lockReturn"
+    / "release" ; Capability to perform "lockRelease"
     / "send"    ; Capability to perform "lockSend"
     / "cancel"  ; Capability to perform "lockCancel" (before expiry)
 

--- a/haskell-src/Concordium/GRPC2.hs
+++ b/haskell-src/Concordium/GRPC2.hs
@@ -794,7 +794,7 @@ instance ToProto RejectReason where
         LockExpired lockId -> Proto.make $ ProtoFields.lockExpired .= toProto lockId
         LockFundNotAuthorized LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockFundNotAuthorized .= mkLockOpNotAuth larrdLockId larrdAccount
         LockSendNotAuthorized LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockSendNotAuthorized .= mkLockOpNotAuth larrdLockId larrdAccount
-        LockReturnNotAuthorized LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockReturnNotAuthorized .= mkLockOpNotAuth larrdLockId larrdAccount
+        LockReleaseNotAuthorized LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockReleaseNotAuthorized .= mkLockOpNotAuth larrdLockId larrdAccount
         LockCancelNotAuthorized LockAccountRejectReasonDetails{larrdLockId, larrdAccount} -> Proto.make $ ProtoFields.lockCancelNotAuthorized .= mkLockOpNotAuth larrdLockId larrdAccount
         LockTokenNotPermitted LockTokenRejectReasonDetails{ltrrdLockId, ltrrdTokenId} ->
             Proto.make $

--- a/haskell-src/Concordium/Types/Execution.hs
+++ b/haskell-src/Concordium/Types/Execution.hs
@@ -2930,8 +2930,8 @@ data RejectReason
       LockFundNotAuthorized !LockAccountRejectReasonDetails
     | -- | The account is not authorized to send funds controlled by the lock.
       LockSendNotAuthorized !LockAccountRejectReasonDetails
-    | -- | The account is not authorized to return funds controlled by the lock.
-      LockReturnNotAuthorized !LockAccountRejectReasonDetails
+    | -- | The account is not authorized to release funds controlled by the lock.
+      LockReleaseNotAuthorized !LockAccountRejectReasonDetails
     | -- | The account is not authorized to cancel the lock.
       LockCancelNotAuthorized !LockAccountRejectReasonDetails
     | -- | The lock does not allow funding with the particular token.
@@ -3047,7 +3047,7 @@ instance S.Serialize RejectReason where
         LockExpired lockId -> S.putWord8 58 <> S.put lockId
         LockFundNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 59 <> S.put larrdLockId <> S.put larrdAccount
         LockSendNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 60 <> S.put larrdLockId <> S.put larrdAccount
-        LockReturnNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 61 <> S.put larrdLockId <> S.put larrdAccount
+        LockReleaseNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 61 <> S.put larrdLockId <> S.put larrdAccount
         LockCancelNotAuthorized LockAccountRejectReasonDetails{..} -> S.putWord8 62 <> S.put larrdLockId <> S.put larrdAccount
         LockTokenNotPermitted LockTokenRejectReasonDetails{..} -> S.putWord8 63 <> S.put ltrrdLockId <> S.put ltrrdTokenId
         LockRecipientNotPermitted LockAccountRejectReasonDetails{..} -> S.putWord8 64 <> S.put larrdLockId <> S.put larrdAccount
@@ -3124,7 +3124,7 @@ instance S.Serialize RejectReason where
             58 -> LockExpired <$> S.get
             59 -> LockFundNotAuthorized <$> getLockAccountRejectReasonDetails
             60 -> LockSendNotAuthorized <$> getLockAccountRejectReasonDetails
-            61 -> LockReturnNotAuthorized <$> getLockAccountRejectReasonDetails
+            61 -> LockReleaseNotAuthorized <$> getLockAccountRejectReasonDetails
             62 -> LockCancelNotAuthorized <$> getLockAccountRejectReasonDetails
             63 -> LockTokenNotPermitted <$> getLockTokenRejectReasonDetails
             64 -> LockRecipientNotPermitted <$> getLockAccountRejectReasonDetails

--- a/haskell-src/Concordium/Types/Locks/CBOR.hs
+++ b/haskell-src/Concordium/Types/Locks/CBOR.hs
@@ -98,7 +98,7 @@ decodeLockId = do
 -- | Capabilities supported by the simple lock controller.
 data LockControllerSimpleV0Capability
     = LockControllerSimpleV0Fund
-    | LockControllerSimpleV0Return
+    | LockControllerSimpleV0Release
     | LockControllerSimpleV0Send
     | LockControllerSimpleV0Cancel
     deriving (Eq, Show)
@@ -107,7 +107,7 @@ encodeLockControllerSimpleV0Capability :: LockControllerSimpleV0Capability -> En
 encodeLockControllerSimpleV0Capability =
     encodeString . \case
         LockControllerSimpleV0Fund -> "fund"
-        LockControllerSimpleV0Return -> "return"
+        LockControllerSimpleV0Release -> "release"
         LockControllerSimpleV0Send -> "send"
         LockControllerSimpleV0Cancel -> "cancel"
 
@@ -116,7 +116,7 @@ decodeLockControllerSimpleV0Capability = do
     role <- decodeString
     case role of
         "fund" -> return LockControllerSimpleV0Fund
-        "return" -> return LockControllerSimpleV0Return
+        "release" -> return LockControllerSimpleV0Release
         "send" -> return LockControllerSimpleV0Send
         "cancel" -> return LockControllerSimpleV0Cancel
         _ -> fail $ "Unsupported lock controller capability: " ++ show role
@@ -216,7 +216,7 @@ data SimpleLockConfigV0 = SimpleLockConfigV0
       lcsv0Grants :: !(Seq.Seq LockControllerSimpleV0Grant),
       -- | Tokens that may be funded into the lock.
       lcsv0Tokens :: !(Seq.Seq TokenId),
-      -- | Whether to retain the lock after all funds are returned.
+      -- | Whether to retain the lock after all funds are released.
       lcsv0KeepAlive :: !Bool,
       -- | Optional memo attached to the lock.
       lcsv0Memo :: !(Maybe TaggableMemo),

--- a/haskell-tests/Generators.hs
+++ b/haskell-tests/Generators.hs
@@ -905,7 +905,7 @@ instance Arbitrary RejectReason where
               LockExpired <$> genLockId,
               LockFundNotAuthorized <$> genLockAccountRejectReasonDetails,
               LockSendNotAuthorized <$> genLockAccountRejectReasonDetails,
-              LockReturnNotAuthorized <$> genLockAccountRejectReasonDetails,
+              LockReleaseNotAuthorized <$> genLockAccountRejectReasonDetails,
               LockCancelNotAuthorized <$> genLockAccountRejectReasonDetails,
               LockTokenNotPermitted <$> genLockTokenRejectReasonDetails,
               LockRecipientNotPermitted <$> genLockAccountRejectReasonDetails,

--- a/haskell-tests/Types/CBOR.hs
+++ b/haskell-tests/Types/CBOR.hs
@@ -1398,12 +1398,12 @@ testLockControllerSimpleV0CapabilityCBOR = describe "LockControllerSimpleV0Capab
             decodeLockControllerSimpleV0Capability
             LockControllerSimpleV0Fund
             "6466756e64"
-    it "return" $
+    it "release" $
         lockFixture
             encodeLockControllerSimpleV0Capability
             decodeLockControllerSimpleV0Capability
-            LockControllerSimpleV0Return
-            "6672657475726e"
+            LockControllerSimpleV0Release
+            "6772656c65617365"
     it "send" $
         lockFixture
             encodeLockControllerSimpleV0Capability

--- a/haskell-tests/Types/TransactionSummarySpec.hs
+++ b/haskell-tests/Types/TransactionSummarySpec.hs
@@ -150,8 +150,8 @@ testLockRejectReasonJSONRepresentation = do
             (LockSendNotAuthorized accountDetails)
             (AE.object ["tag" AE..= ("LockSendNotAuthorized" :: String), "contents" AE..= accountDetails])
         assertJSON
-            (LockReturnNotAuthorized accountDetails)
-            (AE.object ["tag" AE..= ("LockReturnNotAuthorized" :: String), "contents" AE..= accountDetails])
+            (LockReleaseNotAuthorized accountDetails)
+            (AE.object ["tag" AE..= ("LockReleaseNotAuthorized" :: String), "contents" AE..= accountDetails])
         assertJSON
             (LockCancelNotAuthorized accountDetails)
             (AE.object ["tag" AE..= ("LockCancelNotAuthorized" :: String), "contents" AE..= accountDetails])

--- a/rust-src/concordium_base/src/protocol_level_locks/lock_config_simple_v0.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/lock_config_simple_v0.rs
@@ -18,8 +18,8 @@ use concordium_base_derive::{CborDeserialize, CborSerialize, Serialize};
 pub enum LockControllerSimpleV0Capability {
     /// Authorizes funding the lock with a permitted token.
     Fund,
-    /// Authorizes returning funds from the lock.
-    Return,
+    /// Authorizes releasing funds from the lock.
+    Release,
     /// Authorizes sending funds from the lock to a recipient. This is subject to individual token
     /// policies such as pausation and allow/deny lists.
     Send,
@@ -31,7 +31,7 @@ impl LockControllerSimpleV0Capability {
     fn as_str(&self) -> &'static str {
         match self {
             Self::Fund => "fund",
-            Self::Return => "return",
+            Self::Release => "release",
             Self::Send => "send",
             Self::Cancel => "cancel",
         }
@@ -40,7 +40,7 @@ impl LockControllerSimpleV0Capability {
     fn from_str(s: &str) -> Result<Self, CborSerializationError> {
         match s {
             "fund" => Ok(Self::Fund),
-            "return" => Ok(Self::Return),
+            "release" => Ok(Self::Release),
             "send" => Ok(Self::Send),
             "cancel" => Ok(Self::Cancel),
             other => Err(CborSerializationError::invalid_data(format_args!(
@@ -98,7 +98,7 @@ pub struct LockConfigSimpleV0 {
     /// Tokens that may be funded into this lock.
     pub tokens: Vec<TokenId>,
     /// Whether the lock should be kept alive after all funds are
-    /// returned. Interpreted as `false` when omitted from the serialization.
+    /// released. Interpreted as `false` when omitted from the serialization.
     #[cbor(default = false)]
     pub keep_alive: bool,
     /// Optional memo attached to the lock.
@@ -138,7 +138,10 @@ mod tests {
     fn capability_cbor_round_trips_and_matches_fixtures() {
         let fixtures = [
             (LockControllerSimpleV0Capability::Fund, "6466756e64"),
-            (LockControllerSimpleV0Capability::Return, "6672657475726e"),
+            (
+                LockControllerSimpleV0Capability::Release,
+                "6772656c65617365",
+            ),
             (LockControllerSimpleV0Capability::Send, "6473656e64"),
             (LockControllerSimpleV0Capability::Cancel, "6663616e63656c"),
         ];
@@ -237,7 +240,7 @@ mod tests {
     fn capability_serial_round_trips_and_matches_tag_fixtures() {
         let fixtures = [
             (LockControllerSimpleV0Capability::Fund, "00"),
-            (LockControllerSimpleV0Capability::Return, "01"),
+            (LockControllerSimpleV0Capability::Release, "01"),
             (LockControllerSimpleV0Capability::Send, "02"),
             (LockControllerSimpleV0Capability::Cancel, "03"),
         ];

--- a/rust-src/concordium_base/src/protocol_level_locks/mod.rs
+++ b/rust-src/concordium_base/src/protocol_level_locks/mod.rs
@@ -14,7 +14,7 @@
 //! - [`LockControllerSimpleV0Grant`] - A grant of capabilities to a specific
 //!   account.
 //! - [`LockControllerSimpleV0Capability`] - Individual capability that can be
-//!   granted (`Fund`, `Return`, `Send`, `Cancel`).
+//!   granted (`Fund`, `Release`, `Send`, `Cancel`).
 //!
 //! All types support CBOR serialization/deserialization, and optionally
 //! JSON serialization via serde when the `serde_deprecated` feature is

--- a/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
+++ b/rust-src/concordium_base/src/protocol_level_tokens/meta_operations.rs
@@ -132,15 +132,15 @@ pub fn lock_send(
     })
 }
 
-/// Construct an operation to return funds controlled by a lock to the owner.
-pub fn lock_return(
+/// Construct an operation to release funds controlled by a lock to the owner.
+pub fn lock_release(
     token_id: TokenId,
     lock_id: LockId,
     source: AccountAddress,
     amount: TokenAmount,
     memo: Option<CborMemo>,
 ) -> MetaUpdateOperation {
-    MetaUpdateOperation::LockReturn(MetaLockReturnDetails {
+    MetaUpdateOperation::LockRelease(MetaLockReleaseDetails {
         token: token_id,
         lock: lock_id,
         source: CborHolderAccount::from(source),
@@ -251,8 +251,8 @@ pub enum MetaUpdateOperation {
     LockFund(MetaLockFundDetails),
     /// Operation to send funds controlled by a lock.
     LockSend(MetaLockSendDetails),
-    /// Operation to return funds controlled by a lock to the owner.
-    LockReturn(MetaLockReturnDetails),
+    /// Operation to release funds controlled by a lock to the owner.
+    LockRelease(MetaLockReleaseDetails),
     /// Operation to create a lock.
     LockCreate(MetaLockCreateDetails),
     /// Operation to cancel a lock.
@@ -305,8 +305,8 @@ pub enum LockOperation {
     Fund(MetaLockFundDetails),
     /// Operation to send funds controlled by a lock.
     Send(MetaLockSendDetails),
-    /// Operation to return funds controlled by a lock to the owner.
-    Return(MetaLockReturnDetails),
+    /// Operation to release funds controlled by a lock to the owner.
+    Release(MetaLockReleaseDetails),
     /// Operation to create a lock.
     Create(MetaLockCreateDetails),
     /// Operation to cancel a lock.
@@ -520,18 +520,18 @@ pub struct MetaLockSendDetails {
     pub memo: Option<CborMemo>,
 }
 
-/// Return funds under the control of a lock to the owner account.
+/// Release funds under the control of a lock to the owner account.
 /// The funds are moved from the locked balance to the available balance
 /// of the owner.
 #[derive(Debug, Clone, Eq, PartialEq, CborSerialize, CborDeserialize)]
-pub struct MetaLockReturnDetails {
+pub struct MetaLockReleaseDetails {
     /// The token the operation applies to.
     pub token: TokenId,
     /// The lock controlling the funds.
     pub lock: LockId,
     /// The account holding the funds.
     pub source: CborHolderAccount,
-    /// The amount of tokens to return.
+    /// The amount of tokens to release.
     pub amount: TokenAmount,
     /// An optional memo.
     pub memo: Option<CborMemo>,
@@ -809,8 +809,8 @@ mod tests {
     }
 
     #[test]
-    fn test_meta_operation_cbor_lock_return() {
-        let operation = MetaUpdateOperation::LockReturn(MetaLockReturnDetails {
+    fn test_meta_operation_cbor_lock_release() {
+        let operation = MetaUpdateOperation::LockRelease(MetaLockReleaseDetails {
             token: "testPLT".parse().unwrap(),
             lock: LockId::new(20, 7, 0),
             source: CborHolderAccount::from(ADDRESS),
@@ -820,7 +820,7 @@ mod tests {
         let cbor = cbor::cbor_encode(&operation);
         assert_eq!(
             hex::encode(&cbor),
-            "a16a6c6f636b52657475726ea4646c6f636bd99fd88314070065746f6b656e6774657374504c5466616d6f756e74c4820019138866736f75726365d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
+            "a16b6c6f636b52656c65617365a4646c6f636bd99fd88314070065746f6b656e6774657374504c5466616d6f756e74c4820019138866736f75726365d99d73a201d99d71a1011903970358200102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20"
         );
         let operation_decoded: MetaUpdateOperation =
             cbor::cbor_decode(&cbor).expect("CBOR deserialize");

--- a/rust-src/concordium_base/src/transactions.rs
+++ b/rust-src/concordium_base/src/transactions.rs
@@ -2267,8 +2267,8 @@ pub mod cost {
     pub const PLT_LOCK_SEND: Energy = Energy { energy: 100 };
 
     /// TODO - this is a placeholder value for now - COR-2306 will investigate the correct energy to use.
-    /// Additional cost of a lock return operation
-    pub const PLT_LOCK_RETURN: Energy = Energy { energy: 100 };
+    /// Additional cost of a lock release operation
+    pub const PLT_LOCK_RELEASE: Energy = Energy { energy: 100 };
 
     /// TODO - this is a placeholder value for now - COR-2306 will investigate the correct energy to use.
     /// Additional cost of a lock cancel operation
@@ -2737,7 +2737,7 @@ pub mod construct {
                     MetaUpdateOperation::UpdateMetadata(_) => cost::PLT_UPDATE_TOKEN_METADATA,
                     MetaUpdateOperation::LockFund(_) => cost::PLT_LOCK_FUND,
                     MetaUpdateOperation::LockSend(_) => cost::PLT_LOCK_SEND,
-                    MetaUpdateOperation::LockReturn(_) => cost::PLT_LOCK_RETURN,
+                    MetaUpdateOperation::LockRelease(_) => cost::PLT_LOCK_RELEASE,
                     MetaUpdateOperation::LockCreate(_) => cost::PLT_LOCK_CREATE,
                     MetaUpdateOperation::LockCancel(_) => cost::PLT_LOCK_CANCEL,
                 })


### PR DESCRIPTION
Ref COR-2607

Depends on https://github.com/Concordium/concordium-grpc-api/pull/125

## Changes

- Renamed "lock return" to "lock release"

## Checklist

- [x] My code follows the style of this project.
- [x] The code compiles without warnings.
- [x] I have performed a self-review of the changes.
- [x] I have documented my code, in particular the intent of the
      hard-to-understand areas.
- [x] (If necessary) I have updated the CHANGELOG.